### PR TITLE
fix: disable experimental.csp — it broke the live site

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -77,40 +77,10 @@ export default defineConfig({
     prefetchAll: false,
     defaultStrategy: 'hover',
   },
-  experimental: {
-    csp: {
-      algorithm: 'SHA-256',
-      scriptDirective: {
-        strictDynamic: true,
-        resources: [
-          "'self'",
-          "'wasm-unsafe-eval'",
-          'https://www.googletagmanager.com',
-          'https://www.google-analytics.com',
-          'https://snap.licdn.com',
-          'https://px.ads.linkedin.com',
-          'https://pagead2.googlesyndication.com',
-          'https://tpc.googlesyndication.com',
-          'https://googleads.g.doubleclick.net',
-          'https://adservice.google.com',
-          'https://challenges.cloudflare.com',
-        ],
-      },
-      styleDirective: {
-        resources: ["'self'", "'unsafe-inline'"],
-      },
-      directives: [
-        "default-src 'self'",
-        "img-src 'self' data: https://www.google-analytics.com https://px.ads.linkedin.com https://www.googletagmanager.com https://*.tile.openstreetmap.org https://tpc.googlesyndication.com https://googleads.g.doubleclick.net https://www.linkedin.com",
-        "connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://stats.g.doubleclick.net https://ep1.adtrafficquality.google https://snap.licdn.com https://px.ads.linkedin.com https://pagead2.googlesyndication.com https://api.book.adrianwedd.com https://api.github.com https://cdn.adrianwedd.com https://ops.adrianwedd.com https://challenges.cloudflare.com",
-        "media-src 'self' https://cdn.adrianwedd.com",
-        "frame-src https://www.openstreetmap.org https://challenges.cloudflare.com https://tpc.googlesyndication.com https://googleads.g.doubleclick.net",
-        "font-src 'self'",
-        "object-src 'none'",
-        "base-uri 'self'",
-        "form-action 'self'",
-        "frame-ancestors 'none'",
-      ],
-    },
-  },
+  // experimental.csp disabled — caused widespread breakage on static build:
+  // - strict-dynamic disabled host-based 'self' allowlist, blocking all
+  //   /_astro/*.js module scripts (Preact hydration, client router, analytics)
+  // - Some is:inline scripts weren't hashed correctly, triggering violations
+  // Reverted to hand-rolled meta CSP in SEOHead.astro until a safer
+  // implementation lands. See #222.
 });

--- a/src/components/SEOHead.astro
+++ b/src/components/SEOHead.astro
@@ -33,6 +33,10 @@ const fullTitle = title === 'Adrian Wedd' ? title : `${title} — Adrian Wedd`;
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="generator" content="Astro + curiosity" />
 <meta name="color-scheme" content="dark light" />
+<meta
+  http-equiv="Content-Security-Policy"
+  content="default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://snap.licdn.com https://px.ads.linkedin.com https://pagead2.googlesyndication.com https://tpc.googlesyndication.com https://googleads.g.doubleclick.net https://adservice.google.com https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://www.google-analytics.com https://px.ads.linkedin.com https://www.googletagmanager.com https://*.tile.openstreetmap.org https://tpc.googlesyndication.com https://googleads.g.doubleclick.net https://www.linkedin.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://stats.g.doubleclick.net https://ep1.adtrafficquality.google https://snap.licdn.com https://px.ads.linkedin.com https://pagead2.googlesyndication.com https://api.book.adrianwedd.com https://api.github.com https://cdn.adrianwedd.com https://ops.adrianwedd.com https://challenges.cloudflare.com; media-src 'self' https://cdn.adrianwedd.com; frame-src https://www.openstreetmap.org https://challenges.cloudflare.com https://tpc.googlesyndication.com https://googleads.g.doubleclick.net; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';"
+/>
 <meta name="author" content="Adrian Wedd" />
 <meta name="theme-color" content="#c48b6e" />
 {tags && <meta name="keywords" content={tags.join(', ')} />}


### PR DESCRIPTION
## Summary

PR #234 (experimental.csp migration) broke the live site. Reverting.

## What broke

1. **All \`/_astro/*.js\` module scripts blocked** — \`strict-dynamic\` disables host-based allowlisting including \`'self'\`, so every bundled Astro script (Preact hydration, client router, analytics, all 13 interactive islands) failed to load with CSP violations.
2. **Inline script hash mismatches** — some \`is:inline\` scripts triggered CSP violations with required hashes that didn't match any of Astro's emitted hashes. Unclear whether Astro's CSP experiment missed certain scripts or hashed them with different content than runtime.
3. **\`style-src\` hashes override \`'unsafe-inline\`'** per CSP spec — so runtime-injected styles (Turnstile widget, Preact island hydration) were also blocked.

Net effect: site was effectively JS-broken on production from the moment #234 deployed successfully (post-protobufjs-fix #239).

## Fix

- Remove \`experimental.csp\` config from \`astro.config.mjs\`
- Restore the hand-rolled \`<meta http-equiv=\"Content-Security-Policy\">\` in SEOHead.astro
- Preserve the missing-domain additions that the migration PR had added: \`stats.g.doubleclick.net\`, \`ep1.adtrafficquality.google\`, \`www.linkedin.com\`

## Revisit later

Proper CSP hardening options for a future attempt:
- Wait for Astro's CSP feature to stabilise out of experimental
- Serve CSP via HTTP headers from Cloudflare instead of a meta tag (would need a Worker or Pages Function in front of the GitHub Pages site)
- Accept \`'unsafe-inline'\` in script-src as the trade-off for static-build simplicity

Tracking in #222 (reopen).

## Test plan

- [x] Build produces one meta CSP with \`'unsafe-inline'\` in script-src and no hashes
- [ ] Deployed site loads \`/_astro/*.js\` modules successfully
- [ ] AudioPlayer works on blog/project pages
- [ ] ThemeToggle, ConsentBanner, booking widget all hydrate