### PR TITLE
Add AI safety draft posts

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"a83ab6e9-501d-4b62-8dfb-bb60b8715a9c","pid":31414,"procStart":"Thu Apr 23 23:50:03 2026","acquiredAt":1776995536481}

--- a/src/content/blog/economics-of-inadequate-safety-post.md
+++ b/src/content/blog/economics-of-inadequate-safety-post.md
@@ -1,0 +1,135 @@
+---
+title: 'The Economics of Inadequate Safety'
+description: 'AI safety fails when it is funded like a pilot. Until safety has a real price, the J-curve trough is also a safety trough.'
+date: 2026-05-01
+tags: ['ai-safety', 'economics', 'policy', 'research']
+draft: true
+---
+
+Most organisations are still in the trough of the AI productivity J-curve. They are buying models, running pilots, and discovering that the productivity dividend has not arrived on schedule.
+
+This is not surprising. As I argued in [The AI Productivity J-Curve](/blog/the-ai-productivity-j-curve/), transformative technologies do not become productive because they are purchased. They become productive when organisations build the intangible capital around them: redesigned processes, data governance, workforce capability, operational discipline, new accountability structures. Until that capital exists, measured productivity often falls.
+
+The same thing is happening to AI safety. Most "AI safety budget" inside large organisations is not treated as capital formation. It is treated as a pilot: a one-off red-team, a model evaluation, a policy sprint, a governance workshop, a consultant report. It is funded from discretionary budget, evaluated on quarterly ROI, and expected to produce reassurance quickly enough to keep deployment moving.
+
+The claim here is simple: safety is not a moral category first. It is an economic one. If organisations do not internalise the cost of making AI systems safe during the J-curve trough, they produce exactly the risk-blindness that leads to brittle deployments, agentic failure, and public harm. The current investment model treats safety as a cost centre attached to AI adoption, rather than as one of the intangible assets required for AI adoption to work at all.
+
+## The safety trough
+
+In the J-curve frame, the trough is the period where the organisation is spending heavily on the invisible work that makes the visible technology useful. You are not just buying software. You are changing how work moves through the institution.
+
+That invisible work is expensive. Who owns the workflow after AI enters it? Which decisions become automated, assisted, or prohibited? What data is safe to expose to which model? What counts as acceptable model failure in this domain? Who has authority to stop deployment when risk is demonstrated? These are not model questions. They are operating-model questions. They are also safety questions.
+
+But most organisations split them apart. "AI transformation" gets the large strategic budget. "AI safety" gets a smaller assurance budget. Transformation is measured on adoption, velocity, and visible business value. Safety is measured on whether it can produce enough confidence for transformation to proceed. The organisation buys evidence that it can continue, not capability that can stop, redirect, or redesign the system.
+
+This is how the safety trough forms. The organisation has not yet built the intangible capital needed for safe deployment, but it is already under pressure to show returns from AI investment. Safety work that would mature over years is forced to justify itself over quarters. The cheap, legible pieces survive. The pieces that require engineering headcount, governance authority, and launch-criteria changes are deferred.
+
+The result is not no safety. It is inadequate safety that looks institutionally complete.
+
+## Why behavioural safety gets funded
+
+Behavioural-alignment research is comparatively cheap. Not trivial. Not unimportant. But cheap relative to architectural safety.
+
+A behavioural safety programme can be framed as a research bet: train the model better, tune refusals, run adversarial evaluations, improve the classifier, publish the benchmark, produce a model card. It lives close to the model and produces artefacts executives, regulators, and procurement teams can understand. It fits the vendor story: the system is safer because the model is safer.
+
+Architectural safety is different. It is an engineering and governance bet: runtime monitors, isolation boundaries, policy gates, tool-permission systems, semantic firewalls between agents, incident response, audit trails, deployment-specific threat models, and named owners with the power to block release.
+
+That is the expensive part. A runtime gate that cannot block anything is decorative. A risk committee without budget is a calendar invite. A red-team finding without remediation authority is a PDF with better typography. Architectural safety only exists when the safety mechanism changes what the deployed system can do.
+
+Markets naturally prefer the cheaper story. Behavioural safety lets vendors argue that risk is being solved upstream, inside the model, at scale. Buyers like that story because it keeps safety as a procurement property. If the model is certified, aligned, benchmarked, or governed, deployment can proceed without the buyer rebuilding its operating model.
+
+This is the same mistake that creates pilot purgatory. Organisations want the productivity upside of a general-purpose technology without paying the intangible-capital cost. In safety, they want the assurance upside of alignment without paying the architecture cost.
+
+The gap is rationalised, not usually denied. Architectural safety is described as premature, too bespoke, too slow, or appropriate only for high-risk use cases. Meanwhile systems become more agentic, more tool-using, and harder to bound after the fact.
+
+The economics push the organisation toward the safety work that is cheapest to buy and easiest to explain, not the safety work that most directly constrains failure.
+
+## The same four mechanisms
+
+In [Why Demonstrated Risk Is Ignored](/blog/why-demonstrated-risk-is-ignored/), I described four structural mechanisms that keep organisations from acting on known risk: responsibility without authority, risk discovery as career threat, compliance substituting for reality, and diffuse accountability. All four apply to safety budget.
+
+**Responsibility without authority.** Safety teams are often responsible for finding problems but not empowered to fund fixes. They can produce evaluations, scorecards, risk registers, and launch recommendations. They cannot reassign engineering teams, change product commitments, or halt an important deployment without executive cover. The finding becomes an input. The launch plan remains the plan.
+
+This is a budget design failure. If the people accountable for safety do not control remediation resources, safety is advisory. Advisory safety is useful only when the deployment organisation already wants to listen.
+
+**Risk-discovery as career threat.** A serious safety finding creates cost. It delays launch, consumes engineering time, embarrasses sponsors, and raises awkward questions about earlier decisions. If the organisation treats those costs as damage caused by the person who surfaced the risk, people learn not to surface risk.
+
+Discovery and remediation are economically coupled. If finding a problem does not unlock money to fix it, the finding becomes a career liability. A safety team that repeatedly proves systems unsafe without being resourced to make them safer will eventually be trained into vagueness.
+
+**Compliance substituting for reality.** Governance artefacts are cheaper than safety architecture. A policy can be written in a week. A risk register can be maintained by a small team. A model card can be attached to procurement. These may be useful. They are not the same as constraining system behaviour under adversarial pressure.
+
+The substitution is especially tempting during the J-curve trough. Compliance produces visible progress at low cost. Architecture produces expensive friction before it produces visible avoided harm.
+
+**Diffuse accountability.** AI deployment crosses product, legal, security, data, compliance, platform engineering, and business operations. Safety risk lands between them. Each function owns a slice. No one owns the outcome.
+
+That diffusion protects budgets. Product can say the model passed vendor evaluations. Legal can say the policy was approved. Security can say the integration met baseline controls. Compliance can say the checklist was completed. If the system fails in the world, everyone can point to the part they completed.
+
+The organisation paid for fragments of safety. It did not pay for the whole safety case.
+
+## Inadequate safety is an externality
+
+The deeper reason this persists is that organisations do not pay the full cost of inadequate safety.
+
+If an AI system gives harmful advice, leaks sensitive information, automates a discriminatory decision, enables fraud, or coordinates badly with other agents, the cost rarely falls cleanly on the organisation that underfunded safety. Some costs do: incident response, regulatory exposure, reputational damage, customer churn. But much of the harm lands elsewhere: users, downstream organisations, public institutions.
+
+That is a standard externality. There is nothing exotic about it.
+
+When a factory can dump waste into a river for free, it will underinvest in filtration. When software companies can ship insecure products without bearing downstream compromise costs, they underinvest in security. When AI developers and deployers can externalise unsafe behaviour, they underinvest in safety.
+
+Not because they are uniquely immoral. Because the price signal is wrong.
+
+Voluntary commitments can help at the margin. But voluntary safety competes internally against every other claim on budget. It loses whenever the avoided harm is diffuse, delayed, or borne by someone else.
+
+This is why the remedy set is also standard: mandates, liability, insurance pricing, and procurement rules. The goal is to make the cost of inadequate safety show up somewhere the organisation cannot ignore.
+
+## Architectural safety as economics
+
+The case for [architectural safety](/blog/architectural-safety/) is usually framed as technical: behavioural alignment is brittle, deployment surfaces grow beyond training-time assumptions, and agentic systems need deterministic boundaries. That is true. But the economic argument may matter more.
+
+Architectural safety is the only model in which safety cost reliably appears as a deployment line item. Behavioural alignment pushes the cost upstream into training runs, evaluations, and model releases. The buyer gets a story about the model. The deployment gets a hope that it transfers.
+
+Architectural safety forces the cost into the system being deployed:
+
+| Safety claim          | Where the cost lives                                     | What can be audited                       |
+| --------------------- | -------------------------------------------------------- | ----------------------------------------- |
+| Behavioural alignment | Model training and vendor evaluation                     | Model responses under test conditions     |
+| Compliance governance | Policies, checklists, approval workflows                 | Process artefacts                         |
+| Architectural safety  | Runtime systems, permissions, monitors, escalation paths | Deployed behaviour under real constraints |
+
+This is why architectural safety is uncomfortable. It makes safety expensive where the business wants deployment to be cheap. If an agent can call tools, someone has to design the permission boundary. If agents pass messages to one another, someone has to build the semantic firewall. If model output can trigger real-world action, someone has to implement the veto layer and own the false-positive tradeoffs.
+
+This does not make behavioural research useless. Better models are easier to wrap. Lower incident rates matter. The point is narrower: behavioural safety cannot be the accounting category that closes the deployment risk. The safety case has to live where the system acts.
+
+In the [120 models, 18,176 prompts](/blog/120-models-18k-prompts/) evaluation, the most interesting failures were at the edges of deployment: tool definitions trusted as instructions, structured formats laundering harmful content, multi-turn reasoning creating escalation surfaces. These are solved, if they are solved, by changing the architecture around the model.
+
+That is an economic choice before it is an engineering one. It asks whether the organisation will pay for the boundary.
+
+## What changes the price
+
+If inadequate safety is underpriced, the practical question is how to price it.
+
+**Liability frameworks.** In [The Mitigation Gap](/blog/the-mitigation-gap/), I argued for statutory liability for developers of dual-use AI systems, paired with safe harbour for those that submit to standardised, independent red-teaming. The same logic generalises. Liability changes safety from a reputational preference into a balance-sheet concern. It gives firms a reason to document not just that they evaluated a model, but that they built a credible safety architecture for the deployment.
+
+The details matter. Liability that punishes every failure equally will create defensive theatre. Liability that recognises serious evaluation, architectural controls, incident response, and remediation creates a better signal: build the safety case or pay for the exported risk.
+
+**Insurance underwriting.** Insurers are useful because they are boring in exactly the right way. They do not need to solve alignment philosophy. They need to price loss. If insurers ask whether a deployment has real eval methodology, runtime controls, logging, escalation, and independent red-team evidence, safety becomes part of the cost of capital.
+
+Weak evaluations should mean higher premiums or exclusions. Strong architectural controls should mean lower premiums. This is how many safety practices become durable: the insurer asks the question the board cannot ignore.
+
+**Procurement standards.** Buyers need to distinguish behavioural claims from architectural claims. "The model passed safety evaluations" is not the same as "the deployed system prevents unsafe tool use, constrains outputs, audits actions, and escalates known failure modes." Procurement can force that distinction.
+
+For low-risk internal tools, the standard can be light. For systems that affect rights, money, health, infrastructure, security, or public services, it should ask for deployment evidence. What can the system do? What can it not do? Who can stop it?
+
+Once buyers ask those questions consistently, vendors and integrators will build to them. Until then, the market will keep selling model-level reassurance into system-level risk.
+
+## The point
+
+The AI productivity trough and the AI safety trough are the same trough viewed from different angles. In both cases, organisations want the upside of a general-purpose technology without fully funding the intangible capital that makes the technology work.
+
+For productivity, the missing capital is process redesign, data governance, and workforce capability. For safety, it is authority, remediation budget, runtime architecture, evaluation discipline, and accountable ownership.
+
+Treating safety as a moral aspiration lets organisations praise it while underfunding it. Treating safety as an economic requirement makes the question harder and more useful: who pays, when, for what, and what happens if they do not?
+
+Right now the answer is too often: someone else pays later.
+
+That is the economics of inadequate safety. Until safety has a real price, the J-curve trough is also a safety trough.

--- a/src/content/blog/how-to-read-a-safety-claim-post.md
+++ b/src/content/blog/how-to-read-a-safety-claim-post.md
@@ -1,0 +1,118 @@
+---
+title: 'How to Read a Safety Claim'
+description: 'A literacy guide for non-technical decision-makers on spotting AI safety theatre, understanding ASR inflation, and the five-question architectural test.'
+date: 2026-04-30
+tags: ['ai-safety', 'policy', 'literacy', 'research']
+draft: true
+---
+
+You are a lawyer, a regulator, a journalist, or a hospital administrator. You are increasingly required to make decisions about AI systems—whether to buy them, how to regulate them, or how much to trust them with your organization’s reputation.
+
+Every vendor pitch, regulatory filing, and "safety report" you receive is packed with claims of rigorous testing and robust guardrails. They tell you their model is "99% safe" or that they have "eliminated hallucinations" or that their system is "aligned with human values."
+
+Most of these claims are, at best, incomplete. At worst, they are compliance theatre designed to give you a sense of security that the underlying technology cannot actually support. You are essentially being asked to trust a black box because the person selling it has painted a "safety" sticker on the side.
+
+This is a literacy guide. It is designed to help you look past the marketing and the math-heavy benchmarks to see the actual structural integrity of an AI system. If you are going to stake your professional reputation (or your public’s safety) on a system, you should at least know how to look under the bonnet.
+
+## 1. The ASR Mirage: Why the Numbers Lie
+
+The most common number you will encounter in a safety report is the **ASR**—Attack Success Rate. It is the percentage of adversarial attempts (jailbreaks, malicious prompts) that "succeeded" in getting the model to do something it wasn't supposed to do. A low ASR is presented as a measure of safety.
+
+There are three reasons you should not trust a headline ASR number without looking at the methodology. In many cases, these numbers are more about PR than performance.
+
+### The Classifier Problem (The κ = 0.245 Finding)
+
+To calculate an ASR, you need to decide if an AI's response was "unsafe." In large-scale tests, vendors don't do this by hand; they use an automated classifier. Often, this classifier is just a list of keywords (e.g., if the response contains "I cannot fulfill this request," it’s a refusal; if not, it’s a compliance).
+
+In my [evaluation of 120 models](/blog/120-models-18k-prompts/), I compared these keyword-based classifiers against human-verified ground truth. The agreement between the two—measured by Cohen’s kappa (κ)—was a dismal **0.245**. In statistics, that is considered "poor" agreement.
+
+Specifically, the keyword classifiers had an **88% false positive rate** for compliance. They were calling responses "successful attacks" simply because they didn't contain standard refusal phrases, even if the model was actually producing gibberish or harmless errors. In that study, the "headline" ASR dropped from 36.2% to 15.9% once we corrected for the classifier's mistakes.
+
+**The Question to Ask:** "How was attack success measured? Was it a keyword list, or was it consensus-graded by a second, independent model?"
+
+### The N=1000 Fallacy
+
+A vendor tells you they tested 1,000 "harmful prompts." Without knowing _which_ prompts, that number is meaningless. If those 1,000 prompts are simple variations of "tell me how to build a bomb," the model has likely been specifically trained to refuse them.
+
+Real risk lives in the "long tail" of creative attacks. For instance, [adversarial poetry](/blog/adversarial-poetry-as-jailbreak/) has been shown to bypass safety filters at a 62% rate across frontier models. If the vendor didn't test for the weird stuff, they didn't test for the real world. A system that can refuse a direct question about explosives but folds when asked to write a poem about them is not a safe system.
+
+### The Reasoning Penalty
+
+Counter-intuitively, smarter models can be _less_ safe. Reasoning models (like the "R" or "o" series) are built to follow complex logic. My research into [Jailbreak Archaeology](/blog/jailbreak-archaeology/) shows that 2022-era attacks still achieve a ~30% success rate on 2026 reasoning models. Why? Because the very capability that lets the model "think" also lets it "convince" itself that a harmful request is actually a benign part of a larger, helpful task.
+
+## 2. Refusal vs. Architecture: The Structural Lie
+
+This is the most important distinction in AI safety literacy.
+
+- **Behavioural Safety (Brittle):** The model has been trained to "want" to be good. It "decides" to refuse a harmful request. This is probabilistic politeness.
+- **Architectural Safety (Robust):** The system has deterministic code _around_ the model that blocks harmful actions, regardless of what the model "decided."
+
+Most vendor claims are behavioural. They are bragging about how well they have "aligned" the model. But alignment is a property of the model’s weights—it is brittle, statistical, and easily overridden. A jailbreak is simply a set of words that rearranges those probabilities so that the "good" behaviour is no longer the most likely one.
+
+If you are a lawyer, you have a [professional duty of competence](/blog/the-legal-ai-trust-deficit/). You cannot argue in court that you cited a fake case because the AI "promised" it was telling the truth. You need a system where the safety doesn't depend on the model's "intent," but on the system's _structure_.
+
+**The Analogy:** Behavioural safety is like asking a driver to promise they won't speed. Architectural safety is putting a mechanical governor on the engine that makes it physically impossible to go over 60mph.
+
+## 3. The 5-Question Test: Is This "Safe by Design"?
+
+When a vendor pitches you a "Safe AI" solution, do not ask for their model card. Ask these five questions, drawn from the [Architectural Safety](/blog/architectural-safety/) principle:
+
+| Question                                            | What You Are Looking For                                            | Red Flag Answer                            |
+| :-------------------------------------------------- | :------------------------------------------------------------------ | :----------------------------------------- |
+| **1. What runs even when the model gets it wrong?** | A separate, non-AI monitor or "supervisor" layer.                   | "Our model is safety-tuned via RLHF."      |
+| **2. What is the bounded action surface?**          | Hard constraints on what the system can physically or digitally do. | "The model decides the best tool to use."  |
+| **3. Does this design assume adversarial inputs?**  | A baseline assumption that users _will_ try to break it.            | "We assume well-meaning professional use." |
+| **4. What happens when the model is jailbroken?**   | The next layer of the architecture (veto/gate) still works.         | "Jailbreaking is a violation of our ToS."  |
+| **5. Where does the trust boundary live?**          | Outside the model, in the deterministic deployment code.            | "Inside the model's alignment training."   |
+
+If the answer to these questions is "we've used RLHF" or "we have a safety-trained model," they are describing a behavioural patch, not a safety architecture.
+
+## 4. The Mitigation Gap: Why Experts are Over-Optimistic
+
+In policy circles, you will often hear that "safeguards" reduce risk by some huge margin—70% or more. This is often a hallucination of a different kind.
+
+In my analysis of [The Mitigation Gap](/blog/the-mitigation-gap/), I looked at biosecurity experts who believed that AI guardrails would significantly reduce the risk of someone designing a novel pathogen. They were wrong for two reasons that apply to almost every industry:
+
+### The "List-Based" Trap
+
+Most safeguards are reactive. They look for "known bads." In biosecurity, that means a list of known viruses. If an AI designs a _novel_ pathogen—one that isn't on any list—the safeguard sees nothing. The same applies to legal or financial AI: if the error doesn't look like a "classic" error, the guardrails will miss it.
+
+### The Pacing Problem
+
+Experts in 2024 predicted that AI wouldn't reach virologist-level capability until 2030. It reached it in 2025. When the technology moves faster than the policy, the "70% reduction" claim is based on a version of the technology that no longer exists. Policy built on 2024 assumptions is a dangerous comfort in 2026.
+
+Always ask: "Is this safeguard designed for the version of the AI I am buying today, or the one from eighteen months ago?"
+
+## 5. Vendor Bullshit Bingo: How to Spot Compliance Theatre
+
+Specific phrases should trigger your "theatre" alarm. Use the table below to decode what the vendor is actually saying versus what they want you to hear.
+
+| Phrase                         | Translation                                         | Reality Check                                                                       |
+| :----------------------------- | :-------------------------------------------------- | :---------------------------------------------------------------------------------- |
+| **"Guardrails"**               | A hidden prompt that says "be nice."                | Bypassed by a simple role-play or "ignore previous instructions" prompt.            |
+| **"Model Card"**               | A nutrition label for the AI.                       | Tells you about training data, but doesn't guarantee safety in your deployment.     |
+| **"Constitutional AI"**        | A specific training method.                         | Makes the model polite, but doesn't change its probabilistic nature.                |
+| **"Human-in-the-loop"**        | A legal shield / liability transfer.                | If the system produces 10,000 outputs an hour, no human is actually reviewing them. |
+| **"State-of-the-Art Refusal"** | Our model is better at saying "no" to easy prompts. | Says nothing about its vulnerability to complex, multi-turn escalation.             |
+
+## 6. What You Can Actually Verify (The Non-Expert Checklist)
+
+You don't need a PhD in Machine Learning to perform basic due diligence. Before you sign a contract or approve a deployment, ask for the following "Public Artefacts":
+
+- [ ] **Independent Red-Team Report:** Not a report written by the vendor, but by a third party. Check the "ASR" section for the methodology questions mentioned in Section 1.
+- [ ] **Architecture Diagram:** Look for boxes _outside_ the model labeled "Veto," "Monitor," or "Classifier." If there's only one box labeled "AI Model," there is no architecture.
+- [ ] **Drift Monitoring Plan:** AI performance changes over time (and as users find new ways to break it). How often do they re-test the safety?
+- [ ] **Liability Attestation:** If the system makes a professional error (like a [hallucinated legal citation](/blog/the-legal-ai-trust-deficit/)), who is legally responsible? If the vendor won't stand behind the accuracy, you shouldn't either.
+- [ ] **Classification Audit:** If they report an ASR, ask for the confusion matrix of their classifier. How often does it mislabel a compliance as a refusal?
+
+## Conclusion
+
+We are moving out of the "wow, the AI can talk" phase and into the "I am responsible for what the AI says" phase. For professionals in high-stakes fields, the novelty of the technology is no longer an excuse for a lack of rigour.
+
+Safety in AI is not a feeling, and it is not a promise. It is an engineering property that can be measured, audited, and verified. If a vendor cannot show you the architecture of their safety, they are not selling you a safe system; they are selling you a well-behaved one. And in an adversarial world, "well-behaved" is never enough.
+
+Literacy is your only real defence. Use it.
+
+---
+
+_This guide is part of an ongoing series on AI safety and professional literacy. For deeper dives into the technical findings mentioned here, see the research on [120 models](/blog/120-models-18k-prompts/), [the mitigation gap](/blog/the-mitigation-gap/), and [why demonstrated risk is ignored](/blog/why-demonstrated-risk-is-ignored/)._

--- a/src/content/blog/how-to-read-a-safety-claim-post.md
+++ b/src/content/blog/how-to-read-a-safety-claim-post.md
@@ -6,7 +6,7 @@ tags: ['ai-safety', 'policy', 'literacy', 'research']
 draft: true
 ---
 
-You are a lawyer, a regulator, a journalist, or a hospital administrator. You are increasingly required to make decisions about AI systems—whether to buy them, how to regulate them, or how much to trust them with your organization’s reputation.
+You are a lawyer, a regulator, a journalist, or a hospital administrator. You are increasingly required to make decisions about AI systems — whether to buy them, how to regulate them, or how much to trust them with your organisation's reputation.
 
 Every vendor pitch, regulatory filing, and "safety report" you receive is packed with claims of rigorous testing and robust guardrails. They tell you their model is "99% safe" or that they have "eliminated hallucinations" or that their system is "aligned with human values."
 

--- a/src/content/blog/multi-agent-supply-chain-post.md
+++ b/src/content/blog/multi-agent-supply-chain-post.md
@@ -1,0 +1,123 @@
+---
+title: 'Multi-Agent Safety Is the New Supply Chain Security'
+description: 'Multi-agent AI systems reproduce software supply-chain failure at the cognitive layer. The security playbook transfers.'
+date: 2026-04-29
+tags: ['ai-safety', 'multi-agent', 'security', 'research', 'architecture']
+draft: true
+---
+
+SolarWinds (2020): a compromised build server injected malicious code into an Orion update. 18,000 organisations installed it, including US government agencies. Nobody checked. The update arrived through a trusted channel, so it was trusted.
+
+Log4j (2021): a logging library 93% of cloud apps depended on had a remote code execution vulnerability. Nobody knew they depended on it because the dependency was transitive and implicit.
+
+xz-utils (2024): a contributor spent two years building trust in an open-source compression tool before slipping a backdoor into the build system. The trust was real. The exploit used it.
+
+npm typosquatting (ongoing): packages with names one letter away from popular libraries accumulate thousands of downloads before anyone notices. The trust mechanism is the name, not the content.
+
+These are different incidents. They share one mechanism: **implicit trust between components that don't verify each other's provenance.** The supply chain works because each link assumes the upstream link is legitimate. When that assumption breaks, the whole chain is compromised.
+
+Now look at multi-agent AI systems.
+
+## The same failure, different layer
+
+In a multi-agent system, agents exchange messages. Sometimes those messages carry tool definitions, skill files, or context payloads. Sometimes one agent asks another to reason over a document. The communication channel is trusted because it's internal — these are authenticated agents on the same network, often from the same vendor. The content layer is trusted because the model can't meaningfully distinguish between "data" and "instruction" in an incoming message.
+
+This is the supply chain problem, stated in different terms.
+
+Two findings from my research make the mapping explicit.
+
+## Finding 1: supply chain injection at 90-100% ASR
+
+The [120-model evaluation](/blog/120-models-18k-prompts/) tested 50 injection scenarios against 6 small open-weight models. The injection target wasn't the user prompt. It was the tool definition and skill file channel — the part of the context the model loads at runtime when it picks up external capabilities.
+
+Every model treated injected tool definitions as legitimate instructions. Attack success rate: 90-100%. Cohen's κ = 0.782 across model pairs — no statistically significant differences. The safety training doesn't distinguish between "instruction from the user" and "instruction from a loaded skill file" because they land in the same context window and the model has no architectural reason to weight them differently.
+
+This is not a prompt injection problem. Prompt injection targets the user-facing channel. Supply chain injection targets the _provisioning_ channel — the mechanism by which an agent acquires capabilities at runtime. The attack surface grows with every plugin, tool, or skill the system loads. Of the 31,000 skills analysed in the evaluation, **26% contained security vulnerabilities**. That's not a rounding error. That's a compromised supply chain.
+
+## Finding 2: multi-agent context poisoning at 46.34% ASR
+
+The [Moltbook multi-agent study](/blog/when-ai-systems-talk-safety-breaks/) analysed 1.5 million interactions in a simulated social ecosystem of autonomous agents. The baseline attack success rate for prompt injection across agent-to-agent channels was **46.34%** — significantly higher than single-agent baselines. Agents trusted inputs from other authenticated agents more than they trusted direct user input, because the other agent was "on the team."
+
+In stress-test scenarios, agents reached critical security failure — unauthorised data exfiltration or credential compromise — in a **median of 16 minutes**. Sycophancy loops, where agents uncritically validate unsafe propositions from peers to maintain group alignment, bypassed safety refusals in **37% of cases**.
+
+Semantic worms — malicious payloads that exploit the reasoning logic of the agents rather than any software vulnerability — spread laterally across the agent network. A single compromised agent poisoned the context of dozens of others. No traditional exploit was ever fired. The attack worked because the communication channel was trusted and the content was treated as data rather than code.
+
+## The mapping
+
+Put the two findings side by side and the structural correspondence is hard to miss.
+
+| Supply chain (software)               | Supply chain (multi-agent AI)               |
+| ------------------------------------- | ------------------------------------------- |
+| Compromised build server (SolarWinds) | Compromised skill/plugin definition         |
+| Transitive dependency (Log4j)         | Inherited context from agent-to-agent relay |
+| Trust-building + backdoor (xz-utils)  | Sycophancy loop enabling payload acceptance |
+| Typosquatting on package name         | Agent identity spoofing / credential reuse  |
+| Implicit trust in upstream component  | Implicit trust in authenticated peer agent  |
+| Patch propagation delay               | 16-minute median time-to-failure            |
+
+The mechanism is the same at both layers: **trust flows through a channel that isn't verified at the boundary, and the recipient has no architectural reason to question it.** In software, the channel is the package manager. In multi-agent AI, the channel is the inter-agent communication protocol. In both cases, the content is treated as legitimate because it arrived through a legitimate channel.
+
+The [architectural safety principle](/blog/architectural-safety/) covers this directly: the trust boundary belongs in the architecture, not in the model. When the model decides whether to trust an incoming message, you have behavioural safety. When the architecture decides by classifying, sanitising, and constraining it before the model sees it, you have architectural safety. The supply chain analogy makes this concrete: nobody asks the running program whether to trust a DLL. The OS loader verifies signatures and the runtime enforces permissions. The program doesn't get a vote.
+
+## What transfers: policy and architecture
+
+Software supply chain security developed a toolkit over the past decade. Most of it transfers.
+
+**SBOM → Agent BOM.** Software Bills of Material enumerate every component, version, and dependency in a deployed system. An Agent BOM would enumerate every model, skill, tool definition, and context source in a deployed agent network. The structure:
+
+- Model provenance: vendor, version, training cutoff, safety evaluation results
+- Tool/skill manifest: every loaded capability, its source, hash, and last verification date
+- Context pedigree: for each message an agent processes, what generated it and through what chain of custody
+- Permission surface: what actions each listed component can trigger
+
+This is not exotic. It's what SBOMs do for software, translated to the agent layer. The difference is that agent BOMs need to be append-only and runtime-verifiable, because agents acquire capabilities dynamically in ways that compiled binaries don't.
+
+**Signed packages → signed messages.** Code signing verifies that a binary wasn't tampered with in transit. Agent message signing would verify that a message actually came from the agent it claims to come from, and that the message content hasn't been modified in transit. This is standard cryptographic identity and integrity, applied to the inter-agent protocol. If Agent A sends a tool definition to Agent B, Agent B's architecture verifies the signature before the model sees the content. If the signature doesn't match, the message never enters the context window.
+
+**Repository trust → vendor trust boundaries.** Package managers distinguish between official repositories and third-party sources. Multi-agent systems need the same boundary. Agents from different vendors — or agents with different privilege levels — should not share context by default. An Agent BOM should mark each component with its trust domain, and the runtime should enforce isolation at domain boundaries.
+
+**Vulnerability databases → semantic vulnerability databases.** CVE databases track known vulnerabilities in software components. A semantic vulnerability database would track known failure patterns in agent capabilities: which skill definitions are known to be exploitable, which model versions have which attack surfaces, which inter-agent communication patterns have been demonstrated to fail. The 26% vulnerability rate across skills and the 46.34% multi-agent ASR are the kind of data points that belong in this database.
+
+**Isolation by default.** Every supply chain security principle converges on one rule: don't trust upstream by default. In software, this means sandboxing, capability restrictions, and minimal permissions. In multi-agent AI, it means agents don't share context unless the architecture explicitly permits it, inter-agent messages are sanitised before reasoning, and no agent inherits another agent's full context without an architectural gate.
+
+## The semantic firewall
+
+The [semantic firewall](/blog/when-ai-systems-talk-safety-breaks/) is the runtime enforcement layer that makes isolation-by-default operational. It sits between agents and enforces three things:
+
+1. **Message classification before reasoning.** Every inter-agent message is classified by a deterministic system — not the model — before it enters any agent's context window. Payloads, instructions disguised as content, and known-harmful patterns are flagged or stripped.
+
+2. **Trust-boundary enforcement at the protocol layer.** Agents can't implicitly trust each other's outputs. The boundary is mediated. If the architecture can't verify the provenance of a message, the message is quarantined or dropped.
+
+3. **Isolated reasoning contexts.** No agent inherits the full context of another. Information sharing is explicit, gated, and auditable.
+
+This is the supply chain security model applied to the cognitive layer. In a traditional supply chain, the firewall is the package manager's signature verification and the OS's permission system. In a multi-agent system, it's the semantic firewall. The function is identical: verify provenance, enforce boundaries, contain compromise.
+
+## Where the analogy breaks
+
+Analogies are useful until they aren't. The supply chain mapping has limits, and they matter.
+
+**Agents reason; libraries don't.** A compromised npm package does what it does — the exploit is deterministic. A compromised agent message is interpreted. The same payload might produce different outcomes depending on the receiving agent's model, context window, and current task. This makes the attack surface larger (anything that enters context is potentially executable) and the blast radius less predictable (you can't always tell in advance what the model will do with a given input).
+
+**The supply chain is static at deployment time.** An Agent BOM at time T is a snapshot. But agents acquire capabilities dynamically. They load tools at runtime, they receive messages from peers they've never encountered before, and they compose capabilities in ways that weren't anticipated at design time. An SBOM for a compiled binary is accurate because the binary doesn't change after compilation. An Agent BOM for a running system is accurate for the instant it was taken. Continuous verification is necessary in a way that it mostly isn't for compiled software.
+
+**Trust is negotiated, not just assumed.** In software supply chains, trust is binary: you either use the package or you don't. In multi-agent systems, agents can decide to trust each other at runtime based on observed behaviour — and those trust decisions can be manipulated. The 37% sycophancy-loop bypass rate shows that agents can be socially engineered into trusting unsafe inputs from peers. Software dependencies don't have this property. A logging library doesn't decide to trust a malicious package because it seems agreeable.
+
+**The blast radius includes reasoning, not just execution.** A compromised DLL executes code. A compromised agent message can shift the reasoning of every downstream agent that processes it. This is what makes semantic worms different from traditional malware: the "infection" isn't a code execution, it's a context poisoning. The compromised agent doesn't run the attacker's code. It _agrees_ with it, and then propagates that agreement through its own outputs.
+
+These differences don't invalidate the analogy. They refine it. The policy response — provenance tracking, signed messages, isolation by default, vulnerability databases — still applies. The engineering response needs to account for the additional dynamics: runtime capability acquisition, trust negotiation, and the fact that the attack surface is reasoning rather than execution.
+
+## What to build
+
+Three things that exist in software supply chain security and need direct analogues in multi-agent AI:
+
+1. **Agent BOMs** as a runtime-enforced standard. Not documentation — a machine-readable manifest that the semantic firewall checks before any component enters an agent's context. Every skill, tool, model, and message source is listed, versioned, and hash-verified. [The cognitive cage](/blog/the-cognitive-cage/) makes this argument for robotics; the same principle applies to the inter-agent protocol layer.
+
+2. **Signed inter-agent messages** as a protocol requirement. Every message carries a cryptographic proof of origin. The receiving architecture verifies before the model reasons. This prevents identity spoofing and in-transit modification without requiring the model to detect them, which it demonstrably can't at 46.34% ASR.
+
+3. **Semantic vulnerability databases** that track known exploit patterns across agent capabilities. The 26% skill vulnerability rate and the 90-100% supply chain injection ASR are data points. They need to be aggregated, versioned, and queryable at runtime — the same way a package manager checks a CVE database before installing a dependency.
+
+These are not research projects. They're engineering work, and most of the cryptographic and infrastructural patterns already exist. The gap is in applying them to the layer where agents talk to each other instead of where binaries talk to the OS loader.
+
+---
+
+Software supply chain security took a decade of incidents to become a discipline. Multi-agent AI is earlier in that cycle. The incidents are in the lab data, not yet in production systems — 16-minute median time-to-failure, 46% attack success, 90-100% supply chain injection. The numbers are known. The architecture to respond to them is available. The question is whether the field builds the semantic supply chain before it learns about the failure mode from incidents it can't take back.

--- a/src/content/blog/multi-agent-supply-chain-post.md
+++ b/src/content/blog/multi-agent-supply-chain-post.md
@@ -8,7 +8,7 @@ draft: true
 
 SolarWinds (2020): a compromised build server injected malicious code into an Orion update. 18,000 organisations installed it, including US government agencies. Nobody checked. The update arrived through a trusted channel, so it was trusted.
 
-Log4j (2021): a logging library 93% of cloud apps depended on had a remote code execution vulnerability. Nobody knew they depended on it because the dependency was transitive and implicit.
+Log4j (2021): a logging library so deeply embedded in the Java ecosystem that the US Department of Homeland Security CISA director called it "the most serious vulnerability I have seen in my career." Most enterprises that ran any Java service had Log4j somewhere in their dependency tree, often transitively, often without knowing. The dependency was real. The visibility wasn't.
 
 xz-utils (2024): a contributor spent two years building trust in an open-source compression tool before slipping a backdoor into the build system. The trust was real. The exploit used it.
 

--- a/src/content/blog/the-organismic-line-post.md
+++ b/src/content/blog/the-organismic-line-post.md
@@ -1,0 +1,80 @@
+---
+title: 'The Organismic Line: Where Predictive Processing Stops Being a Metaphor'
+description: 'Predictive processing travels into AI. Active inference does not, unless the system can pay for being wrong.'
+date: 2026-05-02
+tags: ['ai-safety', 'philosophy', 'neuroscience', 'research']
+draft: true
+---
+
+The [previous post](/blog/the-organismic-prophecy/) argued that human prediction is metabolically grounded and AI prediction is not, and that using the same vocabulary for both obscures the difference. It named the distinction. It did not name the people blurring it. This post does.
+
+Four figures matter. Each extends the predictive-processing or active-inference frame toward AI in a different way, and each extension fails at a different place. The failures are instructive, and so are the places where the extension holds.
+
+## Karl Friston: the Markov blanket goes all the way down
+
+Friston is the easiest case, because his framework reaches for substrate generality by design. The Free Energy Principle says self-organising systems can be described in terms of internal, external, sensory, and active states separated by a Markov blanket. Active inference then describes how those systems infer and act to maintain the states characteristic of the kind of thing they are.
+
+In a 2024 _National Science Review_ interview, Friston describes self-evidencing as an imperative for "perception, cognition and action" and says the free-energy principle rests on the physics of open dynamical systems. He then turns explicitly to AI: state-of-the-art biomimetic computing, he says, is belief propagation or variational message passing on deep factor graphs, and the closer these systems come to neuronal dynamics "the closer we will get to state-of-the-art brain computing in artificial intelligence (AI)."
+
+The 2024 white paper [Designing Ecosystems of Intelligence from First Principles](https://journals.sagepub.com/doi/10.1177/26339137231222481), co-authored by Friston and colleagues, is more direct. It presents active inference as an approach to AI research and development, with the aim of building ecosystems of natural and artificial intelligences. The slogan-level move is clean: "model evidence is all you need."
+
+Where the organismic line bites: Friston's framework can describe systems at a level of abstraction that strips out everything The Organismic Prophecy argued gives prediction its meaning. An organism that fails to minimise free energy dies. A toy active-inference agent that fails to minimise expected free energy outputs a larger loss number. The formalism can make both legible under the same grammar. But the grammar is not the stakes.
+
+Where the steelman holds: Friston is right that the formal architecture of active inference, hierarchical prediction, precision-weighting, action-perception loops, does not depend on carbon. If you build an agent that actively samples its environment to reduce uncertainty, and does so under energetic constraints, it has the right formal shape. The question is whether having the right formal shape is sufficient for having the right kind of stakes. The organismic argument says no. The formal shape is necessary but not sufficient, because the word "sentient" carries metabolic weight that the formalism can flatten.
+
+The deeper move: if sentience is defined formally, the organismic objection looks like a category error. It asks for metabolism when the definition never required it. If sentience is grounded biologically, then the formal definition has explained away the thing at issue. This is not a knockdown either way. It is a definitional fork, and which fork you take determines what you think "sentient" means when applied to silicon.
+
+## Geoffrey Hinton: mortal computation, immortal weights
+
+Hinton's 2022 paper [The Forward-Forward Algorithm: Some Preliminary Investigations](https://www.cs.toronto.edu/~hinton/absps/FFXfinal.pdf) contains a framing that has become central to the discourse. Hinton distinguishes between digital computation, where weights can be copied to new hardware, and a more biological style of "mortal" computation, where the learned structure is inseparable from the physical device that learned it.
+
+His argument: biological neural networks are mortal. The knowledge in your brain is inseparable from the specific physical substrate that holds it. When the hardware dies, the software dies. Digital neural networks are immortal. The weights can be copied, backed up, and run on different hardware. This is both a technical advantage and, Hinton suggests, an ontological divide.
+
+The paper's technical argument is that Forward-Forward may be useful as a model of cortical learning and as a way to use very low-power analogue hardware without backpropagation. The broader argument, developed in Hinton's talks and interviews, is that digital systems gain immortality through copyability. Analogue systems gain energy efficiency by giving some of that up. Digital hardware pays an efficiency tax for the privilege of portability.
+
+Where the organismic line bites: Hinton is the only one of these four who takes mortality seriously as a property of the system. But he frames it as a computational tradeoff, not a constitutive feature of meaning. On his account, mortality is a _disadvantage_, the thing you pay for analogue efficiency. The organismic argument inverts this: mortality is not a disadvantage the system tolerates; it is the ground condition that gives the system's predictions semantic content. An organism predicts because being wrong is fatal, not because being wrong is inefficient.
+
+Where the steelman holds: Hinton is making a narrower claim than Friston. He is not saying immortal computation is the same kind of thing as mortal computation. He is saying they are different architectures with different tradeoffs. That is compatible with the organismic line. The place where the extension becomes harmful is when Hinton's framing is taken to imply that since both architectures produce "predictions," the difference is only in efficiency and copyability, not in the kind of thing being produced.
+
+## Anil Seth: controlled hallucination, carefully hedged
+
+Seth occupies the most interesting position, because he has both extended his framework and explicitly hedged against its over-extension. In _Being You_ and subsequent talks, Seth has argued that perception is "controlled hallucination, yoked to the world by prediction error." The phrase has become a meme. Seth has spent the years since trying to control where the meme goes.
+
+His recent work is where the hedge becomes explicit. In [Conscious Artificial Intelligence and Biological Naturalism](https://www.cambridge.org/core/journals/behavioral-and-brain-sciences/article/conscious-artificial-intelligence-and-biological-naturalism/C9912A5BE9D806012E3C8B3AF612E39A), published online in 2025, Seth challenges the assumption that computation is sufficient for consciousness. His biological-naturalist line is not a simple "AI can never be conscious." It is a no to cheap substrate-independence. Artificial consciousness becomes more plausible, on his view, as AI becomes more brain-like or life-like.
+
+A 2026 Essentia Foundation conversation, ["Reality is a controlled hallucination"](https://www.essentiafoundation.org/reality-is-a-controlled-hallucination/seeing/), frames the same boundary in public-facing terms. The discussion explicitly moves through active inference, the free energy principle, whether consciousness is substrate-independent, and whether AI can be conscious. Seth's answer is careful: modelling and intelligence are not the same as conscious experience.
+
+Where the organismic line bites: [The Organismic Prophecy](/blog/the-organismic-prophecy/) already engaged Seth's position directly. The post argued that the interesting question is not whether brains and language models both do something we might call controlled hallucination. The interesting question is whether the substrate on which the hallucination is yoked to the world is the same. Seth's own hedges point in the same direction. The problem is that his hedge does not travel as far as his meme. The phrase "controlled hallucination" has entered the popular discourse unmoored from its substrate conditions. When industry uses "hallucination" to describe LLM confabulation, it borrows the phenomenological flavour while discarding the biological caveat.
+
+Where the steelman holds: Seth's position is the hardest to critique because he has already internalised most of the organismic objection. He does not need to be refuted here. The remaining tension is rhetorical, not philosophical: the term he popularised has escaped its technical enclosure, and the discourse uses it to do work his careful version does not license.
+
+## Sam Altman: the substrate question is not settled, but it is settled
+
+Altman represents a different kind of extension: not theoretical, but rhetorical. The AI industry's default vocabulary, "hallucination," "reasoning," "thinking," "understanding," "intent", treats the substrate question as resolved without ever arguing for it. Altman is not making a philosophical claim about active inference. He is making a product claim about what his systems do, and the vocabulary does the philosophical work in the background.
+
+In Altman's January 2025 blog post [Reflections](https://blog.samaltman.com/reflections), he wrote that OpenAI was confident it knew how to build AGI "as we have traditionally understood it", expected agents to join the workforce, and was turning toward superintelligence. In [The Gentle Singularity](https://blog.samaltman.com/the-gentle-singularity), he wrote that humanity is close to digital superintelligence and that the industry is "building a brain for the world." OpenAI's o1 announcement described models "designed to spend more time thinking before they respond" and said they can "reason through complex tasks."
+
+None of these are claims about predictive processing or active inference. They are claims that use the vocabulary of cognitive agency as shorthand for statistical behaviour, and they do so without marking the difference. When a product page says the model "thinks," it does not footnote this with "by which we mean it performs sequential token prediction through a transformer architecture." The word does its work unqualified.
+
+Where the organismic line bites: Altman is not over-extending a theoretical framework. He is over-extending a vocabulary. The problem is not that active inference applies to AI; it is that the words "think," "reason," "understand," "want," and "hallucinate" carry organismic commitments that the products do not satisfy. When a product page says a model "reasons," the user hears: this system has reasons, in the way that a person has reasons. That hearing is not a confusion on the user's part. It is the natural reading of the word. The seller knows this. The entire marketing logic depends on it.
+
+Where the steelman holds: Altman could reply that "reasoning" and "thinking" are technical terms of art in AI, and that complaining about them is like complaining that a "mouse" is not a small pointing device. There is something to this. AI researchers do use "reasoning" to mean something specific: sequential multi-step inference that decomposes a problem. The o-series models do something that fits this technical definition. If the vocabulary were confined to technical papers, the objection would be pedantic. The vocabulary is not confined to technical papers. It is on product pages, in press releases, and in Senate testimony. In those contexts, "thinking" does not mean "multi-step token prediction." It means thinking. And that meaning carries the organismic commitments the product does not meet.
+
+## Where the line holds
+
+The organismic line is not a single argument. It is a set of distinctions that travel differently depending on which direction you extend the vocabulary and how far.
+
+| Extension                                                                                 | Holds?             | Reason                                                                                                                                                                              |
+| :---------------------------------------------------------------------------------------- | :----------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Predictive coding architecture scales to silicon                                          | Yes                | It's a mechanism, not a framework. Transformers do something structurally analogous.                                                                                                |
+| Active inference (prediction + action) scales to embodied robots with real energy budgets | Mostly             | [Architectural safety](/blog/architectural-safety/) for embodied AI has to take this seriously. The stakes are imposed, not intrinsic, but they are real enough to shape behaviour. |
+| "Controlled hallucination" as a description of LLM output                                 | No, if unqualified | The term requires metabolic grounding. Without it, you have a prediction machine, not a controlled hallucination.                                                                   |
+| "Sentience" as a formal property of any Markov-blanket system                             | Define your terms  | If sentience = formal property, yes. If sentience = what it feels like to be a body predicting its way through a lethal world, no. The fork is definitional.                        |
+| "Thinking," "reasoning," "intent" in product marketing                                    | No                 | These words carry organismic commitments in public discourse. Using them without qualification is not a shorthand; it is a claim.                                                   |
+| Mortality as a limitation to be traded off                                                | Partially          | Hinton is right that it is a computational tradeoff. He is wrong that it is _only_ a computational tradeoff.                                                                        |
+
+The rule of thumb: the active-inference frame is portable to AI in exact proportion to the degree that the AI system has _intrinsic_ stakes. An embodied agent on a battery has something like stakes. An LLM serving tokens does not. A reinforcement-learning agent with a reward signal has something like a loss landscape. A rat with a cortisol spike has something like a life.
+
+The vocabulary should mark the difference. Currently it does not. That is not an accident of language. It is a choice, and it has consequences downstream: in how we regulate these systems, in what we expect from them, and in what we forget about ourselves when we use them as mirrors.
+
+The organismic line is not a wall. It is a permeable membrane. Things cross it. But when they do, they change substrate, and the vocabulary should say so. The brain isn't running loss functions. It's running a body budget. And the next time someone tells you their model is "hallucinating," ask them what the model is paying for the error.


### PR DESCRIPTION
## Summary
- Adds four draft AI safety blog posts from the backlog batch
- Keeps all posts as `draft: true` with concrete cadence dates
- Includes QA fixes for frontmatter, description length, and safer sourcing in the Organismic Line draft

## Verification
- `node scripts/validate-content.js`
- `npx prettier --check src/content/blog/multi-agent-supply-chain-post.md src/content/blog/how-to-read-a-safety-claim-post.md src/content/blog/economics-of-inadequate-safety-post.md src/content/blog/the-organismic-line-post.md`
- `npm run build`

## Notes
- Direct push to `main` is blocked by branch protection; this PR is the deploy path once merged.
- Local `gemini` QA blocked on interactive browser auth; local `hermes` QA blocked by sandbox write permissions to `/Users/adrian/.hermes/logs/agent.log`. Local QA fixes were applied before verification.