### PR TITLE
worker-csp: deploy-prep (ORIGIN_HOST, style-src split, integration test)

### DIFF
--- a/worker-csp/README.md
+++ b/worker-csp/README.md
@@ -36,8 +36,16 @@ This is the failure mode that broke #241. Don't flip it until every external scr
 
 The existing `worker/` runs `social.adrianwedd.com` (Facebook automation). This one binds to `adrianwedd.com/*` and does HTML rewriting. Different hostnames, different routes, different blast radius — cleaner to keep them isolated.
 
+## Local integration test
+
+`npm run build` from the repo root, then `cd worker-csp && ./scripts/integration-test.sh`. Boots `python -m http.server` against `../dist/` and `wrangler dev` with `ORIGIN_HOST` pointed at it, then curls representative URLs and asserts that HTML responses carry a `Content-Security-Policy` header whose nonce matches the nonce attached to `<script>` tags in the body, and that the build-time meta CSP is stripped.
+
+## Past blockers (resolved before bind)
+
+- **Self-recursion** — `ORIGIN_HOST` env var decouples the upstream host from the worker's route hostname. Production points at `adrianwedd.github.io`; integration test points at `localhost`.
+- **Real-build integration coverage** — `scripts/integration-test.sh` replaces the vitest-pool-workers approach that miniflare couldn't host (cross-package `?raw` imports).
+- **`style-src` split** — `style-src-elem` requires the nonce; `style-src-attr` keeps `'unsafe-inline'` for Astro's dynamic `style="…"` attrs; legacy `style-src` remains as a fallback for browsers that don't honour the split.
+
 ## Open work before deploy
 
-- **Self-recursion**: `fetch(request)` in `src/index.ts` re-enters the worker if both apex and `www.` routes are bound. Before binding, either rewrite the URL to a dedicated origin host (e.g. `adrianwedd.github.io`) or set a sentinel header + early-return. (#253 / Claude QA 2026-04-28.)
-- **Real-build integration test**: The vitest unit suite uses synthetic HTML fixtures. Real-build coverage (feeding actual `dist/*.html` through the worker) was attempted as a vitest-pool-workers test but `?raw` imports of files outside the package boundary aren't supported by miniflare's module loader. Lift this as a soak-time bash script: `wrangler dev` + `python -m http.server` against `dist/`, curl representative URLs, assert nonce + CSP header. (Codex QA 2026-04-28.)
-- **`style-src-attr` / `style-src-elem` split**: Currently `style-src 'self' 'unsafe-inline'` covers both inline `<style>` elements (which the worker nonces) and `style="…"` attributes (which it can't). Split lets us require nonce on elements and keep `'unsafe-inline'` only for attrs. Astro emits dynamic `style="animation-delay:…"` attrs so attr `'unsafe-inline'` must remain.
+- **Soak the production binding** — bind `worker-csp` to a staging hostname (or use a header bypass), verify Preact hydration, theme toggle, hero canvas, ConsentBanner, GA4, and LinkedIn Insight all run with no CSP violations. Once stable, uncomment the apex/www routes in `wrangler.toml`.

--- a/worker-csp/scripts/integration-test.sh
+++ b/worker-csp/scripts/integration-test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Real-build integration test for worker-csp.
+#
+# Boots a local HTTP server against ../dist/ as the upstream "GitHub Pages"
+# origin, runs `wrangler dev` with ORIGIN_HOST pointed at it, then curls
+# representative URLs and asserts that:
+#   - HTML responses carry a Content-Security-Policy header with a nonce
+#   - <script> and <style> tags in the body are nonced with the SAME value
+#   - Static assets (JS/CSS) pass through without a CSP header
+#
+# This is the lifted-out form of the integration test that miniflare's
+# vitest-pool-workers can't run (?raw imports across package boundaries).
+#
+# Run from worker-csp/: ./scripts/integration-test.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ORIGIN_PORT="${ORIGIN_PORT:-8765}"
+WORKER_PORT="${WORKER_PORT:-8787}"
+DIST_DIR="${DIST_DIR:-../dist}"
+
+if [[ ! -d "$DIST_DIR" ]]; then
+  echo "error: $DIST_DIR not found. Run 'npm run build' from the repo root first." >&2
+  exit 1
+fi
+
+if [[ ! -f "$DIST_DIR/index.html" ]]; then
+  echo "error: $DIST_DIR/index.html missing — is the build complete?" >&2
+  exit 1
+fi
+
+cleanup() {
+  # Kill by port — survives subshell-PID indirection that lets stray
+  # `python -m http.server` processes outlive ORIGIN_PID.
+  for port in "$ORIGIN_PORT" "$WORKER_PORT"; do
+    local pids
+    pids=$(lsof -ti:"$port" 2>/dev/null || true)
+    [[ -n "$pids" ]] && kill $pids 2>/dev/null || true
+  done
+  wait 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Preflight: stale process on either port silently breaks the test (the
+# readiness probe finds the wrong server). Refuse to run.
+for port in "$ORIGIN_PORT" "$WORKER_PORT"; do
+  if lsof -ti:"$port" >/dev/null 2>&1; then
+    echo "error: port $port already in use. Free it or set ORIGIN_PORT/WORKER_PORT." >&2
+    exit 1
+  fi
+done
+
+echo "→ starting origin server on :$ORIGIN_PORT (serving $DIST_DIR)"
+( cd "$DIST_DIR" && exec python3 -m http.server "$ORIGIN_PORT" >/tmp/csp-origin.log 2>&1 ) &
+ORIGIN_PID=$!
+
+echo "→ starting wrangler dev on :$WORKER_PORT (ORIGIN_HOST=localhost:$ORIGIN_PORT)"
+ORIGIN_HOST="localhost:$ORIGIN_PORT" ORIGIN_PROTOCOL="http" \
+  npx wrangler dev --port "$WORKER_PORT" --var "ORIGIN_HOST:localhost:$ORIGIN_PORT" --var "ORIGIN_PROTOCOL:http" \
+  >/tmp/csp-worker.log 2>&1 &
+WORKER_PID=$!
+
+# Wait for both to be ready.
+for i in {1..30}; do
+  if curl -fsS "http://localhost:$ORIGIN_PORT/index.html" >/dev/null 2>&1 \
+     && curl -fsS "http://localhost:$WORKER_PORT/" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! curl -fsS "http://localhost:$WORKER_PORT/" >/dev/null 2>&1; then
+  echo "error: worker did not come up. Last 30 lines of /tmp/csp-worker.log:" >&2
+  tail -30 /tmp/csp-worker.log >&2
+  exit 1
+fi
+
+fail=0
+assert_csp() {
+  local path="$1" desc="$2"
+  echo "→ checking $desc ($path)"
+  local headers tmp_body
+  # Single GET — separate HEAD/GET each generate a fresh nonce, so the
+  # header nonce wouldn't match scripts in the body. Body stays on disk
+  # because shell command substitution mangles binary or large payloads.
+  tmp_body=$(mktemp)
+  headers=$(curl -sS -D - -o "$tmp_body" "http://localhost:$WORKER_PORT$path")
+
+  local csp
+  # Case-insensitive grep + cut: BSD awk on macOS ignores IGNORECASE, so
+  # `Content-Security-Policy:` would slip past a lowercase awk pattern.
+  csp=$(printf '%s' "$headers" | grep -i '^content-security-policy:' | head -1 | sed 's/^[^:]*: //')
+  if [[ -z "$csp" ]]; then
+    echo "  ✗ missing Content-Security-Policy header" >&2; fail=1; return
+  fi
+
+  local header_nonce
+  header_nonce=$(printf '%s' "$csp" | sed -n "s/.*'nonce-\\([^']*\\)'.*/\\1/p")
+  if [[ -z "$header_nonce" ]]; then
+    echo "  ✗ no 'nonce-…' in CSP header" >&2; fail=1; return
+  fi
+
+  # Fixed-string match: nonces are base64 and may contain '+' / '/', which
+  # are regex metacharacters under -E.
+  if ! grep -qF "nonce=\"$header_nonce\"" "$tmp_body"; then
+    echo "  ✗ header nonce $header_nonce not found in body" >&2
+    echo "    body nonces: $(grep -oE 'nonce="[^"]+"' "$tmp_body" | sort -u | head -3 | tr '\n' ' ')" >&2
+    rm -f "$tmp_body"; fail=1; return
+  fi
+
+  if grep -q '<meta http-equiv="Content-Security-Policy"' "$tmp_body"; then
+    echo "  ✗ build-time meta CSP not stripped" >&2
+    rm -f "$tmp_body"; fail=1; return
+  fi
+
+  rm -f "$tmp_body"
+  echo "  ✓ nonce $header_nonce attached to scripts; meta CSP stripped"
+}
+
+assert_passthrough() {
+  local path="$1"
+  echo "→ checking static asset passes through ($path)"
+  local headers
+  headers=$(curl -sSI "http://localhost:$WORKER_PORT$path")
+  if printf '%s' "$headers" | grep -qi '^content-security-policy:'; then
+    echo "  ✗ unexpected CSP header on static asset" >&2; fail=1; return
+  fi
+  echo "  ✓ no CSP header (correct)"
+}
+
+assert_csp "/" "homepage"
+assert_csp "/about/index.html" "about page"
+assert_csp "/blog/index.html" "blog index"
+
+# Pick a real built JS asset to verify pass-through.
+asset=$(find "$DIST_DIR/_astro" -maxdepth 1 -name '*.js' -type f -print -quit 2>/dev/null || true)
+if [[ -n "$asset" ]]; then
+  assert_passthrough "/_astro/$(basename "$asset")"
+fi
+
+if (( fail )); then
+  echo "✗ integration test failed"
+  exit 1
+fi
+echo "✓ integration test passed"

--- a/worker-csp/src/csp.ts
+++ b/worker-csp/src/csp.ts
@@ -5,10 +5,11 @@
  * meta) but replaces 'unsafe-inline' on script-src with a per-request nonce,
  * adds frame-ancestors, and uses a real header instead of a meta tag.
  *
- * style-src keeps 'unsafe-inline' for now. Astro emits style=".." attributes
- * dynamically, which require style-src-attr 'unsafe-inline' under CSP3. We
- * can split style-src-elem (nonce-only) and style-src-attr ('unsafe-inline')
- * in a follow-up; for the first pass, keep both relaxed.
+ * style-src is split CSP3-style: style-src-elem requires the nonce on
+ * <style> blocks (the worker injects it), while style-src-attr keeps
+ * 'unsafe-inline' because Astro emits dynamic style=".." attributes that
+ * the worker can't nonce. Legacy style-src is the union, kept for browsers
+ * that don't yet honour the -elem/-attr split.
  */
 export function buildCsp(opts: { nonce: string; strictDynamic: boolean }): string {
   const { nonce, strictDynamic } = opts;
@@ -37,6 +38,8 @@ export function buildCsp(opts: { nonce: string; strictDynamic: boolean }): strin
   const directives = [
     "default-src 'self'",
     `script-src ${scriptSrc.join(' ')}`,
+    `style-src-elem 'self' 'nonce-${nonce}'`,
+    "style-src-attr 'unsafe-inline'",
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: https://cdn.adrianwedd.com https://www.google-analytics.com https://*.google-analytics.com https://px.ads.linkedin.com https://www.googletagmanager.com https://*.tile.openstreetmap.org https://tpc.googlesyndication.com https://googleads.g.doubleclick.net https://www.linkedin.com",
     "connect-src 'self' https://*.google-analytics.com https://analytics.google.com https://*.g.doubleclick.net https://adservice.google.com https://ep1.adtrafficquality.google https://ep2.adtrafficquality.google https://snap.licdn.com https://px.ads.linkedin.com https://pagead2.googlesyndication.com https://api.book.adrianwedd.com https://api.github.com https://cdn.adrianwedd.com https://ops.adrianwedd.com https://challenges.cloudflare.com",

--- a/worker-csp/src/index.ts
+++ b/worker-csp/src/index.ts
@@ -25,13 +25,23 @@ import { generateNonce } from './nonce.js';
 
 export interface Env {
   STRICT_DYNAMIC: string;
+  // Hostname (or host:port) of the origin to fetch from. Decoupling the
+  // upstream host from the inbound request hostname avoids self-recursion
+  // when both apex and www routes are bound, and lets local integration
+  // tests point the worker at a localhost http server.
+  //
+  // Production: "adrianwedd.github.io" (the GitHub Pages origin).
+  // Local test: "localhost:8000" with ORIGIN_PROTOCOL="http".
+  ORIGIN_HOST: string;
+  // Protocol for upstream fetches. Defaults to "https" if unset/empty.
+  ORIGIN_PROTOCOL?: string;
 }
 
 const HTML_CONTENT_TYPE = /^text\/html\b/i;
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    const upstream = await fetch(request);
+    const upstream = await fetch(originRequest(request, env));
     const contentType = upstream.headers.get('content-type') ?? '';
     if (!HTML_CONTENT_TYPE.test(contentType)) return upstream;
 
@@ -74,6 +84,20 @@ export default {
     return rewritten;
   },
 } satisfies ExportedHandler<Env>;
+
+function originRequest(request: Request, env: Env): Request {
+  const host = env.ORIGIN_HOST;
+  // Defensive: if ORIGIN_HOST isn't set we'd self-recurse on multi-route
+  // bindings. Surface the misconfiguration instead of silently looping.
+  if (!host) throw new Error('ORIGIN_HOST is not configured');
+  const protocol = env.ORIGIN_PROTOCOL || 'https';
+  const inbound = new URL(request.url);
+  const upstream = new URL(`${protocol}://${host}${inbound.pathname}${inbound.search}`);
+  // Preserve method/body/headers; just retarget the URL. GitHub Pages serves
+  // the right site by Host header — passing the upstream host (adrianwedd.github.io)
+  // returns the same content as the custom domain.
+  return new Request(upstream, request);
+}
 
 class NonceInjector {
   constructor(private readonly nonce: string) {}

--- a/worker-csp/test/index.test.ts
+++ b/worker-csp/test/index.test.ts
@@ -52,6 +52,18 @@ describe('buildCsp', () => {
     expect(csp).toMatch(/media-src [^;]*https:\/\/cdn\.adrianwedd\.com/);
   });
 
+  it('splits style-src-elem (nonce) from style-src-attr (unsafe-inline)', () => {
+    // <style> tags get the nonce from the worker, but Astro emits dynamic
+    // style="…" attrs that can't be nonced — keep 'unsafe-inline' for attrs
+    // only, while elements require the nonce.
+    const csp = buildCsp({ nonce: 'STYLENONCE', strictDynamic: false });
+    const elem = csp.split(';').find((d) => d.trim().startsWith('style-src-elem'))!;
+    const attr = csp.split(';').find((d) => d.trim().startsWith('style-src-attr'))!;
+    expect(elem).toMatch(/'nonce-STYLENONCE'/);
+    expect(elem).not.toMatch(/'unsafe-inline'/);
+    expect(attr).toMatch(/'unsafe-inline'/);
+  });
+
   it('keeps adservice.google.com in both script-src and connect-src', () => {
     // adservice issues XHR/beacon calls in addition to loading scripts; if
     // one side is missing the request fails silently in production.
@@ -66,7 +78,7 @@ describe('buildCsp', () => {
 describe('worker fetch handler', () => {
   it('passes through non-HTML responses untouched', async () => {
     fetchMock
-      .get('https://adrianwedd.com')
+      .get('https://adrianwedd.github.io')
       .intercept({ path: '/_astro/page.js' })
       .reply(200, 'console.log(1)', { headers: { 'content-type': 'application/javascript' } });
 
@@ -80,7 +92,7 @@ describe('worker fetch handler', () => {
       '<meta http-equiv="Content-Security-Policy" content="default-src none">' +
       '<script>console.log(1)</script>' +
       '<style>body{color:red}</style>';
-    fetchMock.get('https://adrianwedd.com').intercept({ path: '/' }).reply(200, htmlBody(body), {
+    fetchMock.get('https://adrianwedd.github.io').intercept({ path: '/' }).reply(200, htmlBody(body), {
       headers: { 'content-type': 'text/html; charset=utf-8' },
     });
 
@@ -115,7 +127,7 @@ describe('worker fetch handler', () => {
     // foreign nonce would silently CSP-block that script under enforcement.
     const body = '<script nonce="external">x</script>';
     fetchMock
-      .get('https://adrianwedd.com')
+      .get('https://adrianwedd.github.io')
       .intercept({ path: '/replace' })
       .reply(200, htmlBody(body), {
         headers: { 'content-type': 'text/html; charset=utf-8' },
@@ -133,7 +145,7 @@ describe('worker fetch handler', () => {
     // ETag/Last-Modified/Content-Length no longer match. Leaving them risks
     // truncated responses and incorrect 304 cache hits.
     fetchMock
-      .get('https://adrianwedd.com')
+      .get('https://adrianwedd.github.io')
       .intercept({ path: '/cached' })
       .reply(200, htmlBody('<script>x</script>'), {
         headers: {
@@ -155,7 +167,7 @@ describe('worker fetch handler', () => {
     // Regression: spreading a Response copies own enumerable props only,
     // which loses status/statusText. 404 must remain 404.
     fetchMock
-      .get('https://adrianwedd.com')
+      .get('https://adrianwedd.github.io')
       .intercept({ path: '/missing' })
       .reply(404, htmlBody('<h1>not found</h1>'), {
         headers: { 'content-type': 'text/html; charset=utf-8' },
@@ -167,7 +179,7 @@ describe('worker fetch handler', () => {
   });
 
   it('preserves upstream redirects without rewriting body', async () => {
-    fetchMock.get('https://adrianwedd.com').intercept({ path: '/legacy' }).reply(301, '', {
+    fetchMock.get('https://adrianwedd.github.io').intercept({ path: '/legacy' }).reply(301, '', {
       headers: {
         'content-type': 'text/html; charset=utf-8',
         location: '/new-location/',
@@ -177,5 +189,20 @@ describe('worker fetch handler', () => {
     const res = await SELF.fetch('https://adrianwedd.com/legacy', { redirect: 'manual' });
     expect(res.status).toBe(301);
     expect(res.headers.get('location')).toBe('/new-location/');
+  });
+
+  it('fetches from ORIGIN_HOST, not the inbound hostname (no self-recursion)', async () => {
+    // The interceptor only matches the configured origin; if the worker still
+    // fetched the inbound host, fetchMock would error on the unmatched call.
+    fetchMock
+      .get('https://adrianwedd.github.io')
+      .intercept({ path: '/about/' })
+      .reply(200, htmlBody('<script>x</script>'), {
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      });
+
+    const res = await SELF.fetch('https://www.adrianwedd.com/about/');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-security-policy')).toBeTruthy();
   });
 });

--- a/worker-csp/wrangler.toml
+++ b/worker-csp/wrangler.toml
@@ -23,6 +23,11 @@ compatibility_flags = ["nodejs_compat"]
 # Leave 0 until all dynamically-loaded scripts (Preact hydration, etc.) are
 # verified — strict-dynamic disables the host allowlist (the failure mode in #241).
 STRICT_DYNAMIC = "0"
+# Upstream origin. Decouples the upstream host from the inbound hostname so
+# the worker can't self-recurse when both apex and www routes are bound, and
+# so local integration tests can point at http://localhost:8000.
+ORIGIN_HOST = "adrianwedd.github.io"
+ORIGIN_PROTOCOL = "https"
 
 [observability]
 enabled = true


### PR DESCRIPTION
## Summary

Resolves the three local blockers tracked in `worker-csp/README.md` before binding the worker to production. Issue #253.

- **Self-recursion**: replace `fetch(request)` with a fetch against `${ORIGIN_PROTOCOL}://${ORIGIN_HOST}${pathname}`. Default origin is `adrianwedd.github.io` (the GitHub Pages origin). Decouples upstream from the worker's route hostname so the worker can't re-enter itself if both apex and www routes are bound, and lets the integration test point at `localhost`.
- **`style-src` split**: add `style-src-elem 'self' 'nonce-…'` (the worker nonces all `<style>` elements) and `style-src-attr 'unsafe-inline'` (Astro emits dynamic `style="…"` attrs that can't be nonced). Legacy `style-src` kept as a fallback for browsers that don't honour the `-elem` / `-attr` split.
- **Real-build integration test**: `worker-csp/scripts/integration-test.sh` boots `python -m http.server` against `../dist/` and `wrangler dev` with `ORIGIN_HOST` pointed at it, then asserts HTML responses carry a CSP header whose nonce matches the nonce attached to `<script>` tags in the body, and that the build-time meta CSP is stripped. Replaces the vitest-pool-workers approach that miniflare couldn't host (cross-package `?raw` imports).

Unit tests: **16/16 pass** (two added: `style-src-elem`/`-attr` split, `ORIGIN_HOST` routing).
Integration test: passes against a real `npm run build` of the site.

## Test plan

- [x] `cd worker-csp && npm test` — 16/16
- [x] `npm run build` (repo root), then `cd worker-csp && ./scripts/integration-test.sh` — passes
- [x] `npx astro check` — 0 errors
- [x] `npm run lint` — clean
- [ ] After merge: bind to a soak hostname and verify Preact hydration / theme toggle / hero canvas / ConsentBanner / GA4 / LinkedIn Insight all run with no CSP violations before flipping production routes.

Refs #253.