### PR TITLE
fix(social-autopublish): send type=text to bypass FB Pages link-stripping

### DIFF
--- a/.github/workflows/social-autopublish.yml
+++ b/.github/workflows/social-autopublish.yml
@@ -80,16 +80,21 @@ jobs:
               [ -z "$PLATFORM" ] && continue
               IDEMPOTENCY_KEY="auto-${PLATFORM}-${SLUG}-$(git rev-parse --short HEAD)"
 
+              # type=text not type=link: Facebook Pages can't create custom
+              # link previews via Graph API (since 2017). When we set the
+              # link parameter on a Page feed post, FB silently consumes it
+              # AND strips the URL from the message body — leaving posts
+              # with no clickable URL anywhere. Sending as text keeps the URL
+              # in the message body; FB autolinks it client-side.
               RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${SOCIAL_WORKER_URL}/api/publish" \
                 -H "Authorization: Bearer ${SOCIAL_PUBLISH_SECRET}" \
                 -H "Content-Type: application/json" \
                 --data "$(jq -n \
                   --arg platform "$PLATFORM" \
-                  --arg type "link" \
+                  --arg type "text" \
                   --arg message "$MESSAGE" \
-                  --arg link "$URL" \
                   --arg key "$IDEMPOTENCY_KEY" \
-                  '{platform: $platform, type: $type, message: $message, link: $link, idempotencyKey: $key}')" \
+                  '{platform: $platform, type: $type, message: $message, idempotencyKey: $key}')" \
                 --max-time 30)
               HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
               BODY=$(echo "$RESPONSE" | sed '$d')


### PR DESCRIPTION
Recent FB posts (2026-04-04 AI Nationalism + 2026-04-28 OP/AS/CBD) shipped without clickable URLs. The autopublish workflow was sending `type: link` with a `link` parameter, which Facebook's Graph API silently consumes for Page-published posts AND strips the URL from the message body — net result: posts with no URL anywhere.

Pages haven't been able to create custom link previews via Graph API since 2017; the `link` parameter is dead weight. Switching to `type: text` keeps the URL in the message body where FB will autolink it client-side.

Followup (manual, not part of this PR): delete the 8 broken historical posts via FB Graph API and re-post the 4 unique ones (OP, AS, CBD, AI Nationalism) via the worker's `/api/publish` with the now-corrected payload shape.