### PR TITLE
ci: median-of-3 Lighthouse runs, restore 0.9 threshold

### DIFF
--- a/.github/lighthouse/lighthouserc.json
+++ b/.github/lighthouse/lighthouserc.json
@@ -1,6 +1,7 @@
 {
   "ci": {
     "collect": {
+      "numberOfRuns": 3,
       "staticDistDir": "dist",
       "url": [
         "/",
@@ -13,8 +14,9 @@
       ]
     },
     "assert": {
+      "aggregationMethod": "median",
       "assertions": {
-        "categories:performance": ["error", { "minScore": 0.85 }],
+        "categories:performance": ["error", { "minScore": 0.9 }],
         "categories:accessibility": ["error", { "minScore": 0.9 }],
         "categories:best-practices": ["warn", { "minScore": 0.9 }],
         "categories:seo": ["warn", { "minScore": 0.9 }],


### PR DESCRIPTION
## Summary
Replaces the threshold bandaid from #250 with the proper fix: run Lighthouse 3× per URL and assert against the median.

## Why
Same-commit variance of 0.10+ on GitHub hosted runners has flaked three PRs in 24h while local production scored 1.0. Median-of-3 smooths single-run noise without lowering the bar.

## Changes
- \`numberOfRuns: 3\` in \`collect\`
- \`aggregationMethod: median\` at the \`assert\` level (applies to all assertions)
- \`categories:performance\` threshold restored from 0.85 → 0.9

## Tradeoff
~3× Lighthouse runtime (~6–9 min vs ~2–3). Fits default CI budget. If runner pool strains, drop to \`numberOfRuns: 2\` + \`aggregationMethod: optimistic\`.

## Test plan
- [ ] CI passes with this change (no spurious failures over 3 runs)
- [ ] Total job runtime stays under 15 min
- [ ] All gates apply at the 0.9 bar via median

Closes #251.