### PR TITLE
feat(blog): cross-link to matching project for url/repo

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -47,11 +47,18 @@ const seriesPosts = post.data.series
   : [];
 
 // Projects in the same series
+const allProjects = await getCollection('projects');
 const seriesProjectsList = post.data.series
-  ? (await getCollection('projects'))
+  ? allProjects
       .filter((p) => !p.data.draft && p.data.series === post.data.series)
       .sort((a, b) => (a.data.seriesOrder ?? 0) - (b.data.seriesOrder ?? 0))
   : [];
+
+// Match to a project by slug (blog slug minus trailing "-post")
+const candidateProjectSlug = postSlug.replace(/-post$/, '');
+const matchedProject = allProjects.find(
+  (p) => !p.data.draft && slug(p.id) === candidateProjectSlug,
+);
 ---
 
 <BaseLayout
@@ -174,6 +181,40 @@ const seriesProjectsList = post.data.series
         }
         <span aria-hidden="true">&middot;</span>
         <span>{readingTime} min read</span>
+        {
+          matchedProject?.data.url && (
+            <>
+              <span aria-hidden="true">&middot;</span>
+              <a
+                href={matchedProject.data.url}
+                class="text-xs text-text-muted transition-colors hover:text-accent"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Visit site &nearr;
+              </a>
+            </>
+          )
+        }
+        {
+          matchedProject?.data.repo && (
+            <>
+              <span aria-hidden="true">&middot;</span>
+              <a
+                href={
+                  matchedProject.data.repo.startsWith('http')
+                    ? matchedProject.data.repo
+                    : `https://github.com/adrianwedd/${matchedProject.data.repo}`
+                }
+                class="text-xs text-text-muted transition-colors hover:text-accent"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Source &nearr;
+              </a>
+            </>
+          )
+        }
       </div>
       <h1 class="text-text">{post.data.title}</h1>
       <p class="mt-4 text-lg leading-relaxed text-text-muted">{post.data.description}</p>


### PR DESCRIPTION
## Summary

When a blog post's slug (minus trailing \`-post\`) matches a project slug, render the project's \`url\` and \`repo\` links in the blog post header.

## Motivation

\`/blog/footnotes-at-the-edge-of-reality/\` was missing the \"Visit site\" and \"Source\" links that \`/projects/footnotes-at-the-edge-of-reality/\` has. The blog schema doesn't (and shouldn't) duplicate project fields — instead the blog page now does a slug lookup into the projects collection and renders those links when found.

## Test plan

- [x] Build succeeds, footnotes blog post HTML contains both links
- [ ] Once deployed, verify the links appear in the metadata row at top of \`/blog/footnotes-at-the-edge-of-reality/\`
- [ ] Blog posts without a matching project render unchanged