### PR TITLE
security: migrate CSP from unsafe-inline to hash-based (#222)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -77,4 +77,40 @@ export default defineConfig({
     prefetchAll: false,
     defaultStrategy: 'hover',
   },
+  experimental: {
+    csp: {
+      algorithm: 'SHA-256',
+      scriptDirective: {
+        strictDynamic: true,
+        resources: [
+          "'self'",
+          "'wasm-unsafe-eval'",
+          'https://www.googletagmanager.com',
+          'https://www.google-analytics.com',
+          'https://snap.licdn.com',
+          'https://px.ads.linkedin.com',
+          'https://pagead2.googlesyndication.com',
+          'https://tpc.googlesyndication.com',
+          'https://googleads.g.doubleclick.net',
+          'https://adservice.google.com',
+          'https://challenges.cloudflare.com',
+        ],
+      },
+      styleDirective: {
+        resources: ["'self'", "'unsafe-inline'"],
+      },
+      directives: [
+        "default-src 'self'",
+        "img-src 'self' data: https://www.google-analytics.com https://px.ads.linkedin.com https://www.googletagmanager.com https://*.tile.openstreetmap.org https://tpc.googlesyndication.com https://googleads.g.doubleclick.net https://www.linkedin.com",
+        "connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://stats.g.doubleclick.net https://ep1.adtrafficquality.google https://snap.licdn.com https://px.ads.linkedin.com https://pagead2.googlesyndication.com https://api.book.adrianwedd.com https://api.github.com https://cdn.adrianwedd.com https://ops.adrianwedd.com https://challenges.cloudflare.com",
+        "media-src 'self' https://cdn.adrianwedd.com",
+        "frame-src https://www.openstreetmap.org https://challenges.cloudflare.com https://tpc.googlesyndication.com https://googleads.g.doubleclick.net",
+        "font-src 'self'",
+        "object-src 'none'",
+        "base-uri 'self'",
+        "form-action 'self'",
+        "frame-ancestors 'none'",
+      ],
+    },
+  },
 });

--- a/src/components/SEOHead.astro
+++ b/src/components/SEOHead.astro
@@ -33,10 +33,6 @@ const fullTitle = title === 'Adrian Wedd' ? title : `${title} — Adrian Wedd`;
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="generator" content="Astro + curiosity" />
 <meta name="color-scheme" content="dark light" />
-<meta
-  http-equiv="Content-Security-Policy"
-  content="default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://snap.licdn.com https://px.ads.linkedin.com https://pagead2.googlesyndication.com https://tpc.googlesyndication.com https://googleads.g.doubleclick.net https://adservice.google.com https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://www.google-analytics.com https://px.ads.linkedin.com https://www.googletagmanager.com https://*.tile.openstreetmap.org https://tpc.googlesyndication.com https://googleads.g.doubleclick.net; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://snap.licdn.com https://px.ads.linkedin.com https://pagead2.googlesyndication.com https://api.book.adrianwedd.com https://api.github.com https://cdn.adrianwedd.com https://ops.adrianwedd.com https://challenges.cloudflare.com; media-src 'self' https://cdn.adrianwedd.com; frame-src https://www.openstreetmap.org https://challenges.cloudflare.com https://tpc.googlesyndication.com https://googleads.g.doubleclick.net; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';"
-/>
 <meta name="author" content="Adrian Wedd" />
 <meta name="theme-color" content="#c48b6e" />
 {tags && <meta name="keywords" content={tags.join(', ')} />}


### PR DESCRIPTION
## Summary

- Enable Astro 5's `experimental.csp` to auto-hash all inline scripts at build time
- Drop `'unsafe-inline'` from `script-src` — the primary XSS hardening goal
- Add `strict-dynamic` so hashed scripts can load GA4/GTM/LinkedIn child scripts
- Fix pre-existing CSP violations: add `stats.g.doubleclick.net`, `ep1.adtrafficquality.google` to `connect-src` and `www.linkedin.com` to `img-src`
- Keep `'unsafe-inline'` in `style-src` only (Turnstile/Preact runtime-injected styles)
- Add `frame-ancestors 'none'`

## Test plan

- [ ] Build succeeds with hash-based CSP meta tags on all pages
- [ ] No CSP violations in browser console on `/`, `/blog/`, `/projects/`, `/contact/`, `/search/`
- [ ] GA4 fires after consent grant
- [ ] Pagefind WASM search works
- [ ] View Transitions navigation doesn't break script execution
- [ ] Turnstile widget renders on `/contact/`

Closes #222