### PR TITLE
content: cinematic videos for safety quartet

### DIFF
--- a/src/content/blog/economics-of-inadequate-safety-post.md
+++ b/src/content/blog/economics-of-inadequate-safety-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'economics', 'policy', 'research']
 draft: false
 heroImage: '/notebook-assets/economics-of-inadequate-safety/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/economics-of-inadequate-safety/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/economics-of-inadequate-safety/video.mp4'
 audioDuration: '24:51'
 ---
 

--- a/src/content/blog/how-to-read-a-safety-claim-post.md
+++ b/src/content/blog/how-to-read-a-safety-claim-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'policy', 'literacy', 'research']
 draft: false
 heroImage: '/notebook-assets/how-to-read-a-safety-claim/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/how-to-read-a-safety-claim/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/how-to-read-a-safety-claim/video.mp4'
 audioDuration: '21:45'
 ---
 

--- a/src/content/blog/multi-agent-supply-chain-post.md
+++ b/src/content/blog/multi-agent-supply-chain-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'multi-agent', 'security', 'research', 'architecture']
 draft: false
 heroImage: '/notebook-assets/multi-agent-supply-chain/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/multi-agent-supply-chain/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/multi-agent-supply-chain/video.mp4'
 audioDuration: '23:17'
 ---
 

--- a/src/content/blog/the-organismic-line-post.md
+++ b/src/content/blog/the-organismic-line-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'philosophy', 'neuroscience', 'research']
 draft: false
 heroImage: '/notebook-assets/the-organismic-line/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-organismic-line/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-organismic-line/video.mp4'
 audioDuration: '21:21'
 ---
 


### PR DESCRIPTION
Adds `videoUrl` frontmatter to the four safety-quartet posts merged in #274.

| Post | Video |
|---|---|
| Multi-Agent Safety Is the New Supply Chain Security | 56MB cinematic |
| How to Read a Safety Claim | 49MB cinematic |
| The Economics of Inadequate Safety | 53MB cinematic |
| The Organismic Line | 44MB cinematic |

Generated via `nlm video create --format cinematic --focus '<brand prompt>'`. The `--focus` flag carries the canonical dark-botanical visual direction. Cinematic format ships with its own bundled aesthetic, but the focus prompt steers content framing.

NLM video pipeline transit-state observation: videos go in_progress → unknown → completed. The 'unknown' is misleading but transient. First cinematic attempt for each notebook eventually completed; later retry attempts also completed and were discarded.

All four uploaded to R2 at `cdn.adrianwedd.com/notebook-assets/<slug>/video.mp4`.