### PR TITLE
fix: re-render Turnstile on View Transition navigation to /contact

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -853,6 +853,19 @@ import HeroCanvas from '../components/HeroCanvas.astro';
         initEnquiryForm();
         turnstileVerified = false;
         updateEnquirySubmitBtn();
+        // Turnstile's implicit rendering only runs on initial script load.
+        // After a View Transition swap the new .cf-turnstile div exists but
+        // the widget isn't rendered into it. Explicitly render if present.
+        var container = document.querySelector('.cf-turnstile');
+        if (container && typeof turnstile !== 'undefined') {
+          while (container.firstChild) container.removeChild(container.firstChild);
+          turnstile.render(container, {
+            sitekey: '0x4AAAAAAABtkfyqFbFmIaPO',
+            theme: 'dark',
+            callback: function () { window.onTurnstileSuccess(); },
+            'error-callback': function () { window.onTurnstileError(); },
+          });
+        }
       });
     }
 


### PR DESCRIPTION
## Summary

- The contact form's Turnstile widget doesn't render when arriving via Astro View Transition (e.g. clicking "Contact" from the nav). Works on direct/hard-refresh but not on VT swap.
- Root cause: Turnstile's `api.js` implicit rendering runs once on script load; it doesn't re-scan after DOM replacement.
- Fix: explicit `turnstile.render()` call in the `astro:after-swap` handler.

## Test plan

- [ ] Navigate to /contact from another page via nav link — widget should render
- [ ] Hard refresh /contact — still works
- [ ] Fill form + submit — enquiry created successfully
- [ ] Navigate away and back to /contact — widget re-renders