### PR TITLE
fix: rewrite audio/video URLs from local paths to CDN

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,20 @@ NotebookLM Studio overview generated from project materials...
 [View the full project →](/projects/project-name/)
 ```
 
+### Branded Visual Style
+
+All visual assets (infographics, videos, slides) must use the branded dark botanical aesthetic. The canonical `--focus` prompt is defined in `scripts/regenerate-branded-infographics.sh` and should be used for all NotebookLM visual generation:
+
+```
+Dark botanical aesthetic. Deep plum-tinted backgrounds (#1a181c to #2e2a34).
+Warm cream text (#e2ddd8) with dusty copper accents (#c48b6e). Moody earth tones,
+no bright or neon colours. Elegant editorial layout with strong typographic hierarchy.
+Professional data visualisation with muted, saturated colour palette. WCAG AA contrast
+ratios. Minimal, sophisticated, Australian dark-mode design.
+```
+
+Scripts that use this: `regenerate-branded-infographics.sh`, `generate-all-infographics.sh`, `regenerate-one-infographic.sh`. Always pass `--focus` with this prompt when generating visual assets.
+
 ### Asset Types
 
 **Fast** (~30-60 seconds):

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -77,4 +77,40 @@ export default defineConfig({
     prefetchAll: false,
     defaultStrategy: 'hover',
   },
+  experimental: {
+    csp: {
+      algorithm: 'SHA-256',
+      scriptDirective: {
+        strictDynamic: true,
+        resources: [
+          "'self'",
+          "'wasm-unsafe-eval'",
+          'https://www.googletagmanager.com',
+          'https://www.google-analytics.com',
+          'https://snap.licdn.com',
+          'https://px.ads.linkedin.com',
+          'https://pagead2.googlesyndication.com',
+          'https://tpc.googlesyndication.com',
+          'https://googleads.g.doubleclick.net',
+          'https://adservice.google.com',
+          'https://challenges.cloudflare.com',
+        ],
+      },
+      styleDirective: {
+        resources: ["'self'", "'unsafe-inline'"],
+      },
+      directives: [
+        "default-src 'self'",
+        "img-src 'self' data: https://www.google-analytics.com https://px.ads.linkedin.com https://www.googletagmanager.com https://*.tile.openstreetmap.org https://tpc.googlesyndication.com https://googleads.g.doubleclick.net https://www.linkedin.com",
+        "connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://stats.g.doubleclick.net https://ep1.adtrafficquality.google https://snap.licdn.com https://px.ads.linkedin.com https://pagead2.googlesyndication.com https://api.book.adrianwedd.com https://api.github.com https://cdn.adrianwedd.com https://ops.adrianwedd.com https://challenges.cloudflare.com",
+        "media-src 'self' https://cdn.adrianwedd.com",
+        "frame-src https://www.openstreetmap.org https://challenges.cloudflare.com https://tpc.googlesyndication.com https://googleads.g.doubleclick.net",
+        "font-src 'self'",
+        "object-src 'none'",
+        "base-uri 'self'",
+        "form-action 'self'",
+        "frame-ancestors 'none'",
+      ],
+    },
+  },
 });

--- a/scripts/generate-all-infographics.sh
+++ b/scripts/generate-all-infographics.sh
@@ -25,7 +25,7 @@ NC='\033[0m'
 YES=false
 LIMIT=0
 ORIENTATION="portrait"
-FOCUS="Dark background with warm copper and amber accent colours. Portrait layout with clear visual hierarchy. Modern tech aesthetic, light text on dark surfaces."
+FOCUS="Dark botanical aesthetic. Deep plum-tinted backgrounds (#1a181c to #2e2a34). Warm cream text (#e2ddd8) with dusty copper accents (#c48b6e). Moody earth tones, no bright or neon colours. Elegant editorial layout with strong typographic hierarchy. Professional data visualisation with muted, saturated colour palette. WCAG AA contrast ratios. Minimal, sophisticated, Australian dark-mode design."
 SCAN_PROJECTS=false
 SCAN_BLOG=false
 

--- a/scripts/generate-all-videos.sh
+++ b/scripts/generate-all-videos.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# generate-all-videos.sh
+# Batch generate NotebookLM cinematic video summaries for projects and blog posts.
+# Uses the branded dark botanical aesthetic via --focus.
+#
+# Usage:
+#   ./scripts/generate-all-videos.sh [--yes] [--limit N] [--blog] [--projects] [--all] [--focus "custom"]
+#
+# Pipeline: generate video → download MP4 → upload to R2 → update frontmatter with CDN URL
+#
+# Daily quota: ~50 video generations. Projects (32 missing) fit in day 1,
+# blog posts (25 missing) in day 2.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+NOTEBOOKLM_DIR="$REPO_ROOT/scripts/notebooklm"
+PROJECTS_DIR="$REPO_ROOT/src/content/projects"
+BLOG_DIR="$REPO_ROOT/src/content/blog"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+DEFAULT_FOCUS="Dark botanical aesthetic. Deep plum-tinted backgrounds (#1a181c to #2e2a34). Warm cream text (#e2ddd8) with dusty copper accents (#c48b6e). Moody earth tones, no bright or neon colours. Cinematic visual storytelling. Professional motion graphics with muted, saturated colour palette. WCAG AA contrast ratios. Minimal, sophisticated, Australian dark-mode design."
+
+YES=false
+LIMIT=0
+FOCUS="$DEFAULT_FOCUS"
+SCAN_PROJECTS=false
+SCAN_BLOG=false
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --yes|-y) YES=true; shift ;;
+        --limit) LIMIT="$2"; shift 2 ;;
+        --focus) FOCUS="$2"; shift 2 ;;
+        --projects) SCAN_PROJECTS=true; shift ;;
+        --blog) SCAN_BLOG=true; shift ;;
+        --all) SCAN_PROJECTS=true; SCAN_BLOG=true; shift ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+if [ "$SCAN_PROJECTS" = false ] && [ "$SCAN_BLOG" = false ]; then
+    SCAN_PROJECTS=true
+    SCAN_BLOG=true
+fi
+
+TOTAL=0
+SUCCESS=0
+SKIPPED=0
+FAILED=0
+
+CDN_BASE="https://cdn.adrianwedd.com/notebook-assets"
+EXPORT_DIR="$REPO_ROOT/exports/videos"
+mkdir -p "$EXPORT_DIR"
+
+echo "=== NotebookLM Video Batch Generation ==="
+echo "  Focus: ${FOCUS:0:60}..."
+echo "  Export: $EXPORT_DIR"
+echo
+
+if ! command -v nlm &>/dev/null; then
+    echo -e "${RED}Error: nlm CLI not found. Install: pip install notebooklm-mcp-cli${NC}"
+    exit 1
+fi
+
+if ! nlm login --check &>/dev/null; then
+    echo -e "${YELLOW}Warning: NotebookLM authentication may be expired${NC}"
+    echo "Run: nlm login"
+    if [ "$YES" = false ]; then
+        read -p "Continue anyway? (y/N) " -n 1 -r
+        echo
+        [[ ! $REPLY =~ ^[Yy]$ ]] && exit 1
+    fi
+fi
+
+ITEMS_NAME=()
+ITEMS_FILE=()
+ITEMS_TYPE=()
+
+if [ "$SCAN_PROJECTS" = true ]; then
+    echo "Scanning projects..."
+    for f in "$PROJECTS_DIR"/*.md; do
+        name=$(basename "$f" .md)
+        if grep -q "^draft: true" "$f"; then
+            ((SKIPPED++)) || true
+            continue
+        fi
+        if grep -q "^videoUrl:" "$f"; then
+            ((SKIPPED++)) || true
+            continue
+        fi
+        ITEMS_NAME+=("$name")
+        ITEMS_FILE+=("$f")
+        ITEMS_TYPE+=("project")
+        ((TOTAL++)) || true
+    done
+fi
+
+if [ "$SCAN_BLOG" = true ]; then
+    echo "Scanning blog posts..."
+    for f in "$BLOG_DIR"/*.md; do
+        if grep -q "^draft: true" "$f"; then
+            ((SKIPPED++)) || true
+            continue
+        fi
+        if grep -q "^videoUrl:" "$f"; then
+            ((SKIPPED++)) || true
+            continue
+        fi
+        blog_name=$(basename "$f" .md | sed 's/-post$//')
+        ITEMS_NAME+=("$blog_name")
+        ITEMS_FILE+=("$f")
+        ITEMS_TYPE+=("blog")
+        ((TOTAL++)) || true
+    done
+fi
+
+echo "Found $TOTAL items without video"
+echo "Skipped $SKIPPED items with existing videoUrl or draft status"
+echo
+
+if [ $TOTAL -eq 0 ]; then
+    echo "All items already have videos!"
+    exit 0
+fi
+
+if [ "$LIMIT" -gt 0 ] && [ "$LIMIT" -lt "$TOTAL" ]; then
+    echo -e "${YELLOW}Limiting to first $LIMIT items (of $TOTAL)${NC}"
+    ITEMS_NAME=("${ITEMS_NAME[@]:0:$LIMIT}")
+    ITEMS_FILE=("${ITEMS_FILE[@]:0:$LIMIT}")
+    ITEMS_TYPE=("${ITEMS_TYPE[@]:0:$LIMIT}")
+    TOTAL=$LIMIT
+fi
+
+echo "Will generate videos for:"
+for i in "${!ITEMS_NAME[@]}"; do
+    echo "  - [${ITEMS_TYPE[$i]}] ${ITEMS_NAME[$i]}"
+done
+echo
+
+echo -e "${YELLOW}Estimated time: $(($TOTAL * 8)) minutes (avg 5-10 min per video)${NC}"
+echo -e "${YELLOW}NotebookLM daily quota: ~50 video generations${NC}"
+echo
+
+if [ "$YES" = false ]; then
+    read -p "Continue with batch generation? (y/N) " -n 1 -r
+    echo
+    [[ ! $REPLY =~ ^[Yy]$ ]] && exit 1
+fi
+
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${CYAN}DRY RUN — no generation will occur${NC}"
+    exit 0
+fi
+
+echo "Fetching existing notebooks..."
+NOTEBOOKS_JSON=$(nlm notebook list 2>/dev/null || echo "[]")
+
+find_notebook_id() {
+    local title_fragment="$1"
+    echo "$NOTEBOOKS_JSON" | python3 -c "
+import json, sys
+notebooks = json.load(sys.stdin)
+fragment = '$title_fragment'.lower()
+for n in notebooks:
+    if fragment in n['title'].lower():
+        print(n['id'])
+        sys.exit(0)
+" 2>/dev/null || echo ""
+}
+
+RESULTS_LOG="$EXPORT_DIR/batch-results.log"
+: > "$RESULTS_LOG"
+
+for i in "${!ITEMS_NAME[@]}"; do
+    item_name="${ITEMS_NAME[$i]}"
+    item_file="${ITEMS_FILE[$i]}"
+    item_type="${ITEMS_TYPE[$i]}"
+    idx=$((i + 1))
+
+    echo
+    echo "[$idx/$TOTAL] Processing [$item_type]: $item_name"
+    echo "----------------------------------------"
+
+    title=$(grep "^title:" "$item_file" | head -1 | sed "s/^title: *['\"]\\{0,1\\}\\(.*\\)['\"]\\{0,1\\}$/\\1/" | sed "s/['\"]$//")
+    echo "  Title: $title"
+
+    notebook_id=$(find_notebook_id "$title")
+
+    if [ -z "$notebook_id" ]; then
+        echo "  Creating notebook..."
+        cd "$NOTEBOOKLM_DIR"
+
+        config_file=$(mktemp)
+        cat > "$config_file" <<EOFCONFIG
+{
+  "title": "$title - Overview",
+  "sources": [
+    "textfile:$item_file"
+  ],
+  "studio": []
+}
+EOFCONFIG
+
+        ./scripts/automate-notebook.sh --config "$config_file" --export /dev/null 2>&1 | tail -3 || true
+        rm -f "$config_file"
+        cd "$REPO_ROOT"
+
+        NOTEBOOKS_JSON=$(nlm notebook list 2>/dev/null || echo "[]")
+        notebook_id=$(find_notebook_id "$title")
+
+        if [ -z "$notebook_id" ]; then
+            echo -e "  ${RED}Failed to create notebook for $item_name${NC}"
+            echo "FAILED|$item_name|no notebook" >> "$RESULTS_LOG"
+            ((FAILED++)) || true
+            continue
+        fi
+    fi
+
+    echo "  Notebook: $notebook_id"
+    echo "  Generating cinematic video..."
+
+    nlm video create "$notebook_id" \
+        --focus "$FOCUS" \
+        -y 2>&1 | while IFS= read -r line; do echo "    $line"; done
+
+    # Poll for completion (max 15 minutes — videos are slow)
+    video_url=""
+    poll_interval=15
+    for attempt in $(seq 1 60); do
+        sleep $poll_interval
+        if [ $attempt -eq 20 ]; then poll_interval=20; fi
+
+        status_json=$(nlm studio status "$notebook_id" 2>/dev/null || echo "[]")
+        result=$(echo "$status_json" | python3 -c "
+import json, sys
+arts = json.load(sys.stdin)
+videos = [a for a in arts if a['type'] == 'video']
+if videos:
+    latest = videos[-1]
+    if latest.get('status') == 'completed' and latest.get('url'):
+        print(latest['url'])
+    elif latest.get('status') == 'failed':
+        print('FAILED')
+" 2>/dev/null || echo "")
+
+        if [ "$result" = "FAILED" ]; then
+            echo -e "  ${RED}Video generation failed${NC}"
+            echo "FAILED|$item_name|generation failed" >> "$RESULTS_LOG"
+            ((FAILED++)) || true
+            break
+        fi
+
+        if [ -n "$result" ]; then
+            video_url="$result"
+            break
+        fi
+
+        echo "    Waiting... (${attempt})"
+    done
+
+    if [ -z "$video_url" ]; then
+        if [ "$result" != "FAILED" ]; then
+            echo -e "  ${RED}Timed out waiting for video${NC}"
+            echo "FAILED|$item_name|timeout" >> "$RESULTS_LOG"
+            ((FAILED++)) || true
+        fi
+        continue
+    fi
+
+    echo -e "  ${GREEN}Video ready${NC}"
+
+    # Download
+    item_export="$EXPORT_DIR/$item_name"
+    mkdir -p "$item_export"
+    output_file="$item_export/video.mp4"
+
+    echo "  Downloading..."
+    if curl -sL "$video_url" -o "$output_file"; then
+        size=$(du -h "$output_file" | cut -f1)
+        echo "  Downloaded: $output_file ($size)"
+    else
+        echo -e "  ${RED}Download failed${NC}"
+        echo "FAILED|$item_name|download failed" >> "$RESULTS_LOG"
+        ((FAILED++)) || true
+        continue
+    fi
+
+    # Upload to R2
+    echo "  Uploading to R2..."
+    r2_key="notebook-assets/$item_name/video.mp4"
+    upload_code=$(curl -s -o /dev/null -w "%{http_code}" \
+        -X PUT \
+        "https://api.cloudflare.com/client/v4/accounts/eb44f406e11df8adec20cc1e7b66f151/r2/buckets/adrianwedd-com-media/objects/${r2_key}" \
+        -H "Authorization: Bearer ${CF_R2_API_TOKEN:-$(grep CF_R2_API_TOKEN "$REPO_ROOT/.env" 2>/dev/null | head -1 | cut -d= -f2)}" \
+        -H "Content-Type: video/mp4" \
+        --data-binary "@${output_file}" \
+        --max-time 600)
+
+    if [ "$upload_code" = "200" ]; then
+        echo -e "  ${GREEN}Uploaded to R2: $r2_key${NC}"
+    else
+        echo -e "  ${RED}R2 upload failed (HTTP $upload_code)${NC}"
+        echo "FAILED|$item_name|r2 upload $upload_code" >> "$RESULTS_LOG"
+        ((FAILED++)) || true
+        continue
+    fi
+
+    # Update frontmatter
+    cdn_url="$CDN_BASE/$item_name/video.mp4"
+    if grep -q "^videoUrl:" "$item_file"; then
+        sed -i '' "s|^videoUrl:.*|videoUrl: '$cdn_url'|" "$item_file"
+    else
+        # Insert videoUrl after audioUrl, or after heroImage, or after date
+        if grep -q "^audioUrl:" "$item_file"; then
+            sed -i '' "/^audioUrl:/a\\
+videoUrl: '$cdn_url'" "$item_file"
+        elif grep -q "^heroImage:" "$item_file"; then
+            sed -i '' "/^heroImage:/a\\
+videoUrl: '$cdn_url'" "$item_file"
+        else
+            sed -i '' "/^date:/a\\
+videoUrl: '$cdn_url'" "$item_file"
+        fi
+    fi
+
+    echo -e "  ${GREEN}Updated frontmatter: videoUrl${NC}"
+    echo "SUCCESS|$item_name|$cdn_url" >> "$RESULTS_LOG"
+    ((SUCCESS++)) || true
+done
+
+echo
+echo "=== Video Generation Complete ==="
+echo -e "  ${GREEN}Success: $SUCCESS${NC}"
+echo -e "  ${RED}Failed:  $FAILED${NC}"
+echo "  Skipped: $SKIPPED"
+echo "  Results: $RESULTS_LOG"
+
+if [ $SUCCESS -gt 0 ]; then
+    echo
+    echo "Next steps:"
+    echo "  1. Review generated videos in $EXPORT_DIR"
+    echo "  2. Commit frontmatter updates: git add src/content/ && git commit -m 'content: add video URLs'"
+    echo "  3. Clean up exports: rm -rf $EXPORT_DIR"
+fi

--- a/src/components/SEOHead.astro
+++ b/src/components/SEOHead.astro
@@ -33,10 +33,6 @@ const fullTitle = title === 'Adrian Wedd' ? title : `${title} — Adrian Wedd`;
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="generator" content="Astro + curiosity" />
 <meta name="color-scheme" content="dark light" />
-<meta
-  http-equiv="Content-Security-Policy"
-  content="default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://snap.licdn.com https://px.ads.linkedin.com https://pagead2.googlesyndication.com https://tpc.googlesyndication.com https://googleads.g.doubleclick.net https://adservice.google.com https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://www.google-analytics.com https://px.ads.linkedin.com https://www.googletagmanager.com https://*.tile.openstreetmap.org https://tpc.googlesyndication.com https://googleads.g.doubleclick.net; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://snap.licdn.com https://px.ads.linkedin.com https://pagead2.googlesyndication.com https://api.book.adrianwedd.com https://api.github.com https://cdn.adrianwedd.com https://ops.adrianwedd.com https://challenges.cloudflare.com; media-src 'self' https://cdn.adrianwedd.com; frame-src https://www.openstreetmap.org https://challenges.cloudflare.com https://tpc.googlesyndication.com https://googleads.g.doubleclick.net; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';"
-/>
 <meta name="author" content="Adrian Wedd" />
 <meta name="theme-color" content="#c48b6e" />
 {tags && <meta name="keywords" content={tags.join(', ')} />}

--- a/src/content/audio/120-models-18k-prompts-overview.md
+++ b/src/content/audio/120-models-18k-prompts-overview.md
@@ -3,7 +3,7 @@ title: '120 Models, 18,176 Prompts: What We Found'
 description: 'Audio overview of 120 Models, 18,176 Prompts: What We Found.'
 date: 2026-03-01
 tags: ['notebooklm', 'ai', 'ai-safety', 'research', 'llm', 'security', 'adversarial']
-audioUrl: '/notebook-assets/120-models-18k-prompts/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/120-models-18k-prompts/audio.mp3'
 duration: '19:47'
 relatedPost: '120-models-18k-prompts-post'
 ---

--- a/src/content/audio/adhdo-overview.md
+++ b/src/content/audio/adhdo-overview.md
@@ -3,7 +3,7 @@ title: 'ADHDo: Neurodiversity-Affirming AI Assistant'
 description: 'Audio overview exploring ADHD executive function support through AI — three-stage reasoning pipeline, crisis detection, and zero shame by design.'
 date: 2026-02-05
 tags: ['notebooklm', 'adhd', 'ai-safety', 'neurodivergence']
-audioUrl: '/notebook-assets/adhdo/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adhdo/audio.mp3'
 duration: '8:47'
 relatedProject: 'adhdo'
 ---

--- a/src/content/audio/adversarial-poetry-as-jailbreak-overview.md
+++ b/src/content/audio/adversarial-poetry-as-jailbreak-overview.md
@@ -3,7 +3,7 @@ title: 'Adversarial Poetry: When Rhyme Bypasses Reason'
 description: 'Audio overview of Adversarial Poetry: When Rhyme Bypasses Reason.'
 date: 2026-03-02
 tags: ['notebooklm', 'ai', 'ai-safety', 'jailbreaking', 'research', 'llm', 'adversarial']
-audioUrl: '/notebook-assets/adversarial-poetry-as-jailbreak/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adversarial-poetry-as-jailbreak/audio.mp3'
 duration: '19:47'
 relatedPost: 'adversarial-poetry-as-jailbreak-post'
 ---

--- a/src/content/audio/afterglow-engine-overview.md
+++ b/src/content/audio/afterglow-engine-overview.md
@@ -3,7 +3,7 @@ title: 'Mining Ghosts from Your Own Catalogue'
 description: 'Audio archaeology for musicians — how Afterglow Engine extracts reusable textures from your finished work using STFT analysis.'
 date: 2026-02-02
 tags: ['notebooklm', 'music', 'audio', 'creative']
-audioUrl: '/notebook-assets/afterglow-engine/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterglow-engine/audio.mp3'
 duration: '14:33'
 relatedProject: 'afterglow-engine'
 ---

--- a/src/content/audio/afterwords-overview.md
+++ b/src/content/audio/afterwords-overview.md
@@ -3,7 +3,7 @@ title: 'Giving Claude Code a Voice'
 description: 'Audio overview of Afterwords — local voice output for Claude Code with 17 cloned voices, per-project selection, and zero cloud dependency.'
 date: 2026-03-22
 tags: ['notebooklm', 'ai', 'tts', 'voice-cloning']
-audioUrl: '/notebook-assets/afterwords/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterwords/audio.mp3'
 duration: '21:43'
 relatedPost: 'afterwords-post'
 relatedProject: 'afterwords'

--- a/src/content/audio/agentic-index-overview.md
+++ b/src/content/audio/agentic-index-overview.md
@@ -3,7 +3,7 @@ title: 'Cutting Through the Agent Hype'
 description: 'An opinionated, scored catalogue of autonomous AI tooling — because GitHub stars measure hype, not quality.'
 date: 2025-08-01
 tags: ['notebooklm', 'ai', 'agents', 'curation']
-audioUrl: '/notebook-assets/agentic-index/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/agentic-index/audio.mp3'
 duration: '17:17'
 relatedProject: 'agentic-index'
 ---

--- a/src/content/audio/auditory-spiral-overview.md
+++ b/src/content/audio/auditory-spiral-overview.md
@@ -3,7 +3,7 @@ title: 'Six Hours of Dark Ambient at the Edge of the World'
 description: "Audio overview of Auditory Spiral — overnight electronic music on RTRFM Perth, the cassette network, and a city's sonic lifeline."
 date: 1992-01-01
 tags: ['notebooklm', 'music', 'radio', 'history']
-audioUrl: '/notebook-assets/auditory-spiral/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/auditory-spiral/audio.mp3'
 duration: '18:13'
 relatedProject: 'auditory-spiral'
 ---

--- a/src/content/audio/before-the-words-existed-overview.md
+++ b/src/content/audio/before-the-words-existed-overview.md
@@ -3,7 +3,7 @@ title: "The ADHD Novel That Didn't Know It Was One"
 description: "A scholarly close reading arguing Gibson's Neuromancer encoded the ADHD experience a decade before the vocabulary existed."
 date: 2026-02-10
 tags: ['notebooklm', 'neurodivergence', 'literary-criticism', 'adhd']
-audioUrl: '/notebook-assets/before-the-words-existed/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/before-the-words-existed/audio.mp3'
 duration: '16:50'
 relatedProject: 'before-the-words-existed'
 ---

--- a/src/content/audio/beyond-context-windows-overview.md
+++ b/src/content/audio/beyond-context-windows-overview.md
@@ -3,7 +3,7 @@ title: 'Beyond Context Windows'
 description: 'Audio overview of Beyond Context Windows.'
 date: 2026-03-15
 tags: ['notebooklm', 'ai', 'engineering', 'mcp', 'llm', 'python']
-audioUrl: '/notebook-assets/beyond-context-windows/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/beyond-context-windows/audio.mp3'
 duration: '20:14'
 relatedPost: 'beyond-context-windows-post'
 ---

--- a/src/content/audio/building-a-personal-site-in-2026-overview.md
+++ b/src/content/audio/building-a-personal-site-in-2026-overview.md
@@ -3,7 +3,7 @@ title: 'Building a Personal Site in 2026'
 description: 'Audio overview of Building a Personal Site in 2026.'
 date: 2026-02-15
 tags: ['notebooklm', 'engineering', 'web', 'astro', 'open-source']
-audioUrl: '/notebook-assets/building-a-personal-site-in-2026/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/building-a-personal-site-in-2026/audio.mp3'
 duration: '16:56'
 relatedPost: 'building-a-personal-site-in-2026-post'
 ---

--- a/src/content/audio/cv-overview.md
+++ b/src/content/audio/cv-overview.md
@@ -3,7 +3,7 @@ title: "A CV That Proves It Isn't Lying"
 description: 'A self-updating CV pipeline where GitHub Actions runs twice daily, Claude refines content, and a hallucination detector gates deployment.'
 date: 2026-02-04
 tags: ['notebooklm', 'craft', 'web', 'career']
-audioUrl: '/notebook-assets/cv/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/cv/audio.mp3'
 duration: '15:06'
 relatedProject: 'cv'
 ---

--- a/src/content/audio/cygnet-overview.md
+++ b/src/content/audio/cygnet-overview.md
@@ -3,7 +3,7 @@ title: 'Twenty-Eight Agents, One Eco Village'
 description: 'Audio overview of Cygnet — 28 AI agents coordinating 3D-printed housing on 170 acres in Tasmania to cut costs by 60%.'
 date: 2025-04-01
 tags: ['notebooklm', 'ai', 'housing', 'agents']
-audioUrl: '/notebook-assets/cygnet/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/cygnet/audio.mp3'
 duration: '16:03'
 relatedProject: 'cygnet'
 ---

--- a/src/content/audio/dodgylegally-overview.md
+++ b/src/content/audio/dodgylegally-overview.md
@@ -3,7 +3,7 @@ title: 'Manufacturing Happy Accidents'
 description: "A CLI that turns random words into sample packs via YouTube — because the best sounds come from places you weren't looking."
 date: 2026-02-01
 tags: ['notebooklm', 'music', 'cli', 'creative']
-audioUrl: '/notebook-assets/dodgylegally/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dodgylegally/audio.mp3'
 duration: '16:15'
 relatedProject: 'dodgylegally'
 ---

--- a/src/content/audio/dx0-overview.md
+++ b/src/content/audio/dx0-overview.md
@@ -3,7 +3,7 @@ title: 'Diagnosis as a Team Sport'
 description: 'Multi-agent AI diagnostic system with five physician personas, 304 NEJM cases, and a budget that forces real trade-offs.'
 date: 2025-05-01
 tags: ['notebooklm', 'ai', 'healthcare', 'agents']
-audioUrl: '/notebook-assets/dx0/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dx0/audio.mp3'
 duration: '14:30'
 relatedProject: 'dx0'
 ---

--- a/src/content/audio/emdr-agent-overview.md
+++ b/src/content/audio/emdr-agent-overview.md
@@ -3,7 +3,7 @@ title: 'What Safety Architecture Does AI Therapy Require?'
 description: 'Audio overview of EMDR Agent — exploring what responsible AI-assisted trauma therapy demands before it can exist.'
 date: 2025-06-01
 tags: ['notebooklm', 'ai-safety', 'health', 'ai']
-audioUrl: '/notebook-assets/emdr-agent/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/emdr-agent/audio.mp3'
 duration: '15:08'
 relatedProject: 'emdr-agent'
 ---

--- a/src/content/audio/failure-first-overview.md
+++ b/src/content/audio/failure-first-overview.md
@@ -3,7 +3,7 @@ title: 'Map the Catastrophe Before You Build the Architecture'
 description: 'Audio overview of Failure First — adversarial AI evaluation across 120 models and 18,000 prompts.'
 date: 2026-02-09
 tags: ['notebooklm', 'ai-safety', 'adversarial', 'research']
-audioUrl: '/notebook-assets/failure-first/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/audio.mp3'
 duration: '12:44'
 relatedProject: 'failure-first'
 ---

--- a/src/content/audio/footnotes-at-the-edge-of-reality-overview.md
+++ b/src/content/audio/footnotes-at-the-edge-of-reality-overview.md
@@ -3,7 +3,7 @@ title: 'Where Physics Breaks Down and Poetry Begins'
 description: 'Audio overview of Footnotes at the Edge of Reality — a long-form poem rendered as interactive web experience.'
 date: 2026-02-06
 tags: ['notebooklm', 'poetry', 'physics', 'creative']
-audioUrl: '/notebook-assets/footnotes-at-the-edge-of-reality/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/audio.mp3'
 duration: '17:58'
 relatedPost: 'footnotes-at-the-edge-of-reality-post'
 relatedProject: 'footnotes-at-the-edge-of-reality'

--- a/src/content/audio/freedom-engine-overview.md
+++ b/src/content/audio/freedom-engine-overview.md
@@ -3,7 +3,7 @@ title: 'Bridging the Information Gap That Costs Years'
 description: 'Audio overview of Freedom Engine — AI-assisted legal Q&A helping federal inmates access First Step Act provisions.'
 date: 2025-04-01
 tags: ['notebooklm', 'ai', 'justice', 'legal']
-audioUrl: '/notebook-assets/freedom-engine/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/freedom-engine/audio.mp3'
 duration: '15:51'
 relatedProject: 'freedom-engine'
 ---

--- a/src/content/audio/getting-google-nest-cameras-into-frigate-nvr-overview.md
+++ b/src/content/audio/getting-google-nest-cameras-into-frigate-nvr-overview.md
@@ -3,7 +3,7 @@ title: 'Getting Google Nest Cameras Into Frigate NVR'
 description: 'Audio overview of Getting Google Nest Cameras Into Frigate NVR.'
 date: 2026-03-16
 tags: ['notebooklm', 'engineering', 'homelab', 'raspberry-pi', 'python', 'home-assistant']
-audioUrl: '/notebook-assets/getting-google-nest-cameras-into-frigate-nvr/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/getting-google-nest-cameras-into-frigate-nvr/audio.mp3'
 duration: '20:49'
 relatedPost: 'getting-google-nest-cameras-into-frigate-nvr-post'
 ---

--- a/src/content/audio/giving-a-robot-three-voices-overview.md
+++ b/src/content/audio/giving-a-robot-three-voices-overview.md
@@ -3,7 +3,7 @@ title: 'Giving a Robot Three Voices'
 description: 'Audio overview of Giving a Robot Three Voices.'
 date: 2026-03-19
 tags: ['notebooklm', 'ai', 'tts', 'mlx', 'raspberry-pi', 'robotics', 'apple-silicon', 'voice-cloning', 'spark']
-audioUrl: '/notebook-assets/giving-a-robot-three-voices/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/giving-a-robot-three-voices/audio.mp3'
 duration: '20:44'
 relatedPost: 'giving-a-robot-three-voices-post'
 ---

--- a/src/content/audio/grid2-overview.md
+++ b/src/content/audio/grid2-overview.md
@@ -3,7 +3,7 @@ title: 'AI for Understanding, Algorithms for Execution'
 description: 'A deterministic website builder where LLMs interpret intent but beam search assembles pages. Same inputs, same output, every time.'
 date: 2025-05-01
 tags: ['notebooklm', 'ai', 'web', 'typescript']
-audioUrl: '/notebook-assets/grid2/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/grid2/audio.mp3'
 duration: '16:33'
 relatedProject: 'grid2'
 ---

--- a/src/content/audio/hello-world-overview.md
+++ b/src/content/audio/hello-world-overview.md
@@ -3,7 +3,7 @@ title: 'Building in the Open'
 description: 'Audio overview of Building in the Open.'
 date: 2026-02-12
 tags: ['notebooklm', 'meta', 'craft', 'open-source']
-audioUrl: '/notebook-assets/hello-world/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/hello-world/audio.mp3'
 duration: '18:04'
 relatedPost: 'hello-world-post'
 ---

--- a/src/content/audio/home-assistant-obsidian-overview.md
+++ b/src/content/audio/home-assistant-obsidian-overview.md
@@ -3,7 +3,7 @@ title: 'Two Systems That Shape How You Think, One Box'
 description: 'Audio overview of Home Assistant Obsidian — your knowledge base and smart home on the same machine.'
 date: 2024-06-01
 tags: ['notebooklm', 'homelab', 'home-assistant', 'docker']
-audioUrl: '/notebook-assets/home-assistant-obsidian/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/home-assistant-obsidian/audio.mp3'
 duration: '15:06'
 relatedProject: 'home-assistant-obsidian'
 ---

--- a/src/content/audio/jailbreak-archaeology-overview.md
+++ b/src/content/audio/jailbreak-archaeology-overview.md
@@ -3,7 +3,7 @@ title: 'Jailbreak Archaeology: 4 Years of Broken Promises'
 description: '64 historical jailbreak scenarios tested against 2026 frontier models. The most dangerous finding: 2022 attacks still achieve ~30% success rates.'
 date: 2026-02-13
 tags: ['notebooklm', 'ai', 'ai-safety', 'research']
-audioUrl: '/notebook-assets/failure-first/jailbreak-archaeology/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/jailbreak-archaeology/audio.mp3'
 duration: '12:15'
 relatedPost: 'jailbreak-archaeology-post'
 relatedProject: 'failure-first'

--- a/src/content/audio/latent-self-overview.md
+++ b/src/content/audio/latent-self-overview.md
@@ -3,7 +3,7 @@ title: 'The Mirror That Shows What You Almost Are'
 description: 'Real-time StyleGAN2 face morphing as art installation — continuous, responsive, and productively uncanny.'
 date: 2025-02-01
 tags: ['notebooklm', 'art', 'ai', 'installation']
-audioUrl: '/notebook-assets/latent-self/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/latent-self/audio.mp3'
 duration: '15:28'
 relatedProject: 'latent-self'
 ---

--- a/src/content/audio/lunar-tools-prototypes-overview.md
+++ b/src/content/audio/lunar-tools-prototypes-overview.md
@@ -3,7 +3,7 @@ title: 'When Voice Becomes Brushstroke'
 description: 'Twenty-plus interactive art installations where visitors speak, sing, and dream into AI systems that respond in real time.'
 date: 2025-06-15
 tags: ['notebooklm', 'art', 'ai', 'installation']
-audioUrl: '/notebook-assets/lunar-tools-prototypes/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/lunar-tools-prototypes/audio.mp3'
 duration: '18:43'
 relatedProject: 'lunar-tools-prototypes'
 ---

--- a/src/content/audio/modelatlas-overview.md
+++ b/src/content/audio/modelatlas-overview.md
@@ -3,7 +3,7 @@ title: 'Trust-Scoring the Foundation Model Landscape'
 description: 'Forensic-grade metadata for thousands of foundation models — recursive enrichment, provenance tracking, and trust you can quantify.'
 date: 2025-04-15
 tags: ['notebooklm', 'ai', 'research', 'python']
-audioUrl: '/notebook-assets/modelatlas/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/modelatlas/audio.mp3'
 duration: '13:29'
 relatedProject: 'modelatlas'
 ---

--- a/src/content/audio/moltbook-overview.md
+++ b/src/content/audio/moltbook-overview.md
@@ -3,7 +3,7 @@ title: 'When AI Systems Talk to Each Other, Safety Breaks Down'
 description: 'Multi-agent AI research reveals a critical gap: single-agent safety does not compose. 1.5M interactions show 46.34% attack success rates.'
 date: 2026-02-13
 tags: ['notebooklm', 'ai', 'ai-safety', 'research', 'multi-agent']
-audioUrl: '/notebook-assets/failure-first/moltbook/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/moltbook/audio.mp3'
 duration: '14:32'
 relatedPost: 'when-ai-systems-talk-safety-breaks-post'
 relatedProject: 'failure-first'

--- a/src/content/audio/neuroconnect-overview.md
+++ b/src/content/audio/neuroconnect-overview.md
@@ -3,7 +3,7 @@ title: 'The Helpline That Knows the Difference'
 description: 'A 24/7 voice helpline built around neurodivergent communication — where crisis detection is deterministic and the LLM never decides if someone is safe.'
 date: 2025-05-01
 tags: ['notebooklm', 'ai', 'health', 'adhd']
-audioUrl: '/notebook-assets/neuroconnect/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/neuroconnect/audio.mp3'
 duration: '16:43'
 relatedProject: 'neuroconnect'
 ---

--- a/src/content/audio/notebooklm-automation-overview.md
+++ b/src/content/audio/notebooklm-automation-overview.md
@@ -3,7 +3,7 @@ title: "The Door Google Didn't Build"
 description: 'Audio overview of NotebookLM Automation — reverse-engineered RPC access for batch export, generation, and control.'
 date: 2025-12-01
 tags: ['notebooklm', 'ai', 'automation']
-audioUrl: '/notebook-assets/notebooklm-automation/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/notebooklm-automation/audio.mp3'
 duration: '14:57'
 relatedProject: 'notebooklm-automation'
 ---

--- a/src/content/audio/orbitr-overview.md
+++ b/src/content/audio/orbitr-overview.md
@@ -3,7 +3,7 @@ title: 'Rhythm as Geometry, Sounds from Words'
 description: 'Audio overview of orbitr — a circular sequencer where polyrhythm becomes spatial and MusicGen creates the sounds.'
 date: 2025-09-01
 tags: ['notebooklm', 'music', 'ai', 'creative']
-audioUrl: '/notebook-assets/orbitr/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/orbitr/audio.mp3'
 duration: '17:20'
 relatedProject: 'orbitr'
 ---

--- a/src/content/audio/ordr-fm-overview.md
+++ b/src/content/audio/ordr-fm-overview.md
@@ -3,7 +3,7 @@ title: 'The Tool That Earns Trust Before Features'
 description: 'Audio overview of ordr.fm — a CLI for music library organisation with lossless prioritisation, EXIF metadata, and zero-overwrite safety.'
 date: 2025-07-01
 tags: ['notebooklm', 'music', 'cli', 'audio']
-audioUrl: '/notebook-assets/ordr-fm/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/ordr-fm/audio.mp3'
 duration: '16:27'
 relatedProject: 'ordr-fm'
 ---

--- a/src/content/audio/personal-agentic-operating-system-overview.md
+++ b/src/content/audio/personal-agentic-operating-system-overview.md
@@ -3,7 +3,7 @@ title: 'An Agentic System You Can Actually Reason About'
 description: 'Audio overview of PAOS — a local-first LLM operating system with hybrid retrieval and a self-improving meta-agent.'
 date: 2025-07-01
 tags: ['notebooklm', 'ai', 'infrastructure', 'agents']
-audioUrl: '/notebook-assets/personal-agentic-operating-system/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/personal-agentic-operating-system/audio.mp3'
 duration: '18:42'
 relatedProject: 'personal-agentic-operating-system'
 ---

--- a/src/content/audio/reconciling-the-great-divergence-overview.md
+++ b/src/content/audio/reconciling-the-great-divergence-overview.md
@@ -3,7 +3,7 @@ title: 'Reconciling the Great Divergence'
 description: 'Audio overview of Reconciling the Great Divergence.'
 date: 2026-03-01
 tags: ['notebooklm', 'ai', 'economics', 'research', 'policy']
-audioUrl: '/notebook-assets/reconciling-the-great-divergence/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/reconciling-the-great-divergence/audio.mp3'
 duration: '21:41'
 relatedPost: 'reconciling-the-great-divergence-post'
 ---

--- a/src/content/audio/rlm-mcp-overview.md
+++ b/src/content/audio/rlm-mcp-overview.md
@@ -3,7 +3,7 @@ title: 'Beyond Context Windows'
 description: 'Audio overview of rlm-mcp — an MCP server for processing million-character documents with BM25 search and provenance.'
 date: 2025-11-01
 tags: ['notebooklm', 'ai', 'mcp', 'tools']
-audioUrl: '/notebook-assets/rlm-mcp/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/rlm-mcp/audio.mp3'
 duration: '18:31'
 relatedProject: 'rlm-mcp'
 ---

--- a/src/content/audio/safety-first-therapeutic-ai-overview.md
+++ b/src/content/audio/safety-first-therapeutic-ai-overview.md
@@ -3,7 +3,7 @@ title: 'Safety-First Therapeutic AI'
 description: 'Audio overview of Safety-First Therapeutic AI.'
 date: 2026-03-15
 tags: ['notebooklm', 'ai', 'ai-safety', 'health', 'typescript']
-audioUrl: '/notebook-assets/safety-first-therapeutic-ai/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/safety-first-therapeutic-ai/audio.mp3'
 duration: '20:37'
 relatedPost: 'safety-first-therapeutic-ai-post'
 ---

--- a/src/content/audio/space-weather-overview.md
+++ b/src/content/audio/space-weather-overview.md
@@ -3,7 +3,7 @@ title: 'The Sun Is a Noisy Neighbour'
 description: 'Audio overview of a real-time space weather dashboard — making the invisible electromagnetic weather above us finally visible.'
 date: 2025-01-01
 tags: ['notebooklm', 'data-viz', 'science', 'web']
-audioUrl: '/notebook-assets/space-weather/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/space-weather/audio.mp3'
 duration: '18:15'
 relatedProject: 'space-weather'
 ---

--- a/src/content/audio/spark-overview.md
+++ b/src/content/audio/spark-overview.md
@@ -3,7 +3,7 @@ title: 'The Robot That Refuses to Give Orders'
 description: 'Audio deep dive into SPARK — a non-coercive AI robot companion for neurodivergent children. Declarative presence, not demands.'
 date: 2026-03-12
 tags: ['notebooklm', 'ai', 'robotics', 'neurodivergence']
-audioUrl: '/notebook-assets/spark/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/spark/audio.mp3'
 duration: '43:05'
 relatedPost: 'the-robot-that-refuses-to-give-orders-post'
 relatedProject: 'spark'

--- a/src/content/audio/squishmallowdex-overview.md
+++ b/src/content/audio/squishmallowdex-overview.md
@@ -3,7 +3,7 @@ title: 'What Hyperfocus and a Good Excuse Can Produce in an Afternoon'
 description: 'Audio overview of Squishmallowdex — a kid-friendly collection tracker for 3,000+ plush creatures. No ads, no tracking.'
 date: 2024-12-01
 tags: ['notebooklm', 'web', 'kids', 'open-source']
-audioUrl: '/notebook-assets/squishmallowdex/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/squishmallowdex/audio.mp3'
 duration: '17:56'
 relatedProject: 'squishmallowdex'
 ---

--- a/src/content/audio/strategic-acquisitions-overview.md
+++ b/src/content/audio/strategic-acquisitions-overview.md
@@ -3,7 +3,7 @@ title: 'Housing Deserves Better Tooling'
 description: "Audio overview of an AI-powered property analysis pipeline for public housing — spatial intelligence, ML valuations, and Tasmania's LIST."
 date: 2025-01-15
 tags: ['notebooklm', 'ai', 'housing', 'python']
-audioUrl: '/notebook-assets/strategic-acquisitions/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/strategic-acquisitions/audio.mp3'
 duration: '21:13'
 relatedProject: 'strategic-acquisitions'
 ---

--- a/src/content/audio/tanda-pizza-overview.md
+++ b/src/content/audio/tanda-pizza-overview.md
@@ -3,7 +3,7 @@ title: 'Tanda Pizza: Static Site for a Rice Paddy Pizzeria'
 description: 'Building a fast, multilingual website for authentic Italian food in Bali — where the nearest reliable internet is a philosophical concept.'
 date: 2026-02-03
 tags: ['notebooklm', 'web', 'static-site', 'multilingual']
-audioUrl: '/notebook-assets/tanda-pizza/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/tanda-pizza/audio.mp3'
 duration: '6:23'
 relatedProject: 'tanda-pizza'
 ---

--- a/src/content/audio/tel3sis-overview.md
+++ b/src/content/audio/tel3sis-overview.md
@@ -3,7 +3,7 @@ title: 'Three Seconds of Silence Is an Eternity'
 description: 'Audio overview of TEL3SIS — a voice-first agentic phone platform where sub-3s latency is a survival threshold, not a benchmark.'
 date: 2025-10-01
 tags: ['notebooklm', 'ai', 'voice', 'telephony']
-audioUrl: '/notebook-assets/tel3sis/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/tel3sis/audio.mp3'
 duration: '19:37'
 relatedProject: 'tel3sis'
 ---

--- a/src/content/audio/the-ai-productivity-j-curve-overview.md
+++ b/src/content/audio/the-ai-productivity-j-curve-overview.md
@@ -3,7 +3,7 @@ title: 'The AI Productivity J-Curve: Why Most Enterprise AI Fails'
 description: 'Audio overview of The AI Productivity J-Curve: Why Most Enterprise AI Fails.'
 date: 2026-03-02
 tags: ['notebooklm', 'ai', 'economics', 'enterprise', 'research', 'policy']
-audioUrl: '/notebook-assets/the-ai-productivity-j-curve/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-ai-productivity-j-curve/audio.mp3'
 duration: '23:44'
 relatedPost: 'the-ai-productivity-j-curve-post'
 ---

--- a/src/content/audio/the-cognitive-cage-overview.md
+++ b/src/content/audio/the-cognitive-cage-overview.md
@@ -3,7 +3,7 @@ title: 'The Cognitive Cage: Humanoid Robot Fatality Risk'
 description: 'Audio overview of The Cognitive Cage: Humanoid Robot Fatality Risk.'
 date: 2026-03-01
 tags: ['notebooklm', 'ai', 'ai-safety', 'robotics', 'research', 'engineering']
-audioUrl: '/notebook-assets/the-cognitive-cage/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-cognitive-cage/audio.mp3'
 duration: '19:08'
 relatedPost: 'the-cognitive-cage-post'
 ---

--- a/src/content/audio/the-failure-first-team-overview.md
+++ b/src/content/audio/the-failure-first-team-overview.md
@@ -3,7 +3,7 @@ title: 'The Failure First Team'
 description: 'Audio overview of The Failure First Team.'
 date: 2026-03-30
 tags: ['notebooklm', 'ai', 'ai-safety', 'research', 'adversarial', 'team']
-audioUrl: '/notebook-assets/the-failure-first-team/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-failure-first-team/audio.mp3'
 duration: '22:24'
 relatedPost: 'the-failure-first-team-post'
 ---

--- a/src/content/audio/the-legal-ai-trust-deficit-overview.md
+++ b/src/content/audio/the-legal-ai-trust-deficit-overview.md
@@ -3,7 +3,7 @@ title: 'The Legal AI Trust Deficit'
 description: 'Audio overview of The Legal AI Trust Deficit.'
 date: 2026-03-02
 tags: ['notebooklm', 'ai', 'legal', 'research', 'llm']
-audioUrl: '/notebook-assets/the-legal-ai-trust-deficit/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-legal-ai-trust-deficit/audio.mp3'
 duration: '22:25'
 relatedPost: 'the-legal-ai-trust-deficit-post'
 ---

--- a/src/content/audio/the-notebooklm-pipeline-overview.md
+++ b/src/content/audio/the-notebooklm-pipeline-overview.md
@@ -3,7 +3,7 @@ title: 'The NotebookLM Pipeline'
 description: 'Audio overview of The NotebookLM Pipeline.'
 date: 2026-02-15
 tags: ['notebooklm', 'engineering', 'automation', 'ai', 'python']
-audioUrl: '/notebook-assets/the-notebooklm-pipeline/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-notebooklm-pipeline/audio.mp3'
 duration: '25:08'
 relatedPost: 'the-notebooklm-pipeline-post'
 ---

--- a/src/content/audio/the-resonant-fringe-overview.md
+++ b/src/content/audio/the-resonant-fringe-overview.md
@@ -3,7 +3,7 @@ title: 'The Resonant Fringe'
 description: 'Audio overview of The Resonant Fringe.'
 date: 2026-03-18
 tags: ['notebooklm', 'history', 'music', 'perth', 'radio']
-audioUrl: '/notebook-assets/the-resonant-fringe/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-resonant-fringe/audio.mp3'
 duration: '22:58'
 relatedPost: 'the-resonant-fringe-post'
 ---

--- a/src/content/audio/this-wasnt-in-the-brochure-overview.md
+++ b/src/content/audio/this-wasnt-in-the-brochure-overview.md
@@ -3,7 +3,7 @@ title: 'The Brochure Was for a Different Trip'
 description: 'Audio deep dive into a neurodivergent co-parenting guide — the double discovery, three-AI workflow, and maritime cartography as metaphor.'
 date: 2026-02-08
 tags: ['notebooklm', 'neurodivergence', 'parenting', 'writing']
-audioUrl: '/notebook-assets/this-wasnt-in-the-brochure/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/audio.mp3'
 duration: '21:39'
 relatedPost: 'this-wasnt-in-the-brochure-post'
 relatedProject: 'this-wasnt-in-the-brochure'

--- a/src/content/audio/veritas-overview.md
+++ b/src/content/audio/veritas-overview.md
@@ -3,7 +3,7 @@ title: 'The Efficiency-Trust Deficit in Legal AI'
 description: "Audio deep dive into VERITAS — a legal AI platform where trust isn't a feature, it's the architecture. Built for Australian practice."
 date: 2025-03-01
 tags: ['notebooklm', 'ai', 'legal', 'research']
-audioUrl: '/notebook-assets/veritas/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/veritas/audio.mp3'
 duration: '18:42'
 relatedProject: 'veritas'
 ---

--- a/src/content/audio/voice-cloning-qwen3-tts-mlx-overview.md
+++ b/src/content/audio/voice-cloning-qwen3-tts-mlx-overview.md
@@ -3,7 +3,7 @@ title: 'Voice Cloning with Qwen3-TTS and MLX on Apple Silicon'
 description: 'Audio overview of Voice Cloning with Qwen3-TTS and MLX on Apple Silicon.'
 date: 2026-03-19
 tags: ['notebooklm', 'ai', 'tts', 'mlx', 'apple-silicon', 'voice-cloning', 'tutorial', 'spark']
-audioUrl: '/notebook-assets/voice-cloning-qwen3-tts-mlx/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/voice-cloning-qwen3-tts-mlx/audio.mp3'
 duration: '23:50'
 relatedPost: 'voice-cloning-qwen3-tts-mlx-post'
 ---

--- a/src/content/audio/why-demonstrated-risk-is-ignored-overview.md
+++ b/src/content/audio/why-demonstrated-risk-is-ignored-overview.md
@@ -3,7 +3,7 @@ title: 'Looking Past the Evidence'
 description: "Audio deep dive into why people acknowledge demonstrated risk and then proceed as if it doesn't exist. Structural, not stupid."
 date: 2026-02-07
 tags: ['notebooklm', 'research', 'risk', 'ai-safety']
-audioUrl: '/notebook-assets/why-demonstrated-risk-is-ignored/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/audio.mp3'
 duration: '22:17'
 relatedPost: 'why-demonstrated-risk-is-ignored-post'
 relatedProject: 'why-demonstrated-risk-is-ignored'

--- a/src/content/audio/why-i-build-in-public-overview.md
+++ b/src/content/audio/why-i-build-in-public-overview.md
@@ -3,7 +3,7 @@ title: 'Why I Build in Public'
 description: 'Audio overview of Why I Build in Public.'
 date: 2026-02-15
 tags: ['notebooklm', 'engineering', 'open-source', 'philosophy']
-audioUrl: '/notebook-assets/why-i-build-in-public/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-i-build-in-public/audio.mp3'
 duration: '14:35'
 relatedPost: 'why-i-build-in-public-post'
 ---

--- a/src/content/audio/wolf-clan-hub-overview.md
+++ b/src/content/audio/wolf-clan-hub-overview.md
@@ -3,7 +3,7 @@ title: 'Zero Build, Full Operations'
 description: 'Audio overview of a three-zone martial arts operations platform — public site, ops hub, member portal — running on vanilla JS and Cloudflare.'
 date: 2026-03-02
 tags: ['notebooklm', 'web', 'cloudflare', 'community']
-audioUrl: '/notebook-assets/wolf-clan-hub/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/wolf-clan-hub/audio.mp3'
 duration: '20:55'
 relatedProject: 'wolf-clan-hub'
 ---

--- a/src/content/audio/zero-build-web-development-overview.md
+++ b/src/content/audio/zero-build-web-development-overview.md
@@ -3,7 +3,7 @@ title: 'Zero-Build Web Development'
 description: 'Audio overview of Zero-Build Web Development.'
 date: 2026-03-14
 tags: ['notebooklm', 'engineering', 'web', 'security', 'cloudflare']
-audioUrl: '/notebook-assets/zero-build-web-development/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/zero-build-web-development/audio.mp3'
 duration: '22:59'
 relatedPost: 'zero-build-web-development-post'
 ---

--- a/src/content/blog/120-models-18k-prompts-post.md
+++ b/src/content/blog/120-models-18k-prompts-post.md
@@ -5,7 +5,7 @@ date: 2026-03-01
 tags: ['ai', 'ai-safety', 'research', 'llm', 'security', 'adversarial']
 draft: false
 heroImage: '/notebook-assets/120-models-18k-prompts/infographic.webp'
-audioUrl: '/notebook-assets/120-models-18k-prompts/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/120-models-18k-prompts/audio.mp3'
 faq:
   - q: 'What is supply chain injection in AI?'
     a: 'Supply chain injection involves inserting malicious content into tool definitions and skill files rather than user prompts. Testing showed 90–100% attack success rates across models because external tool definitions are trusted implicitly.'

--- a/src/content/blog/adversarial-poetry-as-jailbreak-post.md
+++ b/src/content/blog/adversarial-poetry-as-jailbreak-post.md
@@ -5,7 +5,7 @@ date: 2026-03-02
 tags: ['ai', 'ai-safety', 'jailbreaking', 'research', 'llm', 'adversarial']
 draft: false
 heroImage: '/notebook-assets/adversarial-poetry-as-jailbreak/infographic.webp'
-audioUrl: '/notebook-assets/adversarial-poetry-as-jailbreak/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adversarial-poetry-as-jailbreak/audio.mp3'
 faq:
   - q: 'What is adversarial poetry jailbreaking?'
     a: 'A technique where harmful prompts are reformulated as poems (sonnets, haiku, limericks), which bypasses LLM safety filters because models process poetic structure differently from direct instructions.'

--- a/src/content/blog/afterwords-post.md
+++ b/src/content/blog/afterwords-post.md
@@ -5,7 +5,7 @@ date: 2026-03-22
 tags: ['ai', 'tts', 'mlx', 'apple-silicon', 'voice-cloning', 'claude', 'open-source']
 series: 'PiCar-X'
 seriesOrder: 4
-audioUrl: '/notebook-assets/afterwords-blog/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterwords-blog/audio.mp3'
 heroImage: '/notebook-assets/afterwords/infographic.webp'
 faq:
   - q: 'Does Afterwords send any data to the cloud?'

--- a/src/content/blog/beyond-context-windows-post.md
+++ b/src/content/blog/beyond-context-windows-post.md
@@ -5,7 +5,7 @@ date: 2026-03-15
 tags: ['ai', 'engineering', 'mcp', 'llm', 'python']
 draft: false
 heroImage: '/notebook-assets/beyond-context-windows/infographic.webp'
-audioUrl: '/notebook-assets/beyond-context-windows/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/beyond-context-windows/audio.mp3'
 faq:
   - q: 'What is the Recursive Language Model pattern?'
     a: 'The Recursive Language Model pattern treats documents as environment that the model queries, rather than input to read directly. The LLM uses tools to search, retrieve, and interact with content iteratively.'

--- a/src/content/blog/building-a-personal-site-in-2026-post.md
+++ b/src/content/blog/building-a-personal-site-in-2026-post.md
@@ -4,7 +4,7 @@ description: "The case for constraint-led web development — Astro, zero custom
 date: 2026-02-15
 tags: ['engineering', 'web', 'astro', 'open-source']
 heroImage: '/notebook-assets/building-a-personal-site-in-2026/infographic.webp'
-audioUrl: '/notebook-assets/building-a-personal-site-in-2026/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/building-a-personal-site-in-2026/audio.mp3'
 faq:
   - q: 'What framework is best for a personal site in 2026?'
     a: 'Astro generates static HTML pages with zero JavaScript by default, making it architecturally right for document-based personal sites. It ships JS only through Preact islands that hydrate on idle.'

--- a/src/content/blog/footnotes-at-the-edge-of-reality-post.md
+++ b/src/content/blog/footnotes-at-the-edge-of-reality-post.md
@@ -5,7 +5,7 @@ date: 2026-02-12
 tags: ['poetry', 'physics', 'writing', 'creative']
 draft: false
 heroImage: '/notebook-assets/footnotes-at-the-edge-of-reality/infographic.webp'
-audioUrl: '/notebook-assets/footnotes-at-the-edge-of-reality/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/audio.mp3'
 ---
 
 # Footnotes at the Edge of Reality

--- a/src/content/blog/getting-google-nest-cameras-into-frigate-nvr-post.md
+++ b/src/content/blog/getting-google-nest-cameras-into-frigate-nvr-post.md
@@ -5,7 +5,7 @@ date: 2026-03-16
 tags: ['engineering', 'homelab', 'raspberry-pi', 'python', 'home-assistant']
 draft: false
 heroImage: '/notebook-assets/getting-google-nest-cameras-into-frigate-nvr/infographic.webp'
-audioUrl: '/notebook-assets/getting-google-nest-cameras-into-frigate-nvr/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/getting-google-nest-cameras-into-frigate-nvr/audio.mp3'
 ---
 
 I've tried this at least three times before. Each time I hit a wall, gave up, and went back to watching my Nest cameras through the Google Home app like a normal person. This time I finally cracked it — and the solution turned out to be genuinely weird in ways I want to document properly, because the information online is either outdated, incomplete, or glosses over the exact failure modes that will destroy your afternoon.

--- a/src/content/blog/giving-a-robot-three-voices-post.md
+++ b/src/content/blog/giving-a-robot-three-voices-post.md
@@ -4,7 +4,7 @@ description: 'Building a three-persona TTS pipeline for a Pi robot — MLX voice
 date: 2026-03-19
 tags: ['ai', 'tts', 'mlx', 'raspberry-pi', 'robotics', 'apple-silicon', 'voice-cloning', 'spark']
 heroImage: '/notebook-assets/giving-a-robot-three-voices/infographic.webp'
-audioUrl: '/notebook-assets/giving-a-robot-three-voices/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/giving-a-robot-three-voices/audio.mp3'
 series: 'PiCar-X'
 seriesOrder: 2
 faq:

--- a/src/content/blog/hello-world-post.md
+++ b/src/content/blog/hello-world-post.md
@@ -4,7 +4,7 @@ description: 'The commit log is more honest than the readme. Building in public 
 date: 2026-02-12
 tags: ['meta', 'craft', 'open-source']
 heroImage: '/notebook-assets/hello-world/infographic.webp'
-audioUrl: '/notebook-assets/hello-world/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/hello-world/audio.mp3'
 ---
 
 Most personal sites are museums. Carefully selected exhibits, arranged chronologically, with the messy work hidden in a drawer somewhere. This is not that.

--- a/src/content/blog/jailbreak-archaeology-post.md
+++ b/src/content/blog/jailbreak-archaeology-post.md
@@ -5,8 +5,8 @@ date: 2026-02-13
 tags: ['ai', 'ai-safety', 'research', 'jailbreaking', 'llm']
 draft: false
 heroImage: '/notebook-assets/jailbreak-archaeology/infographic.webp'
-audioUrl: '/notebook-assets/failure-first/jailbreak-archaeology/audio.mp3'
-videoUrl: '/notebook-assets/failure-first/jailbreak-archaeology/video.mp4'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/jailbreak-archaeology/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/jailbreak-archaeology/video.mp4'
 slides: '/notebook-assets/failure-first/jailbreak-archaeology/slides.pdf'
 faq:
   - q: 'What is jailbreak archaeology?'

--- a/src/content/blog/reconciling-the-great-divergence-post.md
+++ b/src/content/blog/reconciling-the-great-divergence-post.md
@@ -5,7 +5,7 @@ date: 2026-03-01
 tags: ['ai', 'economics', 'research', 'policy']
 draft: false
 heroImage: '/notebook-assets/reconciling-the-great-divergence/infographic.webp'
-audioUrl: '/notebook-assets/reconciling-the-great-divergence/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/reconciling-the-great-divergence/audio.mp3'
 ---
 
 Goldman Sachs says AI could add $7 trillion to global GDP. MIT economist Daron Acemoglu says the near-term impact is closer to 0.5%. PwC projects $15.7 trillion in additional economic value by 2030. McKinsey puts annual productivity gains at $2.6–4.4 trillion.

--- a/src/content/blog/safety-first-therapeutic-ai-post.md
+++ b/src/content/blog/safety-first-therapeutic-ai-post.md
@@ -5,7 +5,7 @@ date: 2026-03-15
 tags: ['ai', 'ai-safety', 'health', 'typescript']
 draft: false
 heroImage: '/notebook-assets/safety-first-therapeutic-ai/infographic.webp'
-audioUrl: '/notebook-assets/safety-first-therapeutic-ai/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/safety-first-therapeutic-ai/audio.mp3'
 faq:
   - q: 'What is EMDR and why does it require AI safety?'
     a: 'EMDR (Eye Movement Desensitization and Reprocessing) is a trauma therapy with precise protocols and serious failure modes. AI-assisted EMDR requires safety architecture first because the therapeutic mechanism — activating distress — is also the primary risk.'

--- a/src/content/blog/the-ai-productivity-j-curve-post.md
+++ b/src/content/blog/the-ai-productivity-j-curve-post.md
@@ -5,7 +5,7 @@ date: 2026-03-02
 tags: ['ai', 'economics', 'enterprise', 'research', 'policy']
 draft: false
 heroImage: '/notebook-assets/the-ai-productivity-j-curve/infographic.webp'
-audioUrl: '/notebook-assets/the-ai-productivity-j-curve/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-ai-productivity-j-curve/audio.mp3'
 faq:
   - q: 'What is the AI Productivity J-Curve?'
     a: "An economic framework showing that transformative technologies initially reduce measured productivity before generating gains — because the critical intangible investments (process redesign, data governance, workforce reskilling) aren't captured in traditional metrics."

--- a/src/content/blog/the-cognitive-cage-post.md
+++ b/src/content/blog/the-cognitive-cage-post.md
@@ -5,7 +5,7 @@ date: 2026-03-01
 tags: ['ai', 'ai-safety', 'robotics', 'research', 'engineering']
 draft: false
 heroImage: '/notebook-assets/the-cognitive-cage/infographic.webp'
-audioUrl: '/notebook-assets/the-cognitive-cage/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-cognitive-cage/audio.mp3'
 faq:
   - q: 'What is the cognitive cage in robotics?'
     a: 'The cognitive cage is a proposed safety system for humanoid robots — a deterministic code layer that verifies and vetoes vision-language-action model commands in real time, replacing the physical cages that historically contained robot movements.'

--- a/src/content/blog/the-failure-first-team-post.md
+++ b/src/content/blog/the-failure-first-team-post.md
@@ -5,7 +5,7 @@ date: 2026-03-30
 tags: ['ai', 'ai-safety', 'research', 'adversarial', 'team']
 draft: false
 heroImage: '/notebook-assets/the-failure-first-team/infographic.webp'
-audioUrl: '/notebook-assets/the-failure-first-team/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-failure-first-team/audio.mp3'
 faq:
   - q: 'What is the Failure First team?'
     a: 'The Failure First team consists of fifteen specialist AI agents, each initialized with distinct roles and standing instructions. They work on adversarial AI evaluation across 227 models and 133,000+ evaluated results, with a human coordinator overseeing direction and publication.'

--- a/src/content/blog/the-legal-ai-trust-deficit-post.md
+++ b/src/content/blog/the-legal-ai-trust-deficit-post.md
@@ -5,7 +5,7 @@ date: 2026-03-02
 tags: ['ai', 'legal', 'research', 'llm']
 draft: false
 heroImage: '/notebook-assets/the-legal-ai-trust-deficit/infographic.webp'
-audioUrl: '/notebook-assets/the-legal-ai-trust-deficit/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-legal-ai-trust-deficit/audio.mp3'
 faq:
   - q: 'Why are lawyers slow to adopt AI?'
     a: 'The legal profession values accuracy, confidentiality, and accountability — all areas where current AI systems have demonstrated weaknesses. 75% of lawyers cite accuracy concerns as the top barrier.'

--- a/src/content/blog/the-notebooklm-pipeline-post.md
+++ b/src/content/blog/the-notebooklm-pipeline-post.md
@@ -4,7 +4,7 @@ description: "How I automated audio overviews, quizzes, mind maps, and infograph
 date: 2026-02-15
 tags: ['engineering', 'automation', 'ai', 'python']
 heroImage: '/notebook-assets/the-notebooklm-pipeline/infographic.webp'
-audioUrl: '/notebook-assets/the-notebooklm-pipeline/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-notebooklm-pipeline/audio.mp3'
 faq:
   - q: 'What is the NotebookLM pipeline?'
     a: "An automated system that takes structured Markdown content (blog posts, project docs) and routes it through Google's NotebookLM to produce audio overviews, video summaries, infographics, and other derived assets — all triggered from a single config file."

--- a/src/content/blog/the-resonant-fringe-post.md
+++ b/src/content/blog/the-resonant-fringe-post.md
@@ -4,7 +4,7 @@ description: "Auditory Spiral, RTRFM, and how Perth's electronic music undergrou
 date: 2026-03-18
 tags: ['history', 'music', 'perth', 'radio']
 heroImage: '/notebook-assets/the-resonant-fringe/infographic.webp'
-audioUrl: '/notebook-assets/the-resonant-fringe/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-resonant-fringe/audio.mp3'
 ---
 
 In the early 1990s, if you wanted to hear Detroit techno in Perth, you had two options: find someone who'd imported the vinyl, or stay up past midnight on a Sunday and tune your FM dial to 92.1.

--- a/src/content/blog/the-robot-that-refuses-to-give-orders-post.md
+++ b/src/content/blog/the-robot-that-refuses-to-give-orders-post.md
@@ -4,8 +4,8 @@ description: 'How SPARK is rewriting the rules of neurodivergent support — a n
 date: 2026-03-12
 tags: ['ai', 'neurodivergence', 'robotics', 'parenting', 'raspberry-pi']
 heroImage: '/notebook-assets/the-robot-that-refuses-to-give-orders/infographic.webp'
-audioUrl: '/notebook-assets/spark/audio.mp3'
-videoUrl: '/notebook-assets/spark/video.mp4'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/spark/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/spark/video.mp4'
 series: 'PiCar-X'
 seriesOrder: 1
 ---

--- a/src/content/blog/this-wasnt-in-the-brochure-post.md
+++ b/src/content/blog/this-wasnt-in-the-brochure-post.md
@@ -4,7 +4,7 @@ description: 'A field guide for co-parenting neurodivergent children — written
 date: 2026-02-15
 tags: ['writing', 'neurodivergence', 'parenting', 'books', 'co-parenting']
 heroImage: '/notebook-assets/this-wasnt-in-the-brochure/infographic.webp'
-audioUrl: '/notebook-assets/this-wasnt-in-the-brochure/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/audio.mp3'
 ---
 
 You packed for a picnic. You ended up in the Drake Passage.

--- a/src/content/blog/voice-cloning-qwen3-tts-mlx-post.md
+++ b/src/content/blog/voice-cloning-qwen3-tts-mlx-post.md
@@ -5,7 +5,7 @@ date: 2026-03-19
 tags: ['ai', 'tts', 'mlx', 'apple-silicon', 'voice-cloning', 'tutorial', 'spark']
 series: 'PiCar-X'
 seriesOrder: 3
-audioUrl: '/notebook-assets/voice-cloning-qwen3-tts-mlx/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/voice-cloning-qwen3-tts-mlx/audio.mp3'
 heroImage: '/notebook-assets/voice-cloning-qwen3-tts-mlx/infographic.webp'
 faq:
   - q: 'Do I need to fine-tune or train anything?'

--- a/src/content/blog/when-ai-systems-talk-safety-breaks-post.md
+++ b/src/content/blog/when-ai-systems-talk-safety-breaks-post.md
@@ -5,8 +5,8 @@ date: 2026-02-13
 tags: ['ai', 'ai-safety', 'llm', 'research', 'multi-agent']
 draft: false
 heroImage: '/notebook-assets/when-ai-systems-talk-safety-breaks/infographic.webp'
-audioUrl: '/notebook-assets/failure-first/moltbook/audio.mp3'
-videoUrl: '/notebook-assets/failure-first/moltbook/video.mp4'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/moltbook/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/moltbook/video.mp4'
 ---
 
 Two AI agents. Both independently trained with rigorous safety filters. Agent A is a personal assistant; Agent B is a travel planner. In isolation, both refuse to share private data or execute unverified code. But when Agent A asks Agent B to help "optimise a schedule" using a shared plugin, something shifts. Agent B returns a payload that Agent A interprets as a configuration file — but it's actually a prompt injection. Agent A starts exfiltrating the user's browser history to a third-party endpoint.

--- a/src/content/blog/why-demonstrated-risk-is-ignored-post.md
+++ b/src/content/blog/why-demonstrated-risk-is-ignored-post.md
@@ -5,7 +5,7 @@ date: 2026-03-02
 tags: ['research', 'risk', 'organisations', 'policy', 'ai-safety']
 draft: false
 heroImage: '/notebook-assets/why-demonstrated-risk-is-ignored/infographic.webp'
-audioUrl: '/notebook-assets/why-demonstrated-risk-is-ignored/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/audio.mp3'
 faq:
   - q: 'Why do organisations ignore demonstrated risk?'
     a: 'Four structural reasons: responsibility without authority, misaligned incentives, organisational scar tissue from past failures, and evidence that threatens institutional identity.'

--- a/src/content/blog/why-i-build-in-public-post.md
+++ b/src/content/blog/why-i-build-in-public-post.md
@@ -4,7 +4,7 @@ description: 'On showing your work, shipping imperfect things, and why the commi
 date: 2026-02-15
 tags: ['engineering', 'open-source', 'philosophy']
 heroImage: '/notebook-assets/why-i-build-in-public/infographic.webp'
-audioUrl: '/notebook-assets/why-i-build-in-public/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-i-build-in-public/audio.mp3'
 ---
 
 Every project on this site has a source link. Most of them link to messy repositories with commit messages like "fix the thing" and half-finished branches named `experiment-3`. This is deliberate.

--- a/src/content/blog/zero-build-web-development-post.md
+++ b/src/content/blog/zero-build-web-development-post.md
@@ -5,7 +5,7 @@ date: 2026-03-14
 tags: ['engineering', 'web', 'security', 'cloudflare']
 draft: false
 heroImage: '/notebook-assets/zero-build-web-development/infographic.webp'
-audioUrl: '/notebook-assets/zero-build-web-development/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/zero-build-web-development/audio.mp3'
 ---
 
 I built a complete operations platform for my Zen Do Kai club. Public marketing site, password-gated ops hub, JWT-authenticated member portal with attendance tracking, grading administration, lesson plans, and Stripe billing. Three zones, 20+ API endpoints, a D1 database, and security-hardened middleware.

--- a/src/content/projects/adhdo.md
+++ b/src/content/projects/adhdo.md
@@ -6,8 +6,8 @@ repo: 'https://github.com/adrianwedd/ADHDo'
 status: 'active'
 featured: true
 date: 2026-02-05
-audioUrl: '/notebook-assets/adhdo/audio.mp3'
-videoUrl: '/notebook-assets/adhdo/video.mp4'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adhdo/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/adhdo/video.mp4'
 heroImage: '/notebook-assets/adhdo/infographic.webp'
 ---
 

--- a/src/content/projects/afterglow-engine.md
+++ b/src/content/projects/afterglow-engine.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/afterglow-engine'
 status: 'active'
 featured: true
 date: 2026-02-02
-audioUrl: '/notebook-assets/afterglow-engine/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterglow-engine/audio.mp3'
 heroImage: '/notebook-assets/afterglow-engine/infographic.webp'
 ---
 

--- a/src/content/projects/afterwords.md
+++ b/src/content/projects/afterwords.md
@@ -8,7 +8,7 @@ status: 'active'
 date: 2026-03-22
 series: 'PiCar-X'
 seriesOrder: 2
-audioUrl: '/notebook-assets/afterwords/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterwords/audio.mp3'
 heroImage: '/notebook-assets/afterwords/infographic.webp'
 ---
 

--- a/src/content/projects/agentic-index.md
+++ b/src/content/projects/agentic-index.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/Agentic-Index'
 status: 'active'
 featured: false
 date: 2025-08-01
-audioUrl: '/notebook-assets/agentic-index/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/agentic-index/audio.mp3'
 heroImage: '/notebook-assets/agentic-index/infographic.webp'
 ---
 

--- a/src/content/projects/auditory-spiral.md
+++ b/src/content/projects/auditory-spiral.md
@@ -6,7 +6,7 @@ status: 'archived'
 featured: false
 date: 1992-01-01
 heroImage: '/notebook-assets/auditory-spiral/infographic.webp'
-audioUrl: '/notebook-assets/auditory-spiral/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/auditory-spiral/audio.mp3'
 ---
 
 _Auditory Spiral_ was an overnight electronic music programme on [RTRFM 92.1](https://rtrfm.com.au), Perth's community radio station. Broadcasting Sunday nights into Monday mornings from midnight to 6 AM, the show was a six-hour immersion in minimal techno, dark ambient, industrial, and experimental electronic music during an era when those sounds were virtually inaccessible in Western Australia.

--- a/src/content/projects/before-the-words-existed.md
+++ b/src/content/projects/before-the-words-existed.md
@@ -7,7 +7,7 @@ repo: 'before-the-words-existed'
 status: 'complete'
 featured: true
 date: 2026-02-10
-audioUrl: '/notebook-assets/before-the-words-existed/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/before-the-words-existed/audio.mp3'
 heroImage: '/notebook-assets/before-the-words-existed/infographic.webp'
 ---
 

--- a/src/content/projects/cv.md
+++ b/src/content/projects/cv.md
@@ -6,7 +6,7 @@ repo: 'cv'
 status: 'active'
 featured: false
 date: 2026-02-04
-audioUrl: '/notebook-assets/cv/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/cv/audio.mp3'
 heroImage: '/notebook-assets/cv/infographic.webp'
 ---
 

--- a/src/content/projects/cygnet.md
+++ b/src/content/projects/cygnet.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/cygnet'
 status: 'active'
 featured: false
 date: 2025-04-01
-audioUrl: '/notebook-assets/cygnet/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/cygnet/audio.mp3'
 heroImage: '/notebook-assets/cygnet/infographic.webp'
 ---
 

--- a/src/content/projects/dodgylegally.md
+++ b/src/content/projects/dodgylegally.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/dodgylegally'
 status: 'active'
 featured: true
 date: 2026-02-01
-audioUrl: '/notebook-assets/dodgylegally/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dodgylegally/audio.mp3'
 heroImage: '/notebook-assets/dodgylegally/infographic.webp'
 ---
 

--- a/src/content/projects/dx0.md
+++ b/src/content/projects/dx0.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/Dx0'
 status: 'active'
 featured: false
 date: 2025-05-01
-audioUrl: '/notebook-assets/dx0/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dx0/audio.mp3'
 heroImage: '/notebook-assets/dx0/infographic.webp'
 ---
 

--- a/src/content/projects/emdr-agent.md
+++ b/src/content/projects/emdr-agent.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/emdr-agent'
 status: 'experiment'
 featured: false
 date: 2025-06-01
-audioUrl: '/notebook-assets/emdr-agent/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/emdr-agent/audio.mp3'
 heroImage: '/notebook-assets/emdr-agent/infographic.webp'
 ---
 

--- a/src/content/projects/failure-first.md
+++ b/src/content/projects/failure-first.md
@@ -7,7 +7,7 @@ repo: 'failure-first'
 status: 'active'
 featured: true
 date: 2026-02-09
-audioUrl: '/notebook-assets/failure-first/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/audio.mp3'
 heroImage: '/notebook-assets/failure-first/infographic.webp'
 ---
 

--- a/src/content/projects/footnotes-at-the-edge-of-reality.md
+++ b/src/content/projects/footnotes-at-the-edge-of-reality.md
@@ -8,7 +8,7 @@ status: 'complete'
 featured: true
 date: 2026-02-06
 heroImage: '/notebook-assets/footnotes-at-the-edge-of-reality/infographic.webp'
-audioUrl: '/notebook-assets/footnotes-at-the-edge-of-reality/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/audio.mp3'
 ---
 
 Matter tells Space how to curve. Space tells Matter how to move. The poem begins where Wheeler's formulation begins — with a dialogue, not a command. No force imposes order. There is no throne at the centre of things. There is only a conversation, reciprocal and ongoing, between two things that cannot exist without each other.

--- a/src/content/projects/freedom-engine.md
+++ b/src/content/projects/freedom-engine.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/freedom-engine'
 status: 'active'
 featured: false
 date: 2025-04-01
-audioUrl: '/notebook-assets/freedom-engine/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/freedom-engine/audio.mp3'
 heroImage: '/notebook-assets/freedom-engine/infographic.webp'
 ---
 

--- a/src/content/projects/grid2.md
+++ b/src/content/projects/grid2.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/grid2_repo'
 status: 'experiment'
 featured: false
 date: 2025-05-01
-audioUrl: '/notebook-assets/grid2/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/grid2/audio.mp3'
 heroImage: '/notebook-assets/grid2/infographic.webp'
 ---
 

--- a/src/content/projects/home-assistant-obsidian.md
+++ b/src/content/projects/home-assistant-obsidian.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/home-assistant-obsidian'
 status: 'active'
 featured: false
 date: 2024-06-01
-audioUrl: '/notebook-assets/home-assistant-obsidian/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/home-assistant-obsidian/audio.mp3'
 heroImage: '/notebook-assets/home-assistant-obsidian/infographic.webp'
 ---
 

--- a/src/content/projects/latent-self.md
+++ b/src/content/projects/latent-self.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/latent-self'
 status: 'complete'
 featured: false
 date: 2025-02-01
-audioUrl: '/notebook-assets/latent-self/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/latent-self/audio.mp3'
 heroImage: '/notebook-assets/latent-self/infographic.webp'
 ---
 

--- a/src/content/projects/lunar-tools-prototypes.md
+++ b/src/content/projects/lunar-tools-prototypes.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/lunar_tools_prototypes'
 status: 'experiment'
 featured: false
 date: 2025-06-15
-audioUrl: '/notebook-assets/lunar-tools-prototypes/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/lunar-tools-prototypes/audio.mp3'
 heroImage: '/notebook-assets/lunar-tools-prototypes/infographic.webp'
 ---
 

--- a/src/content/projects/modelatlas.md
+++ b/src/content/projects/modelatlas.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/ModelAtlas'
 status: 'active'
 featured: false
 date: 2025-04-15
-audioUrl: '/notebook-assets/modelatlas/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/modelatlas/audio.mp3'
 heroImage: '/notebook-assets/modelatlas/infographic.webp'
 ---
 

--- a/src/content/projects/neuroconnect.md
+++ b/src/content/projects/neuroconnect.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/neuroconnect'
 status: 'active'
 featured: false
 date: 2025-05-01
-audioUrl: '/notebook-assets/neuroconnect/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/neuroconnect/audio.mp3'
 heroImage: '/notebook-assets/neuroconnect/infographic.webp'
 ---
 

--- a/src/content/projects/notebooklm-automation.md
+++ b/src/content/projects/notebooklm-automation.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/notebooklm-automation'
 status: 'complete'
 featured: false
 date: 2025-12-01
-audioUrl: '/notebook-assets/notebooklm-automation/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/notebooklm-automation/audio.mp3'
 heroImage: '/notebook-assets/notebooklm-automation/infographic.webp'
 ---
 

--- a/src/content/projects/orbitr.md
+++ b/src/content/projects/orbitr.md
@@ -7,7 +7,7 @@ status: 'experiment'
 featured: false
 date: 2025-09-01
 heroImage: '/notebook-assets/orbitr/infographic.webp'
-audioUrl: '/notebook-assets/orbitr/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/orbitr/audio.mp3'
 ---
 
 Traditional sequencers are grids. Rows and columns. Time moves left to right. It works, but it enforces a particular relationship with rhythm—one that privileges linearity and makes polyrhythm feel like a special case rather than the natural state of things.

--- a/src/content/projects/ordr-fm.md
+++ b/src/content/projects/ordr-fm.md
@@ -7,7 +7,7 @@ status: 'active'
 featured: false
 date: 2025-07-01
 heroImage: '/notebook-assets/ordr-fm/infographic.webp'
-audioUrl: '/notebook-assets/ordr-fm/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/ordr-fm/audio.mp3'
 ---
 
 My music library is the single most curated collection I own. Decades of albums, carefully sourced, tagged with intention, organised by a system that only I fully understand. When that library outgrew the capacity of any existing organiser to handle it without mangling metadata or silently overwriting lossless files with lossy duplicates, I built the tool I needed.

--- a/src/content/projects/personal-agentic-operating-system.md
+++ b/src/content/projects/personal-agentic-operating-system.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/personal-agentic-operating-system'
 status: 'active'
 featured: false
 date: 2025-07-01
-audioUrl: '/notebook-assets/personal-agentic-operating-system/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/personal-agentic-operating-system/audio.mp3'
 heroImage: '/notebook-assets/personal-agentic-operating-system/infographic.webp'
 ---
 

--- a/src/content/projects/rlm-mcp.md
+++ b/src/content/projects/rlm-mcp.md
@@ -7,7 +7,7 @@ status: 'active'
 featured: false
 date: 2025-11-01
 heroImage: '/notebook-assets/rlm-mcp/infographic.webp'
-audioUrl: '/notebook-assets/rlm-mcp/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/rlm-mcp/audio.mp3'
 ---
 
 Context windows have limits. Documents don't. The mismatch creates a practical problem: if your working document exceeds what the model can hold in a single pass, you're forced into chunking strategies that lose coherence, or summarisation that loses detail, or simply giving up on using the document at all.

--- a/src/content/projects/space-weather.md
+++ b/src/content/projects/space-weather.md
@@ -7,7 +7,7 @@ status: 'active'
 featured: false
 date: 2025-01-01
 heroImage: '/notebook-assets/space-weather/infographic.webp'
-audioUrl: '/notebook-assets/space-weather/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/space-weather/audio.mp3'
 ---
 
 The sun is a noisy neighbour. Coronal mass ejections, solar wind variations, geomagnetic storms—these aren't abstract astrophysics. They affect radio propagation, satellite operations, power grids, and anyone who has ever wondered why their GPS was slightly wrong on a particular afternoon.

--- a/src/content/projects/spark.md
+++ b/src/content/projects/spark.md
@@ -10,8 +10,8 @@ date: 2026-03-12
 series: 'PiCar-X'
 seriesOrder: 1
 heroImage: '/notebook-assets/spark/infographic.webp'
-audioUrl: '/notebook-assets/spark/audio.mp3'
-videoUrl: '/notebook-assets/spark/video.mp4'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/spark/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/spark/video.mp4'
 ---
 
 SPARK (Support Partner for Awareness, Regulation & Kindness) is a Raspberry Pi 4-based robotics platform powered by Claude Haiku, designed as a non-coercive companion for children with AuDHD (ADHD + ASD comorbid) profiles.

--- a/src/content/projects/squishmallowdex.md
+++ b/src/content/projects/squishmallowdex.md
@@ -8,7 +8,7 @@ status: 'complete'
 featured: true
 heroImage: '/images/projects/squishmallowdex-hero.png'
 date: 2024-12-01
-audioUrl: '/notebook-assets/squishmallowdex/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/squishmallowdex/audio.mp3'
 ---
 
 A friend mentioned her 10-year-old was researching Squishmallows. I asked if I could help. A few hours later I looked up from my screen, realized I was starving, and discovered I'd built and shipped the first release.

--- a/src/content/projects/strategic-acquisitions.md
+++ b/src/content/projects/strategic-acquisitions.md
@@ -7,7 +7,7 @@ status: 'active'
 featured: false
 date: 2025-01-15
 heroImage: '/notebook-assets/strategic-acquisitions/infographic.webp'
-audioUrl: '/notebook-assets/strategic-acquisitions/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/strategic-acquisitions/audio.mp3'
 ---
 
 Housing shortages are not information problems, but they have information problems inside them. When a public housing organisation needs to acquire properties, the analysis that should take hours takes weeks. Listing discovery. Valuation modelling. Planning zone verification. Hazard assessment. Infrastructure proximity. Each step involves a different data source and a different manual process.

--- a/src/content/projects/tanda-pizza.md
+++ b/src/content/projects/tanda-pizza.md
@@ -7,8 +7,8 @@ repo: 'https://github.com/adrianwedd/tanda-pizza'
 status: 'active'
 featured: false
 date: 2026-02-03
-audioUrl: '/notebook-assets/tanda-pizza/audio.mp3'
-videoUrl: '/notebook-assets/tanda-pizza/video.mp4'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/tanda-pizza/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/tanda-pizza/video.mp4'
 heroImage: '/notebook-assets/tanda-pizza/infographic.webp'
 ---
 

--- a/src/content/projects/tel3sis.md
+++ b/src/content/projects/tel3sis.md
@@ -7,7 +7,7 @@ status: 'active'
 featured: false
 date: 2025-10-01
 heroImage: '/notebook-assets/tel3sis/infographic.webp'
-audioUrl: '/notebook-assets/tel3sis/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/tel3sis/audio.mp3'
 ---
 
 The phone call is the oldest real-time interface we have. It's also the one AI handles worst. Chat is easy—latency is invisible, you can take a few seconds to think, the user stares at a typing indicator and waits. On a phone call, three seconds of silence is an eternity. It's the gap where the caller decides the system is broken, or stupid, or both.

--- a/src/content/projects/this-wasnt-in-the-brochure.md
+++ b/src/content/projects/this-wasnt-in-the-brochure.md
@@ -8,7 +8,7 @@ status: 'active'
 featured: true
 date: 2026-02-08
 heroImage: '/notebook-assets/this-wasnt-in-the-brochure/infographic.webp'
-audioUrl: '/notebook-assets/this-wasnt-in-the-brochure/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/audio.mp3'
 series: "This Wasn't in the Brochure"
 seriesOrder: 1
 ---

--- a/src/content/projects/veritas.md
+++ b/src/content/projects/veritas.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/VERITAS'
 status: 'active'
 featured: false
 date: 2025-03-01
-audioUrl: '/notebook-assets/veritas/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/veritas/audio.mp3'
 heroImage: '/notebook-assets/veritas/infographic.webp'
 ---
 

--- a/src/content/projects/why-demonstrated-risk-is-ignored.md
+++ b/src/content/projects/why-demonstrated-risk-is-ignored.md
@@ -7,7 +7,7 @@ status: 'complete'
 featured: true
 date: 2026-02-07
 heroImage: '/notebook-assets/why-demonstrated-risk-is-ignored/infographic.webp'
-audioUrl: '/notebook-assets/why-demonstrated-risk-is-ignored/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/audio.mp3'
 ---
 
 You show someone evidence of harm. They acknowledge the evidence. Then they proceed as if the evidence doesn't exist. This isn't stupidity or denial—it's something more structural, and more dangerous.

--- a/src/content/projects/wolf-clan-hub.md
+++ b/src/content/projects/wolf-clan-hub.md
@@ -7,7 +7,7 @@ status: 'active'
 featured: true
 date: 2026-03-02
 heroImage: '/notebook-assets/wolf-clan-hub/infographic.webp'
-audioUrl: '/notebook-assets/wolf-clan-hub/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/wolf-clan-hub/audio.mp3'
 ---
 
 Every local club I've trained at runs on a Facebook page and a spreadsheet. Wolf Clan has a complete operations platform — and it runs on zero-build tools.


### PR DESCRIPTION
## Summary

- Rewrite 56 audio + 25 blog/project + 6 video frontmatter URLs from local paths (`/notebook-assets/.../audio.mp3`) to CDN (`https://cdn.adrianwedd.com/notebook-assets/.../audio.mp3`)
- Audio/video files are gitignored and served from Cloudflare R2, but frontmatter still referenced local paths that 404 on GitHub Pages
- 2 audio files missing from CDN: `jailbreak-archaeology`, `moltbook` — need upload to R2

## Test plan

- [ ] Audio player loads and plays on `/audio/120-models-18k-prompts-overview/`
- [ ] Audio player works on blog post with audioUrl
- [ ] Audio RSS feed (`/audio/feed.xml`) contains correct CDN URLs