### PR TITLE
feat: hero animations v2 phase 3 — trail-persistence + soundwave upgrade

### DIFF
--- a/src/components/HeroCanvas.astro
+++ b/src/components/HeroCanvas.astro
@@ -561,7 +561,7 @@ const { animation } = Astro.props;
       ctx.globalAlpha = 1;
     }
 
-    function cleanup() { time = 0; resonanceMult = 1; resonancePhase = 'idle'; }
+    function cleanup() { time = 0; resonanceMult = 1; resonancePhase = 'idle'; resonanceTimer = 0; resonanceFrame = 0; shimmerX = 0; cols = 0; }
 
     return { init: init, frame: frame, cleanup: cleanup };
   })();
@@ -1079,7 +1079,7 @@ const { animation } = Astro.props;
       ctx.globalAlpha = 1;
     }
 
-    function cleanup() { wavefronts = []; emitters = []; }
+    function cleanup() { wavefronts = []; emitters = []; spawnCounter = 0; cascadeTimer = 0; cascadeAlpha = 0; }
 
     return { init: init, frame: frame, cleanup: cleanup, fadeRate: 0.012 };
   })();
@@ -2262,7 +2262,7 @@ const { animation } = Astro.props;
       ctx.globalAlpha = 1;
     }
 
-    function cleanup() { weftThreads = []; snapFlash = null; }
+    function cleanup() { weftThreads = []; snapFlash = null; frameCount = 0; patternCycle = 0; }
 
     return { init: init, frame: frame, cleanup: cleanup, fadeRate: 0.025 };
   })();
@@ -2588,7 +2588,7 @@ const { animation } = Astro.props;
       ctx.globalAlpha = 1;
     }
 
-    function cleanup() { streams = []; }
+    function cleanup() { streams = []; burstTimer = 0; burstStream = -1; }
 
     return { init: init, frame: frame, cleanup: cleanup, fadeRate: 0.02 };
   })();
@@ -2752,7 +2752,7 @@ const { animation } = Astro.props;
         if (shimmerActive) {
           var distFromOrigin = Math.sqrt((br.originX - w / 2) * (br.originX - w / 2) + (br.originY - h / 2) * (br.originY - h / 2));
           if (Math.abs(shimmerDist - distFromOrigin) < 30) {
-            ctx.globalAlpha = Math.min(0.7, ctx.globalAlpha + 0.15);
+            ctx.globalAlpha = Math.min(0.6, ctx.globalAlpha + 0.15);
           }
         }
 


### PR DESCRIPTION
## Summary

Final phase of the hero animations v2 redesign. All 5 trail-persistence animations rewritten + soundwave harmonic upgrade. This completes all 16 animations.

- **Ink** (blog) — sumi-e wash with capillary bleeding tendrils, chromatography (copper body → slate blue tendrils), lighter compositing, mouse bleed acceleration
- **Signal** (contact) — 3 emitters with trail-persistent wavefronts, resonance nodes at interference points, mouse shifts emitter, resonance cascade every ~20s
- **Loom** (colophon) — Jacquard weaving with visible shuttle head, slate blue warp / copper weft, over/under patterns (plain→twill→satin), thread snap events
- **Crystallise** (what's new) — 3 nucleation seeds with hexagonal (±60°) branching, sage green tips / copper structure, grain boundary flashes, shimmer wave
- **Stream** (analytics) — 10 noise-modulated data rivers, confluence eddies, data bursts at 4x speed, slate blue upstream anomaly particles, mouse rock splitting
- **Soundwave** (audio) — ghost harmonic layer in slate blue, resonance peaks every 8s with lighter compositing, spectral shimmer wave, center/edge bar scaling, mouse Y frequency modulation

## All 16 animations now v2

| Phase | Animations | Status |
|---|---|---|
| Phase 1 | terrain, flow, pulse, forge + infrastructure | ✅ Merged |
| Phase 2 | strata, blueprint, radar, entropy, cipher, orbit | ✅ Merged |
| **Phase 3** | **ink, signal, loom, crystallise, stream, soundwave** | **This PR** |

## Test plan

- [x] `npm run build` passes (240 pages)
- [x] JS syntax valid
- [x] Final file: 3087 lines (within 3500 budget)
- [ ] Visual QA: all 6 trail-persistence animations render with ghostly trails
- [ ] Soundwave: ghost harmonic visible, resonance peak flare every ~8s
- [ ] No regression on Phase 1+2 animations
- [ ] Reduced motion check
- [ ] Theme toggle check

🤖 Generated with [Claude Code](https://claude.com/claude-code)