### PR TITLE
content: add cinematic videoUrl for 16 items (Day 2 full batch)

### DIFF
--- a/scripts/generate-all-videos.sh
+++ b/scripts/generate-all-videos.sh
@@ -364,10 +364,10 @@ if videos:
             -y 2>&1 | while IFS= read -r line; do echo "    $line"; done
     fi
 
-    # Poll until status=completed (max ~30 min — some videos run long)
+    # Poll until status=completed (max ~45 min — cinematic videos run long)
     video_status=""
     poll_interval=20
-    for attempt in $(seq 1 90); do
+    for attempt in $(seq 1 135); do
         sleep $poll_interval
 
         status_json=$(nlm studio status "$notebook_id" 2>/dev/null || echo "[]")

--- a/src/content/blog/adversarial-poetry-as-jailbreak-post.md
+++ b/src/content/blog/adversarial-poetry-as-jailbreak-post.md
@@ -6,6 +6,7 @@ tags: ['ai', 'ai-safety', 'jailbreaking', 'research', 'llm', 'adversarial']
 draft: false
 heroImage: '/notebook-assets/adversarial-poetry-as-jailbreak/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adversarial-poetry-as-jailbreak/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/adversarial-poetry-as-jailbreak/video.mp4'
 faq:
   - q: 'What is adversarial poetry jailbreaking?'
     a: 'A technique where harmful prompts are reformulated as poems (sonnets, haiku, limericks), which bypasses LLM safety filters because models process poetic structure differently from direct instructions.'

--- a/src/content/blog/afterwords-post.md
+++ b/src/content/blog/afterwords-post.md
@@ -6,6 +6,7 @@ tags: ['ai', 'tts', 'mlx', 'apple-silicon', 'voice-cloning', 'claude', 'open-sou
 series: 'PiCar-X'
 seriesOrder: 4
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterwords-blog/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterwords/video.mp4'
 heroImage: '/notebook-assets/afterwords/infographic.webp'
 faq:
   - q: 'Does Afterwords send any data to the cloud?'

--- a/src/content/blog/ai-nationalism-post.md
+++ b/src/content/blog/ai-nationalism-post.md
@@ -6,6 +6,7 @@ heroImage: '/notebook-assets/ai-nationalism/infographic.webp'
 tags: ['ai', 'policy', 'geopolitics', 'research']
 draft: false
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/ai-nationalism/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/ai-nationalism/video.mp4'
 ---
 
 The single most important fact about AI geopolitics right now is this: the United States has stated, in official policy documents, that its objective is "unquestioned and unchallenged global technological dominance." Not competitiveness. Not leadership. Dominance. That word choice matters, because it tells you everything about the strategic posture driving semiconductor export controls, alliance formation, and the weaponisation of cloud infrastructure.

--- a/src/content/blog/beyond-context-windows-post.md
+++ b/src/content/blog/beyond-context-windows-post.md
@@ -6,6 +6,7 @@ tags: ['ai', 'engineering', 'mcp', 'llm', 'python']
 draft: false
 heroImage: '/notebook-assets/beyond-context-windows/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/beyond-context-windows/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/beyond-context-windows/video.mp4'
 faq:
   - q: 'What is the Recursive Language Model pattern?'
     a: 'The Recursive Language Model pattern treats documents as environment that the model queries, rather than input to read directly. The LLM uses tools to search, retrieve, and interact with content iteratively.'

--- a/src/content/blog/footnotes-at-the-edge-of-reality-post.md
+++ b/src/content/blog/footnotes-at-the-edge-of-reality-post.md
@@ -6,6 +6,7 @@ tags: ['poetry', 'physics', 'writing', 'creative']
 draft: false
 heroImage: '/notebook-assets/footnotes-at-the-edge-of-reality/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/video.mp4'
 ---
 
 # Footnotes at the Edge of Reality

--- a/src/content/blog/getting-google-nest-cameras-into-frigate-nvr-post.md
+++ b/src/content/blog/getting-google-nest-cameras-into-frigate-nvr-post.md
@@ -6,6 +6,7 @@ tags: ['engineering', 'homelab', 'raspberry-pi', 'python', 'home-assistant']
 draft: false
 heroImage: '/notebook-assets/getting-google-nest-cameras-into-frigate-nvr/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/getting-google-nest-cameras-into-frigate-nvr/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/getting-google-nest-cameras-into-frigate-nvr/video.mp4'
 ---
 
 I've tried this at least three times before. Each time I hit a wall, gave up, and went back to watching my Nest cameras through the Google Home app like a normal person. This time I finally cracked it — and the solution turned out to be genuinely weird in ways I want to document properly, because the information online is either outdated, incomplete, or glosses over the exact failure modes that will destroy your afternoon.

--- a/src/content/projects/orbitr.md
+++ b/src/content/projects/orbitr.md
@@ -8,6 +8,7 @@ featured: false
 date: 2025-09-01
 heroImage: '/notebook-assets/orbitr/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/orbitr/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/orbitr/video.mp4'
 ---
 
 Traditional sequencers are grids. Rows and columns. Time moves left to right. It works, but it enforces a particular relationship with rhythm—one that privileges linearity and makes polyrhythm feel like a special case rather than the natural state of things.

--- a/src/content/projects/ordr-fm.md
+++ b/src/content/projects/ordr-fm.md
@@ -8,6 +8,7 @@ featured: false
 date: 2025-07-01
 heroImage: '/notebook-assets/ordr-fm/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/ordr-fm/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/ordr-fm/video.mp4'
 ---
 
 My music library is the single most curated collection I own. Decades of albums, carefully sourced, tagged with intention, organised by a system that only I fully understand. When that library outgrew the capacity of any existing organiser to handle it without mangling metadata or silently overwriting lossless files with lossy duplicates, I built the tool I needed.

--- a/src/content/projects/personal-agentic-operating-system.md
+++ b/src/content/projects/personal-agentic-operating-system.md
@@ -7,6 +7,7 @@ status: 'active'
 featured: false
 date: 2025-07-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/personal-agentic-operating-system/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/personal-agentic-operating-system/video.mp4'
 heroImage: '/notebook-assets/personal-agentic-operating-system/infographic.webp'
 ---
 

--- a/src/content/projects/rlm-mcp.md
+++ b/src/content/projects/rlm-mcp.md
@@ -8,6 +8,7 @@ featured: false
 date: 2025-11-01
 heroImage: '/notebook-assets/rlm-mcp/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/rlm-mcp/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/rlm-mcp/video.mp4'
 ---
 
 Context windows have limits. Documents don't. The mismatch creates a practical problem: if your working document exceeds what the model can hold in a single pass, you're forced into chunking strategies that lose coherence, or summarisation that loses detail, or simply giving up on using the document at all.

--- a/src/content/projects/space-weather.md
+++ b/src/content/projects/space-weather.md
@@ -8,6 +8,7 @@ featured: false
 date: 2025-01-01
 heroImage: '/notebook-assets/space-weather/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/space-weather/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/space-weather/video.mp4'
 ---
 
 The sun is a noisy neighbour. Coronal mass ejections, solar wind variations, geomagnetic storms—these aren't abstract astrophysics. They affect radio propagation, satellite operations, power grids, and anyone who has ever wondered why their GPS was slightly wrong on a particular afternoon.

--- a/src/content/projects/squishmallowdex.md
+++ b/src/content/projects/squishmallowdex.md
@@ -9,6 +9,7 @@ featured: true
 heroImage: '/images/projects/squishmallowdex-hero.png'
 date: 2024-12-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/squishmallowdex/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/squishmallowdex/video.mp4'
 ---
 
 A friend mentioned her 10-year-old was researching Squishmallows. I asked if I could help. A few hours later I looked up from my screen, realized I was starving, and discovered I'd built and shipped the first release.

--- a/src/content/projects/strategic-acquisitions.md
+++ b/src/content/projects/strategic-acquisitions.md
@@ -8,6 +8,7 @@ featured: false
 date: 2025-01-15
 heroImage: '/notebook-assets/strategic-acquisitions/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/strategic-acquisitions/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/strategic-acquisitions/video.mp4'
 ---
 
 Housing shortages are not information problems, but they have information problems inside them. When a public housing organisation needs to acquire properties, the analysis that should take hours takes weeks. Listing discovery. Valuation modelling. Planning zone verification. Hazard assessment. Infrastructure proximity. Each step involves a different data source and a different manual process.

--- a/src/content/projects/tel3sis.md
+++ b/src/content/projects/tel3sis.md
@@ -8,6 +8,7 @@ featured: false
 date: 2025-10-01
 heroImage: '/notebook-assets/tel3sis/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/tel3sis/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/tel3sis/video.mp4'
 ---
 
 The phone call is the oldest real-time interface we have. It's also the one AI handles worst. Chat is easy—latency is invisible, you can take a few seconds to think, the user stares at a typing indicator and waits. On a phone call, three seconds of silence is an eternity. It's the gap where the caller decides the system is broken, or stupid, or both.

--- a/src/content/projects/veritas.md
+++ b/src/content/projects/veritas.md
@@ -7,6 +7,7 @@ status: 'active'
 featured: false
 date: 2025-03-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/veritas/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/veritas/video.mp4'
 heroImage: '/notebook-assets/veritas/infographic.webp'
 ---
 

--- a/src/content/projects/wolf-clan-hub.md
+++ b/src/content/projects/wolf-clan-hub.md
@@ -8,6 +8,7 @@ featured: true
 date: 2026-03-02
 heroImage: '/notebook-assets/wolf-clan-hub/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/wolf-clan-hub/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/wolf-clan-hub/video.mp4'
 ---
 
 Every local club I've trained at runs on a Facebook page and a spreadsheet. Wolf Clan has a complete operations platform — and it runs on zero-build tools.


### PR DESCRIPTION
## Summary
- Adds `videoUrl` frontmatter to 10 projects + 6 blog posts with cinematic NotebookLM videos now live on R2 CDN
- Generated via `./scripts/generate-all-videos.sh --all` with branded dark-botanical `--focus` prompt
- Bumps video status poll timeout from 30min → 45min (Day 1 lesson: cinematic videos routinely exceed 30min window)

### Projects (10)
orbitr, ordr-fm, personal-agentic-operating-system, rlm-mcp, space-weather, squishmallowdex, strategic-acquisitions, tel3sis, veritas, wolf-clan-hub

### Blog posts (6)
adversarial-poetry-as-jailbreak, afterwords, ai-nationalism, beyond-context-windows, footnotes-at-the-edge-of-reality, getting-google-nest-cameras-into-frigate-nvr

### Failed (retry in Day 3)
- `this-wasnt-in-the-brochure` — notebook creation failed
- `why-demonstrated-risk-is-ignored` — generation timeout
- `120-models-18k-prompts` — generation timeout
- `building-a-personal-site-in-2026` — notebook creation failed

### Still pending after this PR
- 2 projects (this-wasnt-in-the-brochure, why-demonstrated-risk-is-ignored)
- 19 blog posts (4 failed + 15 never attempted)

## Test plan
- [ ] `npm run build` succeeds
- [ ] Video player renders on project and blog detail pages
- [ ] CDN URLs return 200 (spot check: `curl -I https://cdn.adrianwedd.com/notebook-assets/orbitr/video.mp4`)