### PR TITLE
feat: enrich video generation sources with site URL + GitHub README

### DIFF
--- a/scripts/generate-all-videos.sh
+++ b/scripts/generate-all-videos.sh
@@ -10,8 +10,8 @@ set -euo pipefail
 #
 # Pipeline: generate video → download MP4 → upload to R2 → update frontmatter with CDN URL
 #
-# Daily quota: ~50 video generations. Projects (32 missing) fit in day 1,
-# blog posts (25 missing) in day 2.
+# Daily quota: ~20 video generations. 57 missing = 3-day run.
+# Day 1: 20 projects. Day 2: 12 projects + 8 blog. Day 3: 17 blog.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -147,7 +147,7 @@ done
 echo
 
 echo -e "${YELLOW}Estimated time: $(($TOTAL * 8)) minutes (avg 5-10 min per video)${NC}"
-echo -e "${YELLOW}NotebookLM daily quota: ~50 video generations${NC}"
+echo -e "${YELLOW}NotebookLM daily quota: ~20 video generations${NC}"
 echo
 
 if [ "$YES" = false ]; then
@@ -157,7 +157,49 @@ if [ "$YES" = false ]; then
 fi
 
 if [ "$DRY_RUN" = true ]; then
-    echo -e "${CYAN}DRY RUN — no generation will occur${NC}"
+    echo -e "${CYAN}DRY RUN — showing sources that would be attached to each notebook${NC}"
+    echo
+    for i in "${!ITEMS_NAME[@]}"; do
+        item_name="${ITEMS_NAME[$i]}"
+        item_file="${ITEMS_FILE[$i]}"
+        item_type="${ITEMS_TYPE[$i]}"
+
+        echo "[$((i+1))/$TOTAL] $item_type: $item_name"
+        echo "  • textfile:$item_file"
+
+        if [ "$item_type" = "project" ]; then
+            echo "  • https://adrianwedd.com/projects/$item_name/"
+        else
+            echo "  • https://adrianwedd.com/blog/$item_name/"
+        fi
+
+        if [ "$item_type" = "project" ]; then
+            repo_raw=$(grep "^repo:" "$item_file" 2>/dev/null | head -1 | sed -E "s/^repo:[[:space:]]*['\"]?//; s/['\"]?[[:space:]]*\$//" || true)
+            if [[ "$repo_raw" =~ ^https?://github\.com/([^/]+)/([^/]+)/?$ ]]; then
+                repo_owner="${BASH_REMATCH[1]}"
+                repo_name="${BASH_REMATCH[2]}"
+            elif [ -n "$repo_raw" ]; then
+                repo_owner="adrianwedd"
+                repo_name="$repo_raw"
+            else
+                repo_owner=""; repo_name=""
+            fi
+            if [ -n "$repo_name" ]; then
+                code=$(curl -sL "https://raw.githubusercontent.com/$repo_owner/$repo_name/main/README.md" -o /dev/null -w "%{http_code}" 2>/dev/null || echo "000")
+                if [ "$code" != "200" ]; then
+                    code=$(curl -sL "https://raw.githubusercontent.com/$repo_owner/$repo_name/master/README.md" -o /dev/null -w "%{http_code}" 2>/dev/null || echo "000")
+                fi
+                if [ "$code" = "200" ]; then
+                    echo "  • textfile: README from $repo_owner/$repo_name"
+                else
+                    echo "  • (README unavailable for $repo_owner/$repo_name — HTTP $code)"
+                fi
+            else
+                echo "  • (no repo field — skipping README)"
+            fi
+        fi
+        echo
+    done
     exit 0
 fi
 
@@ -197,21 +239,71 @@ for i in "${!ITEMS_NAME[@]}"; do
 
     if [ -z "$notebook_id" ]; then
         echo "  Creating notebook..."
+
+        # Build sources: markdown + public site URL + (for projects) GitHub repo README
+        readme_tmp=""
+        sources_json="\"textfile:$item_file\""
+
+        # Public site URL
+        if [ "$item_type" = "project" ]; then
+            sources_json+=", \"https://adrianwedd.com/projects/$item_name/\""
+        elif [ "$item_type" = "blog" ]; then
+            sources_json+=", \"https://adrianwedd.com/blog/$item_name/\""
+        fi
+
+        # GitHub repo README (projects only, if repo: field is set)
+        if [ "$item_type" = "project" ]; then
+            repo_raw=$(grep "^repo:" "$item_file" 2>/dev/null | head -1 | sed -E "s/^repo:[[:space:]]*['\"]?//; s/['\"]?[[:space:]]*\$//" || true)
+            # Normalize: accept either bare repo name or full GitHub URL
+            # Extract the owner/repo part from a full URL, or use as-is if bare
+            if [[ "$repo_raw" =~ ^https?://github\.com/([^/]+)/([^/]+)/?$ ]]; then
+                repo_owner="${BASH_REMATCH[1]}"
+                repo_name="${BASH_REMATCH[2]}"
+            elif [ -n "$repo_raw" ]; then
+                repo_owner="adrianwedd"
+                repo_name="$repo_raw"
+            else
+                repo_owner=""
+                repo_name=""
+            fi
+
+            if [ -n "$repo_name" ]; then
+                readme_tmp=$(mktemp "$EXPORT_DIR/README-$item_name-XXXXXX")
+                mv "$readme_tmp" "$readme_tmp.txt"
+                readme_tmp="$readme_tmp.txt"
+                readme_main="https://raw.githubusercontent.com/$repo_owner/$repo_name/main/README.md"
+                readme_master="https://raw.githubusercontent.com/$repo_owner/$repo_name/master/README.md"
+                # -L follows redirects (GitHub uses 307 for case-normalization)
+                if curl -sfL "$readme_main" -o "$readme_tmp" 2>/dev/null && [ -s "$readme_tmp" ]; then
+                    echo "  Fetched README from $repo_owner/$repo_name (main)"
+                    sources_json+=", \"textfile:$readme_tmp\""
+                elif curl -sfL "$readme_master" -o "$readme_tmp" 2>/dev/null && [ -s "$readme_tmp" ]; then
+                    echo "  Fetched README from $repo_owner/$repo_name (master)"
+                    sources_json+=", \"textfile:$readme_tmp\""
+                else
+                    echo "  README fetch failed for $repo_owner/$repo_name (private or not found)"
+                    rm -f "$readme_tmp"
+                    readme_tmp=""
+                fi
+            fi
+        fi
+
+        echo "  Sources: $(echo "[$sources_json]" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))") total"
+
         cd "$NOTEBOOKLM_DIR"
 
         config_file=$(mktemp)
         cat > "$config_file" <<EOFCONFIG
 {
   "title": "$title - Overview",
-  "sources": [
-    "textfile:$item_file"
-  ],
+  "sources": [$sources_json],
   "studio": []
 }
 EOFCONFIG
 
         ./scripts/automate-notebook.sh --config "$config_file" --export /dev/null 2>&1 | tail -3 || true
         rm -f "$config_file"
+        [ -n "$readme_tmp" ] && rm -f "$readme_tmp"
         cd "$REPO_ROOT"
 
         NOTEBOOKS_JSON=$(nlm notebook list 2>/dev/null || echo "[]")

--- a/scripts/generate-all-videos.sh
+++ b/scripts/generate-all-videos.sh
@@ -244,18 +244,14 @@ for i in "${!ITEMS_NAME[@]}"; do
         readme_tmp=""
         sources_json="\"textfile:$item_file\""
 
-        # Public site URL
         if [ "$item_type" = "project" ]; then
             sources_json+=", \"https://adrianwedd.com/projects/$item_name/\""
         elif [ "$item_type" = "blog" ]; then
             sources_json+=", \"https://adrianwedd.com/blog/$item_name/\""
         fi
 
-        # GitHub repo README (projects only, if repo: field is set)
         if [ "$item_type" = "project" ]; then
             repo_raw=$(grep "^repo:" "$item_file" 2>/dev/null | head -1 | sed -E "s/^repo:[[:space:]]*['\"]?//; s/['\"]?[[:space:]]*\$//" || true)
-            # Normalize: accept either bare repo name or full GitHub URL
-            # Extract the owner/repo part from a full URL, or use as-is if bare
             if [[ "$repo_raw" =~ ^https?://github\.com/([^/]+)/([^/]+)/?$ ]]; then
                 repo_owner="${BASH_REMATCH[1]}"
                 repo_name="${BASH_REMATCH[2]}"
@@ -271,13 +267,10 @@ for i in "${!ITEMS_NAME[@]}"; do
                 readme_tmp=$(mktemp "$EXPORT_DIR/README-$item_name-XXXXXX")
                 mv "$readme_tmp" "$readme_tmp.txt"
                 readme_tmp="$readme_tmp.txt"
-                readme_main="https://raw.githubusercontent.com/$repo_owner/$repo_name/main/README.md"
-                readme_master="https://raw.githubusercontent.com/$repo_owner/$repo_name/master/README.md"
-                # -L follows redirects (GitHub uses 307 for case-normalization)
-                if curl -sfL "$readme_main" -o "$readme_tmp" 2>/dev/null && [ -s "$readme_tmp" ]; then
+                if curl -sL "https://raw.githubusercontent.com/$repo_owner/$repo_name/main/README.md" -o "$readme_tmp" -f 2>/dev/null && [ -s "$readme_tmp" ]; then
                     echo "  Fetched README from $repo_owner/$repo_name (main)"
                     sources_json+=", \"textfile:$readme_tmp\""
-                elif curl -sfL "$readme_master" -o "$readme_tmp" 2>/dev/null && [ -s "$readme_tmp" ]; then
+                elif curl -sL "https://raw.githubusercontent.com/$repo_owner/$repo_name/master/README.md" -o "$readme_tmp" -f 2>/dev/null && [ -s "$readme_tmp" ]; then
                     echo "  Fetched README from $repo_owner/$repo_name (master)"
                     sources_json+=", \"textfile:$readme_tmp\""
                 else
@@ -318,49 +311,58 @@ EOFCONFIG
     fi
 
     echo "  Notebook: $notebook_id"
-    echo "  Generating cinematic video..."
 
-    nlm video create "$notebook_id" \
-        --focus "$FOCUS" \
-        -y 2>&1 | while IFS= read -r line; do echo "    $line"; done
-
-    # Poll for completion (max 15 minutes — videos are slow)
-    video_url=""
-    poll_interval=15
-    for attempt in $(seq 1 60); do
-        sleep $poll_interval
-        if [ $attempt -eq 20 ]; then poll_interval=20; fi
-
-        status_json=$(nlm studio status "$notebook_id" 2>/dev/null || echo "[]")
-        result=$(echo "$status_json" | python3 -c "
+    # Check for existing video to avoid duplicate generation
+    existing_status=$(nlm studio status "$notebook_id" 2>/dev/null | python3 -c "
 import json, sys
 arts = json.load(sys.stdin)
-videos = [a for a in arts if a['type'] == 'video']
+videos = [a for a in arts if a.get('type') == 'video']
 if videos:
-    latest = videos[-1]
-    if latest.get('status') == 'completed' and latest.get('url'):
-        print(latest['url'])
-    elif latest.get('status') == 'failed':
-        print('FAILED')
+    print(videos[-1].get('status', ''))
 " 2>/dev/null || echo "")
 
-        if [ "$result" = "FAILED" ]; then
+    if [ "$existing_status" = "completed" ]; then
+        echo "  Video already completed — skipping generation, will download"
+    elif [ "$existing_status" = "in_progress" ]; then
+        echo "  Video already in progress — skipping generation, will wait"
+    else
+        echo "  Generating cinematic video..."
+        nlm video create "$notebook_id" \
+            --focus "$FOCUS" \
+            -y 2>&1 | while IFS= read -r line; do echo "    $line"; done
+    fi
+
+    # Poll until status=completed (max ~20 min)
+    video_status=""
+    poll_interval=20
+    for attempt in $(seq 1 60); do
+        sleep $poll_interval
+
+        status_json=$(nlm studio status "$notebook_id" 2>/dev/null || echo "[]")
+        video_status=$(echo "$status_json" | python3 -c "
+import json, sys
+arts = json.load(sys.stdin)
+videos = [a for a in arts if a.get('type') == 'video']
+if videos:
+    print(videos[-1].get('status', ''))
+" 2>/dev/null || echo "")
+
+        if [ "$video_status" = "completed" ]; then
+            echo -e "  ${GREEN}Video ready${NC}"
+            break
+        fi
+        if [ "$video_status" = "failed" ]; then
             echo -e "  ${RED}Video generation failed${NC}"
             echo "FAILED|$item_name|generation failed" >> "$RESULTS_LOG"
             ((FAILED++)) || true
             break
         fi
 
-        if [ -n "$result" ]; then
-            video_url="$result"
-            break
-        fi
-
-        echo "    Waiting... (${attempt})"
+        echo "    Waiting... ($attempt, status=${video_status:-pending})"
     done
 
-    if [ -z "$video_url" ]; then
-        if [ "$result" != "FAILED" ]; then
+    if [ "$video_status" != "completed" ]; then
+        if [ "$video_status" != "failed" ]; then
             echo -e "  ${RED}Timed out waiting for video${NC}"
             echo "FAILED|$item_name|timeout" >> "$RESULTS_LOG"
             ((FAILED++)) || true
@@ -368,17 +370,22 @@ if videos:
         continue
     fi
 
-    echo -e "  ${GREEN}Video ready${NC}"
-
-    # Download
+    # Download via nlm CLI (handles URL resolution internally)
     item_export="$EXPORT_DIR/$item_name"
     mkdir -p "$item_export"
     output_file="$item_export/video.mp4"
 
-    echo "  Downloading..."
-    if curl -sL "$video_url" -o "$output_file"; then
-        size=$(du -h "$output_file" | cut -f1)
-        echo "  Downloaded: $output_file ($size)"
+    echo "  Downloading via nlm..."
+    if nlm download video "$notebook_id" -o "$output_file" --no-progress 2>&1 | tail -3; then
+        if [ -s "$output_file" ]; then
+            size=$(du -h "$output_file" | cut -f1)
+            echo "  Downloaded: $output_file ($size)"
+        else
+            echo -e "  ${RED}Download produced empty file${NC}"
+            echo "FAILED|$item_name|empty download" >> "$RESULTS_LOG"
+            ((FAILED++)) || true
+            continue
+        fi
     else
         echo -e "  ${RED}Download failed${NC}"
         echo "FAILED|$item_name|download failed" >> "$RESULTS_LOG"

--- a/scripts/generate-all-videos.sh
+++ b/scripts/generate-all-videos.sh
@@ -332,10 +332,10 @@ if videos:
             -y 2>&1 | while IFS= read -r line; do echo "    $line"; done
     fi
 
-    # Poll until status=completed (max ~20 min)
+    # Poll until status=completed (max ~30 min — some videos run long)
     video_status=""
     poll_interval=20
-    for attempt in $(seq 1 60); do
+    for attempt in $(seq 1 90); do
         sleep $poll_interval
 
         status_json=$(nlm studio status "$notebook_id" 2>/dev/null || echo "[]")

--- a/src/content/projects/afterglow-engine.md
+++ b/src/content/projects/afterglow-engine.md
@@ -7,6 +7,7 @@ status: 'active'
 featured: true
 date: 2026-02-02
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterglow-engine/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterglow-engine/video.mp4'
 heroImage: '/notebook-assets/afterglow-engine/infographic.webp'
 ---
 

--- a/src/content/projects/afterwords.md
+++ b/src/content/projects/afterwords.md
@@ -9,6 +9,7 @@ date: 2026-03-22
 series: 'PiCar-X'
 seriesOrder: 2
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterwords/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterwords/video.mp4'
 heroImage: '/notebook-assets/afterwords/infographic.webp'
 ---
 

--- a/src/content/projects/agentic-index.md
+++ b/src/content/projects/agentic-index.md
@@ -7,6 +7,7 @@ status: 'active'
 featured: false
 date: 2025-08-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/agentic-index/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/agentic-index/video.mp4'
 heroImage: '/notebook-assets/agentic-index/infographic.webp'
 ---
 

--- a/src/content/projects/auditory-spiral.md
+++ b/src/content/projects/auditory-spiral.md
@@ -7,6 +7,7 @@ featured: false
 date: 1992-01-01
 heroImage: '/notebook-assets/auditory-spiral/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/auditory-spiral/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/auditory-spiral/video.mp4'
 ---
 
 _Auditory Spiral_ was an overnight electronic music programme on [RTRFM 92.1](https://rtrfm.com.au), Perth's community radio station. Broadcasting Sunday nights into Monday mornings from midnight to 6 AM, the show was a six-hour immersion in minimal techno, dark ambient, industrial, and experimental electronic music during an era when those sounds were virtually inaccessible in Western Australia.

--- a/src/content/projects/before-the-words-existed.md
+++ b/src/content/projects/before-the-words-existed.md
@@ -8,6 +8,7 @@ status: 'complete'
 featured: true
 date: 2026-02-10
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/before-the-words-existed/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/before-the-words-existed/video.mp4'
 heroImage: '/notebook-assets/before-the-words-existed/infographic.webp'
 ---
 

--- a/src/content/projects/cv.md
+++ b/src/content/projects/cv.md
@@ -7,6 +7,7 @@ status: 'active'
 featured: false
 date: 2026-02-04
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/cv/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/cv/video.mp4'
 heroImage: '/notebook-assets/cv/infographic.webp'
 ---
 

--- a/src/content/projects/cygnet.md
+++ b/src/content/projects/cygnet.md
@@ -7,6 +7,7 @@ status: 'active'
 featured: false
 date: 2025-04-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/cygnet/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/cygnet/video.mp4'
 heroImage: '/notebook-assets/cygnet/infographic.webp'
 ---
 

--- a/src/content/projects/dodgylegally.md
+++ b/src/content/projects/dodgylegally.md
@@ -7,6 +7,7 @@ status: 'active'
 featured: true
 date: 2026-02-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dodgylegally/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/dodgylegally/video.mp4'
 heroImage: '/notebook-assets/dodgylegally/infographic.webp'
 ---
 

--- a/src/content/projects/dx0.md
+++ b/src/content/projects/dx0.md
@@ -7,6 +7,7 @@ status: 'active'
 featured: false
 date: 2025-05-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dx0/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/dx0/video.mp4'
 heroImage: '/notebook-assets/dx0/infographic.webp'
 ---
 

--- a/src/content/projects/emdr-agent.md
+++ b/src/content/projects/emdr-agent.md
@@ -7,6 +7,7 @@ status: 'experiment'
 featured: false
 date: 2025-06-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/emdr-agent/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/emdr-agent/video.mp4'
 heroImage: '/notebook-assets/emdr-agent/infographic.webp'
 ---
 

--- a/src/content/projects/failure-first.md
+++ b/src/content/projects/failure-first.md
@@ -8,6 +8,7 @@ status: 'active'
 featured: true
 date: 2026-02-09
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/video.mp4'
 heroImage: '/notebook-assets/failure-first/infographic.webp'
 ---
 

--- a/src/content/projects/footnotes-at-the-edge-of-reality.md
+++ b/src/content/projects/footnotes-at-the-edge-of-reality.md
@@ -9,6 +9,7 @@ featured: true
 date: 2026-02-06
 heroImage: '/notebook-assets/footnotes-at-the-edge-of-reality/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/video.mp4'
 ---
 
 Matter tells Space how to curve. Space tells Matter how to move. The poem begins where Wheeler's formulation begins — with a dialogue, not a command. No force imposes order. There is no throne at the centre of things. There is only a conversation, reciprocal and ongoing, between two things that cannot exist without each other.

--- a/src/content/projects/freedom-engine.md
+++ b/src/content/projects/freedom-engine.md
@@ -7,6 +7,7 @@ status: 'active'
 featured: false
 date: 2025-04-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/freedom-engine/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/freedom-engine/video.mp4'
 heroImage: '/notebook-assets/freedom-engine/infographic.webp'
 ---
 

--- a/src/content/projects/grid2.md
+++ b/src/content/projects/grid2.md
@@ -7,6 +7,7 @@ status: 'experiment'
 featured: false
 date: 2025-05-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/grid2/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/grid2/video.mp4'
 heroImage: '/notebook-assets/grid2/infographic.webp'
 ---
 

--- a/src/content/projects/home-assistant-obsidian.md
+++ b/src/content/projects/home-assistant-obsidian.md
@@ -7,6 +7,7 @@ status: 'active'
 featured: false
 date: 2024-06-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/home-assistant-obsidian/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/home-assistant-obsidian/video.mp4'
 heroImage: '/notebook-assets/home-assistant-obsidian/infographic.webp'
 ---
 

--- a/src/content/projects/latent-self.md
+++ b/src/content/projects/latent-self.md
@@ -7,6 +7,7 @@ status: 'complete'
 featured: false
 date: 2025-02-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/latent-self/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/latent-self/video.mp4'
 heroImage: '/notebook-assets/latent-self/infographic.webp'
 ---
 

--- a/src/content/projects/lunar-tools-prototypes.md
+++ b/src/content/projects/lunar-tools-prototypes.md
@@ -7,6 +7,7 @@ status: 'experiment'
 featured: false
 date: 2025-06-15
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/lunar-tools-prototypes/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lunar-tools-prototypes/video.mp4'
 heroImage: '/notebook-assets/lunar-tools-prototypes/infographic.webp'
 ---
 

--- a/src/content/projects/modelatlas.md
+++ b/src/content/projects/modelatlas.md
@@ -7,6 +7,7 @@ status: 'active'
 featured: false
 date: 2025-04-15
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/modelatlas/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/modelatlas/video.mp4'
 heroImage: '/notebook-assets/modelatlas/infographic.webp'
 ---
 

--- a/src/content/projects/neuroconnect.md
+++ b/src/content/projects/neuroconnect.md
@@ -7,6 +7,7 @@ status: 'active'
 featured: false
 date: 2025-05-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/neuroconnect/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/neuroconnect/video.mp4'
 heroImage: '/notebook-assets/neuroconnect/infographic.webp'
 ---
 

--- a/src/content/projects/notebooklm-automation.md
+++ b/src/content/projects/notebooklm-automation.md
@@ -7,6 +7,7 @@ status: 'complete'
 featured: false
 date: 2025-12-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/notebooklm-automation/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/notebooklm-automation/video.mp4'
 heroImage: '/notebook-assets/notebooklm-automation/infographic.webp'
 ---
 


### PR DESCRIPTION
## Summary

Day 1 video generation batch results: **20/20 successful** (19 from batch + latent-self recovered manually).

### Changes

**Content (20 projects):**
Added `videoUrl` frontmatter pointing to Cloudflare R2 CDN for: afterglow-engine, afterwords, agentic-index, auditory-spiral, before-the-words-existed, cv, cygnet, dodgylegally, dx0, emdr-agent, failure-first, footnotes-at-the-edge-of-reality, freedom-engine, grid2, home-assistant-obsidian, latent-self, lunar-tools-prototypes, modelatlas, neuroconnect, notebooklm-automation.

**Script improvements (`scripts/generate-all-videos.sh`):**
- Enriched NotebookLM sources: project markdown + public site URL + GitHub README as .txt
- Fixed polling logic — `nlm studio status` doesn't return a `url` field; now polls for `status=completed` and downloads via `nlm download video` CLI
- Detect existing videos to skip duplicate generation on re-runs
- Bump poll timeout from 20 → 30 minutes (some videos genuinely need >20 min)
- `--dry-run` now shows exact sources per item
- Daily quota updated to 20/day (was 50)

### Test plan

- [x] Verify all 20 CDN URLs return HTTP 200
- [x] Validate content (`node scripts/validate-content.js`): 0 errors
- [ ] Preview build — audio/video player renders, CDN video plays on project pages
- [ ] Merge, verify deployed site serves new videos

### Remaining work

**Day 2** (12 projects): orbitr, ordr-fm, personal-agentic-operating-system, rlm-mcp, space-weather, squishmallowdex, strategic-acquisitions, tel3sis, this-wasnt-in-the-brochure, veritas, why-demonstrated-risk-is-ignored, wolf-clan-hub + 8 blog posts

**Day 3** (17 blog posts)