### PR TITLE
fix(a11y): theme toggle announces changes + aria-pressed + visible-target for keyboard 't'

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -8,6 +8,7 @@
   type="button"
   class="theme-toggle rounded-lg p-2 text-text-muted transition-colors hover:bg-surface-alt hover:text-text"
   aria-label="Toggle dark/light theme"
+  aria-pressed="false"
 >
   <svg
     class="theme-icon-moon h-5 w-5"
@@ -54,6 +55,16 @@
       document.querySelectorAll('.theme-icon-sun').forEach(function (el) {
         el.classList.toggle('hidden', theme === 'dark');
       });
+      // aria-pressed reflects "light theme on?" so screen readers announce
+      // the toggle state correctly. Updated on every code path that changes
+      // the theme — click, keyboard 't', system preference change, VT swap.
+      document.querySelectorAll('.theme-toggle').forEach(function (el) {
+        el.setAttribute('aria-pressed', theme === 'light' ? 'true' : 'false');
+      });
+      // Polite live-region announcement so keyboard / screen-reader users
+      // get explicit feedback that the change happened.
+      var live = document.getElementById('theme-toggle-status');
+      if (live) live.textContent = theme === 'light' ? 'Light theme' : 'Dark theme';
     }
 
     applyTheme(getTheme());

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -75,6 +75,8 @@ const props = Astro.props;
     >
       Skip to main content
     </a>
+    {/* Polite live region announced when the theme changes (click or 't' shortcut) */}
+    <span id="theme-toggle-status" role="status" aria-live="polite" class="sr-only"></span>
     <Header />
     <main id="main-content" class="flex-1">
       <slot />
@@ -254,14 +256,20 @@ const props = Astro.props;
 
             if (key === 't' && !pending) {
               e.preventDefault();
-              var themeToggle = document.querySelector('.theme-toggle');
-              if (themeToggle) {
-                themeToggle.click();
-              } else {
-                document.documentElement.classList.toggle('light');
-                localStorage.setItem('theme', document.documentElement.classList.contains('light') ? 'light' : 'dark');
-                document.dispatchEvent(new CustomEvent('theme-changed'));
+              // Prefer a visible toggle so the click delegates correctly.
+              // Header renders both desktop + mobile copies; querySelectorAll
+              // returns them in document order, and offsetParent === null
+              // is the standard "is the element rendered?" check.
+              var toggles = document.querySelectorAll('.theme-toggle');
+              var target = null;
+              for (var ti = 0; ti < toggles.length; ti++) {
+                if (toggles[ti].offsetParent !== null) {
+                  target = toggles[ti];
+                  break;
+                }
               }
+              if (!target && toggles.length) target = toggles[0];
+              if (target) target.click();
               return;
             }
 


### PR DESCRIPTION
QA pass on 2026-04-28 (Gemini F1+F2). Three a11y gaps surfaced now that the keyboard shortcut funnels through the same path as the button click.

## Changes
1. **\`aria-pressed\` on the toggle button** — reflects "light theme on?". Updated by \`applyTheme\` on every code path (click, keyboard \`t\`, system preference change, View Transitions swap). Screen readers now announce the toggle state correctly.

2. **Polite live region in BaseLayout** — \`role="status" aria-live="polite"\`, visually hidden. \`applyTheme\` writes "Light theme" or "Dark theme" into it on every change. AT users get the same confirmation sighted users see in the icon flip — important for the keyboard-only path where there's no click feedback.

3. **Visible-target keyboard \`t\` handler** — old code used \`document.querySelector('.theme-toggle')\` which returns the first match in document order. Header renders a desktop and a mobile copy; on a desktop viewport the mobile toggle is \`display:none\` but still first/last in the DOM depending on order. Now iterates and prefers the first \`offsetParent !== null\` (visible) toggle, falling back to the first only if none are rendered.

4. **Removed dead fallback** that mutated \`.light\` class directly. \`ThemeToggle\` is always present, so the fallback was unreachable in practice — but if it ever fired it would desync \`aria-pressed\` and the live region with the actual theme. Cleaner to remove.

## Verified
- \`npm run build\`: 406 pages
- \`npm run lint\`: clean
- \`aria-pressed=\"false\"\` appears twice in \`dist/index.html\` (desktop + mobile ThemeToggle copies)
- \`#theme-toggle-status\` live region present in body before Header