### PR TITLE
content: cinematic videos for AS + CBD

### DIFF
--- a/src/content/blog/architectural-safety-post.md
+++ b/src/content/blog/architectural-safety-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'research', 'engineering', 'policy']
 draft: false
 heroImage: '/notebook-assets/architectural-safety/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/architectural-safety/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/architectural-safety/video.mp4'
 audioDuration: '22:59'
 ---
 

--- a/src/content/blog/non-coercive-design-post.md
+++ b/src/content/blog/non-coercive-design-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'neurodivergence', 'engineering', 'philosophy', 'research']
 draft: false
 heroImage: '/notebook-assets/non-coercive-design/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/non-coercive-design/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/non-coercive-design/video.mp4'
 audioDuration: '23:33'
 ---
 


### PR DESCRIPTION
Adds the cinematic videos that were missing from /blog/architectural-safety/ (70MB) and /blog/non-coercive-design/ (40MB). Generated with the working pattern: `--format cinematic --focus '<brand prompt>'`.