### PR TITLE
fix(tsconfig): exclude worker-csp/ from root astro check

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     }
   },
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist", "worker"]
+  "exclude": ["dist", "worker", "worker-csp"]
 }


### PR DESCRIPTION
Surfaced by post-merge QA after #255 + #256 landed on main.

The new `worker-csp/` directory has its own `tsconfig.json` that declares Cloudflare Workers + vitest-pool-workers types, but the root `tsconfig.json` was picking up its files via the `**/*` include and emitting 3 errors during `astro check`:

- Cannot find name `HTMLRewriter`
- Cannot find name `ExportedHandler`
- Cannot find module `cloudflare:test`

These are valid identifiers inside `worker-csp/` (loaded via its own tsconfig), but loading Workers types into the Astro project would be wrong. Just exclude the directory like we already do for `worker/`.

## Verified
- `npx astro check`: was 3 errors → now **0 errors, 0 warnings, 36 hints** (the pre-existing TS hints unchanged)
- `npm run build`: still 406 pages
- `npm run lint`: still clean