### PR TITLE
fix: bump protobufjs to 7.5.5 to unblock deploys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8467,9 +8467,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## Summary

protobufjs 7.5.4 has a critical advisory (GHSA-xq3m-2v4x-88gg — arbitrary code execution) which is tripping the CI audit gate (\`npm audit --audit-level=high\`). Last 3 deploys have failed:

- CSP hash migration (#234)
- Audio CDN URL fix (#236)
- Day 1 videos (#237)

**None of those changes are actually live on adrianwedd.com** — the last successful deploy was 2026-04-15.

## Fix

\`npm audit fix\` auto-resolves protobufjs to 7.5.5. It's a transitive dep via \`@google-analytics/data → google-gax\`. No code changes required.

## Verification

- \`npm audit --audit-level=high --omit=dev\` exits 0 locally
- Remaining yaml moderate advisories are dev-only, below the high threshold

## Impact

Once merged, the deploy workflow will finally roll out all three backed-up PRs — the blog/project pages will correctly load audio from CDN, CSP hashes will go live, and Day 1 video URLs will render on project pages.