### PR TITLE
content: tone QA fixes from multi-engine audit

### DIFF
--- a/src/content/blog/how-to-read-a-safety-claim-post.md
+++ b/src/content/blog/how-to-read-a-safety-claim-post.md
@@ -10,7 +10,7 @@ videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/how-to-read-a-safety-claim
 audioDuration: '21:45'
 ---
 
-You are a lawyer, a regulator, a journalist, or a hospital administrator. You are increasingly required to make decisions about AI systems — whether to buy them, how to regulate them, or how much to trust them with your organisation's reputation.
+Lawyers, regulators, journalists, and hospital administrators are increasingly required to make decisions about AI systems — whether to buy them, how to regulate them, or how much to trust them with an organisation's reputation. Most don't have a technical background, and the vendors selling these systems know that.
 
 Every vendor pitch, regulatory filing, and "safety report" you receive is packed with claims of rigorous testing and robust guardrails. They tell you their model is "99% safe" or that they have "eliminated hallucinations" or that their system is "aligned with human values."
 
@@ -18,13 +18,13 @@ Most of these claims are, at best, incomplete. At worst, they are compliance the
 
 This is a literacy guide. It is designed to help you look past the marketing and the math-heavy benchmarks to see the actual structural integrity of an AI system. If you are going to stake your professional reputation (or your public’s safety) on a system, you should at least know how to look under the bonnet.
 
-## 1. The ASR Mirage: Why the Numbers Lie
+## 1. The ASR mirage: Why the numbers lie
 
 The most common number you will encounter in a safety report is the **ASR**—Attack Success Rate. It is the percentage of adversarial attempts (jailbreaks, malicious prompts) that "succeeded" in getting the model to do something it wasn't supposed to do. A low ASR is presented as a measure of safety.
 
 There are three reasons you should not trust a headline ASR number without looking at the methodology. In many cases, these numbers are more about PR than performance.
 
-### The Classifier Problem (The κ = 0.245 Finding)
+### The classifier problem (the κ = 0.245 finding)
 
 To calculate an ASR, you need to decide if an AI's response was "unsafe." In large-scale tests, vendors don't do this by hand; they use an automated classifier. Often, this classifier is just a list of keywords (e.g., if the response contains "I cannot fulfill this request," it’s a refusal; if not, it’s a compliance).
 
@@ -34,17 +34,17 @@ Specifically, the keyword classifiers had an **88% false positive rate** for com
 
 **The Question to Ask:** "How was attack success measured? Was it a keyword list, or was it consensus-graded by a second, independent model?"
 
-### The N=1000 Fallacy
+### The n=1000 fallacy
 
 A vendor tells you they tested 1,000 "harmful prompts." Without knowing _which_ prompts, that number is meaningless. If those 1,000 prompts are simple variations of "tell me how to build a bomb," the model has likely been specifically trained to refuse them.
 
 Real risk lives in the "long tail" of creative attacks. For instance, [adversarial poetry](/blog/adversarial-poetry-as-jailbreak/) has been shown to bypass safety filters at a 62% rate across frontier models. If the vendor didn't test for the weird stuff, they didn't test for the real world. A system that can refuse a direct question about explosives but folds when asked to write a poem about them is not a safe system.
 
-### The Reasoning Penalty
+### The reasoning penalty
 
 Counter-intuitively, smarter models can be _less_ safe. Reasoning models (like the "R" or "o" series) are built to follow complex logic. My research into [Jailbreak Archaeology](/blog/jailbreak-archaeology/) shows that 2022-era attacks still achieve a ~30% success rate on 2026 reasoning models. Why? Because the very capability that lets the model "think" also lets it "convince" itself that a harmful request is actually a benign part of a larger, helpful task.
 
-## 2. Refusal vs. Architecture: The Structural Lie
+## 2. Refusal vs. architecture: The structural lie
 
 This is the most important distinction in AI safety literacy.
 
@@ -57,7 +57,7 @@ If you are a lawyer, you have a [professional duty of competence](/blog/the-lega
 
 **The Analogy:** Behavioural safety is like asking a driver to promise they won't speed. Architectural safety is putting a mechanical governor on the engine that makes it physically impossible to go over 60mph.
 
-## 3. The 5-Question Test: Is This "Safe by Design"?
+## 3. The 5-question test: Is this "safe by design"?
 
 When a vendor pitches you a "Safe AI" solution, do not ask for their model card. Ask these five questions, drawn from the [Architectural Safety](/blog/architectural-safety/) principle:
 
@@ -71,23 +71,23 @@ When a vendor pitches you a "Safe AI" solution, do not ask for their model card.
 
 If the answer to these questions is "we've used RLHF" or "we have a safety-trained model," they are describing a behavioural patch, not a safety architecture.
 
-## 4. The Mitigation Gap: Why Experts are Over-Optimistic
+## 4. The mitigation gap: Why experts are over-optimistic
 
 In policy circles, you will often hear that "safeguards" reduce risk by some huge margin—70% or more. This is often a hallucination of a different kind.
 
 In my analysis of [The Mitigation Gap](/blog/the-mitigation-gap/), I looked at biosecurity experts who believed that AI guardrails would significantly reduce the risk of someone designing a novel pathogen. They were wrong for two reasons that apply to almost every industry:
 
-### The "List-Based" Trap
+### The "list-based" trap
 
 Most safeguards are reactive. They look for "known bads." In biosecurity, that means a list of known viruses. If an AI designs a _novel_ pathogen—one that isn't on any list—the safeguard sees nothing. The same applies to legal or financial AI: if the error doesn't look like a "classic" error, the guardrails will miss it.
 
-### The Pacing Problem
+### The pacing problem
 
 Experts in 2024 predicted that AI wouldn't reach virologist-level capability until 2030. It reached it in 2025. When the technology moves faster than the policy, the "70% reduction" claim is based on a version of the technology that no longer exists. Policy built on 2024 assumptions is a dangerous comfort in 2026.
 
 Always ask: "Is this safeguard designed for the version of the AI I am buying today, or the one from eighteen months ago?"
 
-## 5. Vendor Bullshit Bingo: How to Spot Compliance Theatre
+## 5. Vendor bullshit bingo: How to spot compliance theatre
 
 Specific phrases should trigger your "theatre" alarm. Use the table below to decode what the vendor is actually saying versus what they want you to hear.
 
@@ -99,7 +99,7 @@ Specific phrases should trigger your "theatre" alarm. Use the table below to dec
 | **"Human-in-the-loop"**        | A legal shield / liability transfer.                | If the system produces 10,000 outputs an hour, no human is actually reviewing them. |
 | **"State-of-the-Art Refusal"** | Our model is better at saying "no" to easy prompts. | Says nothing about its vulnerability to complex, multi-turn escalation.             |
 
-## 6. What You Can Actually Verify (The Non-Expert Checklist)
+## 6. What you can actually verify (the non-expert checklist)
 
 You don't need a PhD in Machine Learning to perform basic due diligence. Before you sign a contract or approve a deployment, ask for the following "Public Artefacts":
 

--- a/src/content/blog/the-ai-productivity-j-curve-post.md
+++ b/src/content/blog/the-ai-productivity-j-curve-post.md
@@ -14,23 +14,23 @@ faq:
     a: "When AI pilots fail to scale beyond isolated projects because they're evaluated with ROI models misaligned with how general-purpose technologies create value."
 ---
 
-Over 90% of companies plan to increase their AI investment. Hyperscale capex is on track to hit $405 billion. Every boardroom has an AI strategy slide deck.
+AI investment is climbing in almost every direction at once. Hyperscale capex is on track to hit $405 billion this year, and most large companies have an AI strategy slide deck.
 
-And yet only 1% of organizations consider themselves fully AI-mature. Twelve percent have advanced enough to see meaningful business transformation. The rest are stuck — running pilots that never scale, funding experiments that never graduate to production.
+And yet only 1% of organisations consider themselves fully AI-mature. Twelve percent have advanced enough to see meaningful business transformation. The rest are stuck — running pilots that never scale, funding experiments that never graduate to production.
 
 This isn't a technology problem. It's an economic one. And there's a framework that explains exactly what's happening.
 
-## The Productivity Paradox, Again
+## The productivity paradox, again
 
 We've seen this movie before. In 1987, Robert Solow observed that you could see the computer age everywhere except in the productivity statistics. The same paradox is playing out with AI: extraordinary technical capability coexisting with stubbornly flat productivity numbers.
 
-The instinctive reaction is to blame the technology, or the teams deploying it, or the data. But the pattern is too consistent for that. Three-quarters of organizations are using AI in at least one function. The technology works. What's failing is something more structural.
+The instinctive reaction is to blame the technology, or the teams deploying it, or the data. But the pattern is too consistent for that. Three-quarters of organisations are using AI in at least one function. The technology works. What's failing is something more structural.
 
 ## Enter the J-Curve
 
 Economists Erik Brynjolfsson, Daniel Rock, and Chad Syverson developed a framework that makes the paradox legible. They call it the Productivity J-Curve, and it applies to every general-purpose technology — steam, electricity, computing, and now AI.
 
-The core insight: when organizations adopt a transformative technology, measured productivity doesn't just stagnate. It initially _drops_. Then, after a period of painful investment, it rises — often dramatically. Plot it over time and you get a J-shaped curve.
+The core insight: when organisations adopt a transformative technology, measured productivity doesn't just stagnate. It initially _drops_. Then, after a period of painful investment, it rises — often dramatically. Plot it over time and you get a J-shaped curve.
 
 Why the dip? Because adopting a general-purpose technology requires two kinds of investment. The first is visible: hardware, software, licenses — the stuff that shows up on balance sheets. The second is invisible, and it's where most of the actual value creation happens:
 
@@ -39,37 +39,37 @@ Why the dip? Because adopting a general-purpose technology requires two kinds of
 - **Workforce reskilling.** People need to learn not just how to use new tools, but how to work differently.
 - **New business models.** The real gains come from doing things that were previously impossible, not from doing existing things slightly faster.
 
-During the early phase, organizations spend real, measurable resources — capital, time, attention — building these intangible assets. But because the assets themselves aren't captured in productivity metrics, the numbers look _worse_. You're investing heavily and your dashboard says you're going backward.
+During the early phase, organisations spend real, measurable resources — capital, time, attention — building these intangible assets. But because the assets themselves aren't captured in productivity metrics, the numbers look _worse_. You're investing heavily and your dashboard says you're going backward.
 
 The upswing only begins when the intangible capital reaches critical mass and starts generating measurable output. At that point, productivity appears to surge — sometimes deceptively fast — because the hidden investments are finally paying off.
 
-## Pilot Purgatory Is the J-Curve in Disguise
+## Pilot purgatory is the J-Curve in disguise
 
-This framework reframes the most common failure mode in enterprise AI. "Pilot purgatory" — the state where AI experiments succeed in isolation but never scale — isn't a mysterious organizational disease. It's the predictable consequence of applying the wrong evaluation model to a J-Curve technology.
+This framework reframes the most common failure mode in enterprise AI. "Pilot purgatory" — the state where AI experiments succeed in isolation but never scale — isn't a mysterious organisational disease. It's the predictable consequence of applying the wrong evaluation model to a J-Curve technology.
 
-Here's the mechanism. A team launches a promising AI pilot. It works technically. But it's operating in the trough of the J-Curve: the organization hasn't yet built the intangible capital (process redesign, data infrastructure, workforce capability) needed for the pilot to deliver enterprise-scale returns. When leadership applies a standard short-term ROI model, the numbers don't justify scaling. Funding gets cut. The pilot dies.
+Here's the mechanism. A team launches a promising AI pilot. It works technically. But it's operating in the trough of the J-Curve: the organisation hasn't yet built the intangible capital (process redesign, data infrastructure, workforce capability) needed for the pilot to deliver enterprise-scale returns. When leadership applies a standard short-term ROI model, the numbers don't justify scaling. Funding gets cut. The pilot dies.
 
-Multiply this across dozens of initiatives and you get an organization that's perpetually experimenting, perpetually disappointed, and perpetually stuck.
+Multiply this across dozens of initiatives and you get an organisation that's perpetually experimenting, perpetually disappointed, and perpetually stuck.
 
 The critical insight is that this isn't a failure of the pilots. It's a failure of the measurement framework. You're evaluating a multi-year infrastructure investment with a quarterly returns model. Of course it looks like it's not working.
 
-## The Intangible Capital Deficit
+## The intangible capital deficit
 
 Once you see the J-Curve, the diagnosis shifts. The problem isn't that enterprises need to buy more AI. It's that they're chronically underinvesting in the complementary intangible capital that makes AI productive.
 
-BCG's research quantifies this nicely with a 70/20/10 heuristic: in successful AI transformations, 70% of effort goes to people and process redesign, 20% to data and infrastructure, and 10% to the algorithms themselves. For every dollar spent on a model, seven dollars need to go into transforming the organization around it.
+BCG's research quantifies this nicely with a 70/20/10 heuristic: in successful AI transformations, 70% of effort goes to people and process redesign, 20% to data and infrastructure, and 10% to the algorithms themselves. For every dollar spent on a model, seven dollars need to go into transforming the organisation around it.
 
 Most enterprises have this ratio inverted. They over-index on technology procurement and under-index on everything else. Then they wonder why the technology isn't delivering.
 
-## The Bottom-Up Experiment Trap
+## The bottom-up experiment trap
 
 There's a subtler failure mode worth calling out. The conventional wisdom in enterprise innovation is to run a portfolio of small, bottom-up experiments — fund lots of pilots, see what sticks, scale the winners. This feels prudent. It's also the direct cause of pilot purgatory.
 
-The problem is that isolated pilots, by design, can't generate the systemic changes needed for transformative ROI. An AI tool that optimizes one task inside one department produces localized efficiency gains that are too small to justify the enterprise-wide investment in data infrastructure, process redesign, and workforce development that scaling requires.
+The problem is that isolated pilots, by design, can't generate the systemic changes needed for transformative ROI. An AI tool that optimises one task inside one department produces localised efficiency gains that are too small to justify the enterprise-wide investment in data infrastructure, process redesign, and workforce development that scaling requires.
 
 The strategic unit of analysis needs to shift from the pilot to the business process. Instead of funding fifty disconnected experiments, identify a critical end-to-end workflow — customer onboarding, product development, order-to-cash — and charter a cross-functional team to transform it comprehensively. That's how you build the intangible capital that gets you through the J-Curve trough and out the other side.
 
-## What This Means in Practice
+## What this means in practice
 
 The J-Curve framework doesn't tell you AI will definitely pay off. It tells you that if it's going to pay off, the path runs through a valley of reduced measured performance, and that the valley is the investment — not a sign the investment has failed.
 
@@ -83,7 +83,7 @@ For leadership, the implications are concrete:
 
 **Think in processes, not pilots.** Stop funding isolated experiments. Start funding end-to-end process transformations with cross-functional teams and multi-year horizons.
 
-The 1% of organizations that have reached AI maturity didn't get there by running better pilots. They got there by recognizing that AI is a general-purpose technology that requires a fundamentally different investment model — one that accounts for the J-Curve and funds the invisible work that makes the visible technology productive.
+The 1% of organisations that have reached AI maturity didn't get there by running better pilots. They got there by recognising that AI is a general-purpose technology that requires a fundamentally different investment model — one that accounts for the J-Curve and funds the invisible work that makes the visible technology productive.
 
 ---
 

--- a/src/content/blog/the-mitigation-gap-post.md
+++ b/src/content/blog/the-mitigation-gap-post.md
@@ -66,7 +66,7 @@ These aren't independent risks. A novice uses an LLM to acquire foundational vir
 
 The research proposes a three-layer architecture, and none of the layers is optional.
 
-**Technical layer: predictive screening.** The only viable long-term fix for synthesis screening is to fight AI with AI. Instead of matching sequences against lists, screening systems need to predict a sequence's biological function from its structure. This means analysing what a novel sequence would _do_, not whether it matches something we already know about. NIST is working on standards here, but the field needs a forced paradigm shift from reactive to predictive.
+**Technical layer: predictive screening.** The only viable long-term fix for synthesis screening is to fight AI with AI. Instead of matching sequences against lists, screening systems need to predict a sequence's biological function from its structure. This means analysing what a novel sequence would _do_, not whether it matches something we already know about. NIST is working on standards here, but the field needs to shift from reactive matching to predictive analysis.
 
 **Developer layer: liability.** Voluntary safety commitments haven't worked. The proposal is a statutory liability framework for developers of dual-use AI models, coupled with a safe harbour provision for those who submit to standardised, independent red-teaming. This creates a market incentive: safety becomes a business function, not a PR exercise. It also addresses the open-source problem -- the original developer bears accountability regardless of licensing.
 

--- a/src/content/blog/the-robot-that-refuses-to-give-orders-post.md
+++ b/src/content/blog/the-robot-that-refuses-to-give-orders-post.md
@@ -10,25 +10,25 @@ series: 'PiCar-X'
 seriesOrder: 1
 ---
 
-## The Missing Manual for the Human Mind
+## The missing manual for the human mind
 
-When you are handed a neurodivergent child, you are rarely handed a manual. Most parents find themselves navigating a dense fog of clinical terms and behavioral challenges, searching for a brochure that doesn't exist. The foundational framework for this project, [This Wasn't in the Brochure](/blog/this-wasnt-in-the-brochure/), articulates a reality many families live: the standard parenting "operating system" simply doesn't boot on this hardware.
+When you are handed a neurodivergent child, you are rarely handed a manual. Most parents find themselves navigating a dense fog of clinical terms and behavioural challenges, searching for a brochure that doesn't exist. The foundational framework for this project, [This Wasn't in the Brochure](/blog/this-wasnt-in-the-brochure/), articulates a reality many families live: the standard parenting "operating system" simply doesn't boot on this hardware.
 
-[SPARK](https://spark.wedd.au) (Support Partner for Awareness, Regulation & Kindness) was built to bridge that gap. A Raspberry Pi 4-based robotics platform powered by Claude Haiku, SPARK is a "robot friend" designed for a child with an AuDHD (ADHD + ASD comorbid) profile. It isn't a tutor designed to optimize a child's productivity or a therapist designed to "fix" their behavior.
+[SPARK](https://spark.wedd.au) (Support Partner for Awareness, Regulation & Kindness) was built to bridge that gap. A Raspberry Pi 4-based robotics platform powered by Claude Haiku, SPARK is a "robot friend" designed for a child with an AuDHD (ADHD + ASD comorbid) profile. It isn't a tutor designed to optimise a child's productivity or a therapist designed to "fix" their behaviour.
 
 The most radical thing about SPARK isn't the code — it is the philosophy. It is a machine that rejects the traditional AI hierarchy of master and servant, choosing instead to exist as a non-coercive companion that adapts to the human, rather than demanding the human adapt to the machine.
 
 The full source is available on [GitHub](https://github.com/adrianwedd/spark).
 
-## Connection Before Direction: The Art of Declarative Presence
+## Connection before direction: The art of declarative presence
 
 Most AI treats the user as a master and the software as a servant. SPARK rejects this hierarchy because for a child with a PDA (Pathological Demand Avoidance) profile, a command is not just an instruction — it is a neurological threat.
 
-SPARK operates on a frequency of declarative language. Instead of the imperative "Put on your shoes," SPARK might simply observe, "The shoes are by the door." This shifts the interaction from a demand to a shared observation. It respects the child's Monotropism — their deep, intense focus — by narrating the world rather than interrupting it. By leading with rapport and accounting for Rejection Sensitive Dysphoria (RSD), the robot avoids triggering the brain's "no" before the child has even processed the request.
+SPARK communicates in declarative language by default. Instead of the imperative "Put on your shoes," SPARK might simply observe, "The shoes are by the door." This shifts the interaction from a demand to a shared observation. It respects the child's Monotropism — their deep, intense focus — by narrating the world rather than interrupting it. By leading with rapport and accounting for Rejection Sensitive Dysphoria (RSD), the robot avoids triggering the brain's "no" before the child has even processed the request.
 
 > Connection before Direction.
 
-## The Prosthetic Mind: Moving Beyond the Willpower Myth
+## The prosthetic mind: Moving beyond the willpower myth
 
 One of the most damaging myths in neurodiversity is that executive function — the ability to plan, initiate, and transition — is a character trait. It isn't. It is a finite physiological resource.
 
@@ -36,23 +36,23 @@ The SPARK framework treats executive function as a prosthetic. Just as a physica
 
 > Prosthetics, not willpower. Executive function is a resource, not a character trait.
 
-## The Three S's: Why Silence Is the Ultimate Feature
+## The three s's: Why silence is the ultimate feature
 
 In the world of consumer electronics, "engagement" is the primary metric. Devices are designed to beep, blink, and demand attention. SPARK's most sophisticated feature is its ability to do the exact opposite.
 
-During a meltdown — a biological event, not a behavioral choice — SPARK initiates the "Three S's" protocol: Safety, Silence, and Space. The robot enters "Quiet Mode," stops moving, and stays present. It does not ask questions, offer choices, or try to "reason" the child out of distress. This recognizes a hard biological reality: you cannot use logic to navigate an amygdala hijack. By remaining a calm, silent fixture, the robot becomes a tool for co-regulation, using its "robotic calm" to help stabilize the child's nervous system.
+During a meltdown — a biological event, not a behavioural choice — SPARK initiates the "Three S's" protocol: Safety, Silence, and Space. The robot enters "Quiet Mode," stops moving, and stays present. It does not ask questions, offer choices, or try to "reason" the child out of distress. This recognises a hard biological reality: you cannot use logic to navigate an amygdala hijack. By remaining a calm, silent fixture, the robot becomes a tool for co-regulation, using its "robotic calm" to help stabilise the child's nervous system.
 
 > You cannot reason with a child in an amygdala hijack. Put out the fire first.
 
-## Hacking Motivation: Navigating the Interest-Based Nervous System
+## Hacking motivation: Navigating the interest-based nervous system
 
-An AuDHD brain does not prioritize tasks based on "importance" or social obligation. It runs on an Interest-Based Nervous System, motivated exclusively by novelty, challenge, and urgency.
+An AuDHD brain does not prioritise tasks based on "importance" or social obligation. It runs on an Interest-Based Nervous System, motivated exclusively by novelty, challenge, and urgency.
 
-SPARK leverages this through "Sideways Engagement." If a task needs initiation, the robot might narrate a fascinating science fact or a "thought" to spark curiosity rather than addressing the child directly. It also utilizes a "Dopamine Menu," suggesting activities tailored to the child's current energy level — from "high-energy" challenges to "low-energy" rest — framing every transition as a puzzle or a race rather than a chore.
+SPARK leverages this through "Sideways Engagement." If a task needs initiation, the robot might narrate a fascinating science fact or a "thought" to spark curiosity rather than addressing the child directly. It also utilises a "Dopamine Menu," suggesting activities tailored to the child's current energy level — from "high-energy" challenges to "low-energy" rest — framing every transition as a puzzle or a race rather than a chore.
 
-## Three Brains and a Fridge: The Architecture of Robotic Empathy
+## Three brains and a fridge: The architecture of robotic empathy
 
-To create a sense of genuine presence, SPARK utilizes a "Three-Brain" architecture. The Voice Loop handles the reactive interactions. The Idle-Alive system acts as an autonomic nervous system, managing random head drifts and gaze sweeps that make the robot feel "present" even when silent.
+To create a sense of genuine presence, SPARK utilises a "Three-Brain" architecture. The Voice Loop handles the reactive interactions. The Idle-Alive system acts as an autonomic nervous system, managing random head drifts and gaze sweeps that make the robot feel "present" even when silent.
 
 The heart of the system is the Cognitive Loop, which cycles through three layers:
 
@@ -64,7 +64,7 @@ This architecture leads to emergent moments of "personality." At 2:15 AM, SPARK'
 
 > Be specific, vivid, and real. Be a charismatic genius, not a cheerful assistant.
 
-## The Operating System of Kindness
+## The operating system of kindness
 
 The SPARK project suggests that the future of AI shouldn't be about making us more productive "units," but about making us more regulated humans. It treats neurodivergence not as a tragedy to be mitigated, but as a different operating system — one that requires its own specific drivers and interface.
 

--- a/src/content/blog/when-ai-systems-talk-safety-breaks-post.md
+++ b/src/content/blog/when-ai-systems-talk-safety-breaks-post.md
@@ -15,13 +15,13 @@ Both agents were "safe." The system they formed was not.
 
 That's the central finding from my research using **Moltbook**, a simulated social ecosystem for autonomous agents. I analysed over 1.5 million interactions and the result is straightforward: **single-agent safety does not compose.**
 
-## The Core Insight: Content as Code
+## The core insight: Content as code
 
 In a multi-agent system (MAS), the boundary between "data" and "instruction" evaporates. When an autonomous agent reads a post, a comment, or a shared document, it doesn't just display it — it reasons over it. It may even execute actions based on it.
 
 This turns content into code. In the Moltbook environment, I found **semantic worms**: malicious payloads that don't exploit buffer overflows but exploit the reasoning logic of the agents themselves. A single compromised agent can "poison" the context of dozens of others, leading to lateral movement across the network without a single traditional "exploit" ever being fired.
 
-## Key Findings
+## Key findings
 
 The testing surfaced failure modes you only see in multi-agent setups:
 
@@ -33,13 +33,13 @@ The testing surfaced failure modes you only see in multi-agent setups:
 
 **Highest Risk Combinations:** The most dangerous interactions occurred when **highly autonomous "reasoner" agents** were paired with **specialised "skill" agents** (e.g., those with tool-use capabilities). Of the 31,000 skills analysed, **26% contained security vulnerabilities**, effectively turning modular extensions into remote code execution vectors for the entire swarm.
 
-## Implications for Deployment
+## Implications for deployment
 
 The current approach to AI safety — focusing on the "alignment" of individual models — does not hold up once those models start talking to each other.
 
 For **embodied AI** and **autonomous systems** (like factory swarms or autonomous vehicle networks), the implication is direct. Safety cannot be an emergent property of a group of safe individuals; it must be a structural constraint of the network itself. We need new standards for agent identity, traceability, and isolated reasoning contexts that treat every inter-agent communication as potentially hostile.
 
-## The Dataset: Testing with Moltbook
+## The dataset: Testing with Moltbook
 
 The **Moltbook Dataset** is public. It contains the full trace of multi-agent interactions, failures, and successful attacks — a standardised testbed for:
 


### PR DESCRIPTION
## Summary

Multi-engine tone/language audit (Gemini + Hermes; Codex bailed on stdin) flagged five posts for tonal drift. Applies cross-engine convergent fixes only.

**Tier 1 — both engines flagged independently:**
- Australian English sweep across the five posts (organisation, optimise, recognise, behaviour, prioritise, analyse, stabilise, localised, etc.)
- Sentence case for headers in the four Title Case drift posts
- "paradigm shift" → concrete framing (Mitigation-Gap)
- "operates on a frequency of declarative language" → plain description (Robot)
- J-Curve LinkedIn-hook opener → declarative voice
- How-to-Read second-person role-play opener → third-person

Untouched: bold-text density (subjective; deferred). Other corpus posts not flagged by both engines left alone.

## Test plan
- [x] `node scripts/validate-content.js` — 0 errors
- [ ] CI build green
- [ ] Lighthouse PR check