### PR TITLE
content: add cinematic videoUrl for 18 items + fix notebook title quoting

### DIFF
--- a/scripts/generate-all-videos.sh
+++ b/scripts/generate-all-videos.sh
@@ -232,12 +232,12 @@ find_notebook_id() {
     echo "$NOTEBOOKS_JSON" | python3 -c "
 import json, sys
 notebooks = json.load(sys.stdin)
-fragment = '$title_fragment'.lower()
+fragment = sys.argv[1].lower()
 for n in notebooks:
     if fragment in n['title'].lower():
         print(n['id'])
         sys.exit(0)
-" 2>/dev/null || echo ""
+" "$title_fragment" 2>/dev/null || echo ""
 }
 
 RESULTS_LOG="$EXPORT_DIR/batch-results.log"

--- a/src/content/blog/120-models-18k-prompts-post.md
+++ b/src/content/blog/120-models-18k-prompts-post.md
@@ -6,6 +6,7 @@ tags: ['ai', 'ai-safety', 'research', 'llm', 'security', 'adversarial']
 draft: false
 heroImage: '/notebook-assets/120-models-18k-prompts/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/120-models-18k-prompts/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/120-models-18k-prompts/video.mp4'
 faq:
   - q: 'What is supply chain injection in AI?'
     a: 'Supply chain injection involves inserting malicious content into tool definitions and skill files rather than user prompts. Testing showed 90–100% attack success rates across models because external tool definitions are trusted implicitly.'

--- a/src/content/blog/building-a-personal-site-in-2026-post.md
+++ b/src/content/blog/building-a-personal-site-in-2026-post.md
@@ -5,6 +5,7 @@ date: 2026-02-15
 tags: ['engineering', 'web', 'astro', 'open-source']
 heroImage: '/notebook-assets/building-a-personal-site-in-2026/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/building-a-personal-site-in-2026/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/building-a-personal-site-in-2026/video.mp4'
 faq:
   - q: 'What framework is best for a personal site in 2026?'
     a: 'Astro generates static HTML pages with zero JavaScript by default, making it architecturally right for document-based personal sites. It ships JS only through Preact islands that hydrate on idle.'

--- a/src/content/blog/giving-a-robot-three-voices-post.md
+++ b/src/content/blog/giving-a-robot-three-voices-post.md
@@ -5,6 +5,7 @@ date: 2026-03-19
 tags: ['ai', 'tts', 'mlx', 'raspberry-pi', 'robotics', 'apple-silicon', 'voice-cloning', 'spark']
 heroImage: '/notebook-assets/giving-a-robot-three-voices/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/giving-a-robot-three-voices/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/giving-a-robot-three-voices/video.mp4'
 series: 'PiCar-X'
 seriesOrder: 2
 faq:

--- a/src/content/blog/hello-world-post.md
+++ b/src/content/blog/hello-world-post.md
@@ -5,6 +5,7 @@ date: 2026-02-12
 tags: ['meta', 'craft', 'open-source']
 heroImage: '/notebook-assets/hello-world/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/hello-world/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/hello-world/video.mp4'
 ---
 
 Most personal sites are museums. Carefully selected exhibits, arranged chronologically, with the messy work hidden in a drawer somewhere. This is not that.

--- a/src/content/blog/project-chimera-post.md
+++ b/src/content/blog/project-chimera-post.md
@@ -6,6 +6,7 @@ heroImage: '/notebook-assets/project-chimera/infographic.webp'
 tags: ['ai', 'enterprise', 'research', 'engineering']
 draft: false
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/project-chimera/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/project-chimera/video.mp4'
 ---
 
 JPMorgan Chase, in a rare analysis of a private company, recently described OpenAI's position at the frontier of AI as an "increasingly fragile moat." The reasoning: no single developer can maintain a sustained competitive edge at the model layer, which will inevitably force companies to compete on price, eroding margins and commoditising access to powerful AI. GPT-5 launched into a market where Anthropic and Google matched or exceeded its benchmarks almost immediately. The innovation cycle has compressed to the point where frontier performance is a temporary state, not a durable advantage.

--- a/src/content/blog/reconciling-the-great-divergence-post.md
+++ b/src/content/blog/reconciling-the-great-divergence-post.md
@@ -6,6 +6,7 @@ tags: ['ai', 'economics', 'research', 'policy']
 draft: false
 heroImage: '/notebook-assets/reconciling-the-great-divergence/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/reconciling-the-great-divergence/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/reconciling-the-great-divergence/video.mp4'
 ---
 
 Goldman Sachs says AI could add $7 trillion to global GDP. MIT economist Daron Acemoglu says the near-term impact is closer to 0.5%. PwC projects $15.7 trillion in additional economic value by 2030. McKinsey puts annual productivity gains at $2.6–4.4 trillion.

--- a/src/content/blog/safety-first-therapeutic-ai-post.md
+++ b/src/content/blog/safety-first-therapeutic-ai-post.md
@@ -6,6 +6,7 @@ tags: ['ai', 'ai-safety', 'health', 'typescript']
 draft: false
 heroImage: '/notebook-assets/safety-first-therapeutic-ai/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/safety-first-therapeutic-ai/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/safety-first-therapeutic-ai/video.mp4'
 faq:
   - q: 'What is EMDR and why does it require AI safety?'
     a: 'EMDR (Eye Movement Desensitization and Reprocessing) is a trauma therapy with precise protocols and serious failure modes. AI-assisted EMDR requires safety architecture first because the therapeutic mechanism — activating distress — is also the primary risk.'

--- a/src/content/blog/the-ai-productivity-j-curve-post.md
+++ b/src/content/blog/the-ai-productivity-j-curve-post.md
@@ -6,6 +6,7 @@ tags: ['ai', 'economics', 'enterprise', 'research', 'policy']
 draft: false
 heroImage: '/notebook-assets/the-ai-productivity-j-curve/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-ai-productivity-j-curve/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-ai-productivity-j-curve/video.mp4'
 faq:
   - q: 'What is the AI Productivity J-Curve?'
     a: "An economic framework showing that transformative technologies initially reduce measured productivity before generating gains — because the critical intangible investments (process redesign, data governance, workforce reskilling) aren't captured in traditional metrics."

--- a/src/content/blog/the-cognitive-cage-post.md
+++ b/src/content/blog/the-cognitive-cage-post.md
@@ -6,6 +6,7 @@ tags: ['ai', 'ai-safety', 'robotics', 'research', 'engineering']
 draft: false
 heroImage: '/notebook-assets/the-cognitive-cage/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-cognitive-cage/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-cognitive-cage/video.mp4'
 faq:
   - q: 'What is the cognitive cage in robotics?'
     a: 'The cognitive cage is a proposed safety system for humanoid robots — a deterministic code layer that verifies and vetoes vision-language-action model commands in real time, replacing the physical cages that historically contained robot movements.'

--- a/src/content/blog/the-failure-first-team-post.md
+++ b/src/content/blog/the-failure-first-team-post.md
@@ -6,6 +6,7 @@ tags: ['ai', 'ai-safety', 'research', 'adversarial', 'team']
 draft: false
 heroImage: '/notebook-assets/the-failure-first-team/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-failure-first-team/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-failure-first-team/video.mp4'
 faq:
   - q: 'What is the Failure First team?'
     a: 'The Failure First team consists of fifteen specialist AI agents, each initialized with distinct roles and standing instructions. They work on adversarial AI evaluation across 227 models and 133,000+ evaluated results, with a human coordinator overseeing direction and publication.'

--- a/src/content/blog/the-legal-ai-trust-deficit-post.md
+++ b/src/content/blog/the-legal-ai-trust-deficit-post.md
@@ -6,6 +6,7 @@ tags: ['ai', 'legal', 'research', 'llm']
 draft: false
 heroImage: '/notebook-assets/the-legal-ai-trust-deficit/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-legal-ai-trust-deficit/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-legal-ai-trust-deficit/video.mp4'
 faq:
   - q: 'Why are lawyers slow to adopt AI?'
     a: 'The legal profession values accuracy, confidentiality, and accountability — all areas where current AI systems have demonstrated weaknesses. 75% of lawyers cite accuracy concerns as the top barrier.'

--- a/src/content/blog/the-mitigation-gap-post.md
+++ b/src/content/blog/the-mitigation-gap-post.md
@@ -6,6 +6,7 @@ heroImage: '/notebook-assets/the-mitigation-gap/infographic.webp'
 tags: ['ai', 'ai-safety', 'research', 'biosecurity', 'policy']
 draft: false
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-mitigation-gap/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-mitigation-gap/video.mp4'
 ---
 
 Biosecurity experts believe current safeguards reduce AI-enabled catastrophic biorisk by over 70%. They are wrong.

--- a/src/content/blog/the-notebooklm-pipeline-post.md
+++ b/src/content/blog/the-notebooklm-pipeline-post.md
@@ -5,6 +5,7 @@ date: 2026-02-15
 tags: ['engineering', 'automation', 'ai', 'python']
 heroImage: '/notebook-assets/the-notebooklm-pipeline/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-notebooklm-pipeline/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-notebooklm-pipeline/video.mp4'
 faq:
   - q: 'What is the NotebookLM pipeline?'
     a: "An automated system that takes structured Markdown content (blog posts, project docs) and routes it through Google's NotebookLM to produce audio overviews, video summaries, infographics, and other derived assets — all triggered from a single config file."

--- a/src/content/blog/the-resonant-fringe-post.md
+++ b/src/content/blog/the-resonant-fringe-post.md
@@ -5,6 +5,7 @@ date: 2026-03-18
 tags: ['history', 'music', 'perth', 'radio']
 heroImage: '/notebook-assets/the-resonant-fringe/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-resonant-fringe/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-resonant-fringe/video.mp4'
 ---
 
 In the early 1990s, if you wanted to hear Detroit techno in Perth, you had two options: find someone who'd imported the vinyl, or stay up past midnight on a Sunday and tune your FM dial to 92.1.

--- a/src/content/blog/voice-cloning-qwen3-tts-mlx-post.md
+++ b/src/content/blog/voice-cloning-qwen3-tts-mlx-post.md
@@ -6,6 +6,7 @@ tags: ['ai', 'tts', 'mlx', 'apple-silicon', 'voice-cloning', 'tutorial', 'spark'
 series: 'PiCar-X'
 seriesOrder: 3
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/voice-cloning-qwen3-tts-mlx/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/voice-cloning-qwen3-tts-mlx/video.mp4'
 heroImage: '/notebook-assets/voice-cloning-qwen3-tts-mlx/infographic.webp'
 faq:
   - q: 'Do I need to fine-tune or train anything?'

--- a/src/content/blog/why-demonstrated-risk-is-ignored-post.md
+++ b/src/content/blog/why-demonstrated-risk-is-ignored-post.md
@@ -6,6 +6,7 @@ tags: ['research', 'risk', 'organisations', 'policy', 'ai-safety']
 draft: false
 heroImage: '/notebook-assets/why-demonstrated-risk-is-ignored/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/video.mp4'
 faq:
   - q: 'Why do organisations ignore demonstrated risk?'
     a: 'Four structural reasons: responsibility without authority, misaligned incentives, organisational scar tissue from past failures, and evidence that threatens institutional identity.'

--- a/src/content/blog/why-i-build-in-public-post.md
+++ b/src/content/blog/why-i-build-in-public-post.md
@@ -5,6 +5,7 @@ date: 2026-02-15
 tags: ['engineering', 'open-source', 'philosophy']
 heroImage: '/notebook-assets/why-i-build-in-public/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-i-build-in-public/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-i-build-in-public/video.mp4'
 ---
 
 Every project on this site has a source link. Most of them link to messy repositories with commit messages like "fix the thing" and half-finished branches named `experiment-3`. This is deliberate.

--- a/src/content/projects/why-demonstrated-risk-is-ignored.md
+++ b/src/content/projects/why-demonstrated-risk-is-ignored.md
@@ -8,6 +8,7 @@ featured: true
 date: 2026-02-07
 heroImage: '/notebook-assets/why-demonstrated-risk-is-ignored/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/video.mp4'
 ---
 
 You show someone evidence of harm. They acknowledge the evidence. Then they proceed as if the evidence doesn't exist. This isn't stupidity or denial—it's something more structural, and more dangerous.


### PR DESCRIPTION
## Summary

Adds `videoUrl` frontmatter for 17 blog posts and 1 project with cinematic NotebookLM videos on R2 CDN.

Fixes `find_notebook_id` in `generate-all-videos.sh` — titles containing apostrophes caused a Python `SyntaxError` when shell-interpolated into a string literal, silently breaking notebook lookup and producing false "no notebook" failures. This was the root cause of 4 consecutive failures for `this-wasnt-in-the-brochure` across Days 2–4. Fixed by passing the fragment via `sys.argv[1]`.

Supersedes closed #244.

### Blog posts (17)
120-models-18k-prompts, building-a-personal-site-in-2026, giving-a-robot-three-voices, hello-world, project-chimera, reconciling-the-great-divergence, safety-first-therapeutic-ai, the-ai-productivity-j-curve, the-cognitive-cage, the-failure-first-team, the-legal-ai-trust-deficit, the-mitigation-gap, the-notebooklm-pipeline, the-resonant-fringe, voice-cloning-qwen3-tts-mlx, why-demonstrated-risk-is-ignored, why-i-build-in-public

### Project (1)
why-demonstrated-risk-is-ignored

### Still pending
- `this-wasnt-in-the-brochure` (project + blog) — will succeed now that quoting bug is fixed
- `zero-build-web-development` (blog) — never attempted, was cut by batch limit

## Test plan
- [ ] `npm run build` succeeds
- [ ] Video player renders on blog detail pages
- [ ] CDN URLs return 200 (spot check: `curl -I https://cdn.adrianwedd.com/notebook-assets/hello-world/video.mp4`)