### PR TITLE
content: add cinematic videoUrl for 8 items + fix notebook title quoting (Day 3)

### DIFF
--- a/scripts/generate-all-videos.sh
+++ b/scripts/generate-all-videos.sh
@@ -232,12 +232,12 @@ find_notebook_id() {
     echo "$NOTEBOOKS_JSON" | python3 -c "
 import json, sys
 notebooks = json.load(sys.stdin)
-fragment = '$title_fragment'.lower()
+fragment = sys.argv[1].lower()
 for n in notebooks:
     if fragment in n['title'].lower():
         print(n['id'])
         sys.exit(0)
-" 2>/dev/null || echo ""
+" "$title_fragment" 2>/dev/null || echo ""
 }
 
 RESULTS_LOG="$EXPORT_DIR/batch-results.log"

--- a/src/content/blog/120-models-18k-prompts-post.md
+++ b/src/content/blog/120-models-18k-prompts-post.md
@@ -6,6 +6,7 @@ tags: ['ai', 'ai-safety', 'research', 'llm', 'security', 'adversarial']
 draft: false
 heroImage: '/notebook-assets/120-models-18k-prompts/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/120-models-18k-prompts/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/120-models-18k-prompts/video.mp4'
 faq:
   - q: 'What is supply chain injection in AI?'
     a: 'Supply chain injection involves inserting malicious content into tool definitions and skill files rather than user prompts. Testing showed 90–100% attack success rates across models because external tool definitions are trusted implicitly.'

--- a/src/content/blog/giving-a-robot-three-voices-post.md
+++ b/src/content/blog/giving-a-robot-three-voices-post.md
@@ -5,6 +5,7 @@ date: 2026-03-19
 tags: ['ai', 'tts', 'mlx', 'raspberry-pi', 'robotics', 'apple-silicon', 'voice-cloning', 'spark']
 heroImage: '/notebook-assets/giving-a-robot-three-voices/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/giving-a-robot-three-voices/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/giving-a-robot-three-voices/video.mp4'
 series: 'PiCar-X'
 seriesOrder: 2
 faq:

--- a/src/content/blog/project-chimera-post.md
+++ b/src/content/blog/project-chimera-post.md
@@ -6,6 +6,7 @@ heroImage: '/notebook-assets/project-chimera/infographic.webp'
 tags: ['ai', 'enterprise', 'research', 'engineering']
 draft: false
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/project-chimera/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/project-chimera/video.mp4'
 ---
 
 JPMorgan Chase, in a rare analysis of a private company, recently described OpenAI's position at the frontier of AI as an "increasingly fragile moat." The reasoning: no single developer can maintain a sustained competitive edge at the model layer, which will inevitably force companies to compete on price, eroding margins and commoditising access to powerful AI. GPT-5 launched into a market where Anthropic and Google matched or exceeded its benchmarks almost immediately. The innovation cycle has compressed to the point where frontier performance is a temporary state, not a durable advantage.

--- a/src/content/blog/the-failure-first-team-post.md
+++ b/src/content/blog/the-failure-first-team-post.md
@@ -6,6 +6,7 @@ tags: ['ai', 'ai-safety', 'research', 'adversarial', 'team']
 draft: false
 heroImage: '/notebook-assets/the-failure-first-team/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-failure-first-team/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-failure-first-team/video.mp4'
 faq:
   - q: 'What is the Failure First team?'
     a: 'The Failure First team consists of fifteen specialist AI agents, each initialized with distinct roles and standing instructions. They work on adversarial AI evaluation across 227 models and 133,000+ evaluated results, with a human coordinator overseeing direction and publication.'

--- a/src/content/blog/the-mitigation-gap-post.md
+++ b/src/content/blog/the-mitigation-gap-post.md
@@ -6,6 +6,7 @@ heroImage: '/notebook-assets/the-mitigation-gap/infographic.webp'
 tags: ['ai', 'ai-safety', 'research', 'biosecurity', 'policy']
 draft: false
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-mitigation-gap/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-mitigation-gap/video.mp4'
 ---
 
 Biosecurity experts believe current safeguards reduce AI-enabled catastrophic biorisk by over 70%. They are wrong.

--- a/src/content/blog/why-demonstrated-risk-is-ignored-post.md
+++ b/src/content/blog/why-demonstrated-risk-is-ignored-post.md
@@ -6,6 +6,7 @@ tags: ['research', 'risk', 'organisations', 'policy', 'ai-safety']
 draft: false
 heroImage: '/notebook-assets/why-demonstrated-risk-is-ignored/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/video.mp4'
 faq:
   - q: 'Why do organisations ignore demonstrated risk?'
     a: 'Four structural reasons: responsibility without authority, misaligned incentives, organisational scar tissue from past failures, and evidence that threatens institutional identity.'

--- a/src/content/blog/why-i-build-in-public-post.md
+++ b/src/content/blog/why-i-build-in-public-post.md
@@ -5,6 +5,7 @@ date: 2026-02-15
 tags: ['engineering', 'open-source', 'philosophy']
 heroImage: '/notebook-assets/why-i-build-in-public/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-i-build-in-public/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-i-build-in-public/video.mp4'
 ---
 
 Every project on this site has a source link. Most of them link to messy repositories with commit messages like "fix the thing" and half-finished branches named `experiment-3`. This is deliberate.

--- a/src/content/projects/why-demonstrated-risk-is-ignored.md
+++ b/src/content/projects/why-demonstrated-risk-is-ignored.md
@@ -8,6 +8,7 @@ featured: true
 date: 2026-02-07
 heroImage: '/notebook-assets/why-demonstrated-risk-is-ignored/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/video.mp4'
 ---
 
 You show someone evidence of harm. They acknowledge the evidence. Then they proceed as if the evidence doesn't exist. This isn't stupidity or denial—it's something more structural, and more dangerous.


### PR DESCRIPTION
## Summary
- Adds `videoUrl` to 7 blog posts + 1 project with cinematic videos on R2 CDN
- Fixes Python quoting bug in `find_notebook_id` — apostrophes in titles caused SyntaxError, silently breaking lookup and producing false "no notebook" failures (affected "This Wasn't in the Brochure" and any future titles with apostrophes)

### Projects (1)
why-demonstrated-risk-is-ignored

### Blog posts (7)
120-models-18k-prompts, giving-a-robot-three-voices, project-chimera, the-failure-first-team, the-mitigation-gap, why-demonstrated-risk-is-ignored, why-i-build-in-public

### Remaining (Day 4)
12 blog posts still pending (failed with transient "no notebook" errors overnight — retry in progress with fixed script)

## Test plan
- [ ] `npm run build` succeeds
- [ ] Video player renders on updated pages