### PR TITLE
content: add final 3 cinematic videoUrls + add Hermes CLI to QA tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,11 +390,21 @@ gemini "query"                       # interactive mode
 ```
 Use for: accessibility review, design consistency, content QA. Has file access.
 
-### Three-Way QA Pattern
-Run Codex + Gemini + Claude agent in parallel for comprehensive review:
+### Hermes CLI
+```bash
+hermes chat -q "prompt"              # one-shot mode (like codex exec / gemini -p)
+hermes chat -q "prompt" --quiet      # no banner/spinner
+hermes chat -q "prompt" -s skill     # preload skills (e.g. -s arxiv)
+hermes chat -q "prompt" -m model     # specific model (e.g. anthropic/claude-sonnet-4)
+```
+Use for: research tasks, cross-referencing, second-opinion QA, web browsing. Also registered as MCP server (`hermes-acp`) for direct tool access (browser, web search, memory, cron) without shelling out.
+
+### Multi-Engine QA Pattern
+Run Codex + Gemini + Hermes + Claude agent in parallel for comprehensive review:
 ```bash
 codex exec --full-auto "QA prompt" 2>&1 | tee /tmp/codex-qa.txt &
 gemini -p "QA prompt" --yolo 2>&1 | tee /tmp/gemini-qa.txt &
+hermes chat -q "QA prompt" --quiet 2>&1 | tee /tmp/hermes-qa.txt &
 wait
 ```
-Each engine catches different things. Codex is strongest on security + correctness. Gemini is strongest on design + accessibility. Claude agent is strongest on architecture + spec compliance.
+Each engine catches different things. Codex is strongest on security + correctness. Gemini is strongest on design + accessibility. Hermes is strongest on research + cross-referencing. Claude agent is strongest on architecture + spec compliance.

--- a/src/content/blog/this-wasnt-in-the-brochure-post.md
+++ b/src/content/blog/this-wasnt-in-the-brochure-post.md
@@ -5,6 +5,7 @@ date: 2026-02-15
 tags: ['writing', 'neurodivergence', 'parenting', 'books', 'co-parenting']
 heroImage: '/notebook-assets/this-wasnt-in-the-brochure/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/video.mp4'
 ---
 
 You packed for a picnic. You ended up in the Drake Passage.

--- a/src/content/blog/zero-build-web-development-post.md
+++ b/src/content/blog/zero-build-web-development-post.md
@@ -6,6 +6,7 @@ tags: ['engineering', 'web', 'security', 'cloudflare']
 draft: false
 heroImage: '/notebook-assets/zero-build-web-development/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/zero-build-web-development/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/zero-build-web-development/video.mp4'
 ---
 
 I built a complete operations platform for my Zen Do Kai club. Public marketing site, password-gated ops hub, JWT-authenticated member portal with attendance tracking, grading administration, lesson plans, and Stripe billing. Three zones, 20+ API endpoints, a D1 database, and security-hardened middleware.

--- a/src/content/blog/zero-build-web-development-post.md
+++ b/src/content/blog/zero-build-web-development-post.md
@@ -3,7 +3,7 @@ title: 'Zero-Build Web Development'
 description: 'What happens when you build a three-zone operations platform for a martial arts club with no framework, no build step, and no npm.'
 date: 2026-03-14
 tags: ['engineering', 'web', 'security', 'cloudflare']
-draft: false
+draft: false 
 heroImage: '/notebook-assets/zero-build-web-development/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/zero-build-web-development/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/zero-build-web-development/video.mp4'

--- a/src/content/projects/this-wasnt-in-the-brochure.md
+++ b/src/content/projects/this-wasnt-in-the-brochure.md
@@ -9,6 +9,7 @@ featured: true
 date: 2026-02-08
 heroImage: '/notebook-assets/this-wasnt-in-the-brochure/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/video.mp4'
 series: "This Wasn't in the Brochure"
 seriesOrder: 1
 ---


### PR DESCRIPTION
## Summary
- Completes cinematic video coverage — every non-draft project and blog post now has a `videoUrl` on CDN
- `this-wasnt-in-the-brochure` (project + blog) finally succeeded after the `find_notebook_id` quoting fix in #246
- `zero-build-web-development` — first attempt, clean success
- Adds Hermes CLI to CLAUDE.md QA tools section with usage examples and MCP integration note
- Updates multi-engine QA pattern from three-way to four-way (Codex + Gemini + Hermes + Claude)

## Test plan
- [ ] `npm run build` succeeds
- [ ] Video player renders on this-wasnt-in-the-brochure and zero-build-web-development pages
- [ ] `curl -I https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/video.mp4` returns 200