### PR TITLE
fix(contact): auto-advance booking calendar when landing on Sunday

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -579,7 +579,12 @@ import HeroCanvas from '../components/HeroCanvas.astro';
       var bookingForm = el('booking-form');
       if (!bookingForm || bookingForm.dataset.bookingInit) return;
       bookingForm.dataset.bookingInit = '1';
-      weekOffset = 0;
+
+      var today = new Date();
+      // If today is Sunday, default to next week as the current week is almost over
+      // and most users are looking for upcoming business days.
+      weekOffset = today.getDay() === 0 ? 1 : 0;
+
       selectedSlot = null;
       renderWeek();
     }

--- a/worker-csp/src/csp.ts
+++ b/worker-csp/src/csp.ts
@@ -18,6 +18,11 @@ export function buildCsp(opts: { nonce: string; strictDynamic: boolean }): strin
     "'self'",
     `'nonce-${nonce}'`,
     "'wasm-unsafe-eval'", // Pagefind WASM
+    // Cloudflare Turnstile creates srcdoc iframes in the page context; those
+    // documents inherit our script-src CSP but lack the per-request nonce.
+    // 'strict-dynamic' doesn't cover inline scripts in srcdoc parsing contexts,
+    // so we hash the one stable inline script that Turnstile embeds.
+    "'sha256-eJGI0Ik4oYe/PKLDOt4wcN76wYs8h+Ew05pMzdY6xG8='",
     // Host allowlist: honoured by browsers that don't support strict-dynamic.
     'https://www.googletagmanager.com',
     'https://www.google.com',
@@ -43,7 +48,8 @@ export function buildCsp(opts: { nonce: string; strictDynamic: boolean }): strin
     "style-src-attr 'unsafe-inline'",
     "style-src 'self' 'unsafe-inline'",
     // GA4 audience pixels use country-specific google TLDs (e.g. google.com.au).
-    "img-src 'self' data: https://cdn.adrianwedd.com https://www.google-analytics.com https://*.google-analytics.com https://px.ads.linkedin.com https://www.googletagmanager.com https://*.tile.openstreetmap.org https://tpc.googlesyndication.com https://googleads.g.doubleclick.net https://www.linkedin.com https://www.google.com.au",
+    // ep1/ep2.adtrafficquality.google serve the sodar tracking pixel as an image.
+    "img-src 'self' data: https://cdn.adrianwedd.com https://www.google-analytics.com https://*.google-analytics.com https://px.ads.linkedin.com https://www.googletagmanager.com https://*.tile.openstreetmap.org https://tpc.googlesyndication.com https://googleads.g.doubleclick.net https://www.linkedin.com https://www.google.com.au https://ep1.adtrafficquality.google https://ep2.adtrafficquality.google",
     "connect-src 'self' https://*.google-analytics.com https://analytics.google.com https://*.g.doubleclick.net https://adservice.google.com https://ep1.adtrafficquality.google https://ep2.adtrafficquality.google https://snap.licdn.com https://px.ads.linkedin.com https://pagead2.googlesyndication.com https://api.book.adrianwedd.com https://api.github.com https://cdn.adrianwedd.com https://ops.adrianwedd.com https://challenges.cloudflare.com",
     "media-src 'self' https://cdn.adrianwedd.com",
     'frame-src https://www.openstreetmap.org https://challenges.cloudflare.com https://www.google.com https://tpc.googlesyndication.com https://googleads.g.doubleclick.net https://ep2.adtrafficquality.google',

--- a/worker-csp/test/index.test.ts
+++ b/worker-csp/test/index.test.ts
@@ -52,6 +52,15 @@ describe('buildCsp', () => {
     expect(csp).toMatch(/media-src [^;]*https:\/\/cdn\.adrianwedd\.com/);
   });
 
+  it('includes Turnstile srcdoc script hash and adtrafficquality sodar origins', () => {
+    const csp = buildCsp({ nonce: 'x', strictDynamic: false });
+    // Turnstile srcdoc hash allows Cloudflare's inline script in the inherited CSP
+    expect(csp).toMatch(/'sha256-eJGI0Ik4oYe\/PKLDOt4wcN76wYs8h\+Ew05pMzdY6xG8='/);
+    // Google Ads sodar pixel loads as image from ep1/ep2
+    expect(csp).toMatch(/img-src [^;]*https:\/\/ep1\.adtrafficquality\.google/);
+    expect(csp).toMatch(/img-src [^;]*https:\/\/ep2\.adtrafficquality\.google/);
+  });
+
   it('uses unsafe-inline for style-src-elem (no nonce — CSP3 nonce suppresses unsafe-inline)', () => {
     // Astro ClientRouter injects <style> elements dynamically on each VT navigation.
     // Per CSP3, adding a nonce-source to style-src-elem silently suppresses


### PR DESCRIPTION
## Summary

When a user visits the contact page on a Sunday, the booking calendar widget shows the current week — but Mon–Sat are all in the past and Sunday has no available slots (the API returns `{"slots":[]}` for weekends). The result is a fully disabled grid that looks broken.

**Fix:** `initBooking()` now checks `today.getDay() === 0` (Sunday) and sets `weekOffset = 1` instead of `0`, opening the calendar on the upcoming week where business day slots are actually available.

## Findings from multi-engine QA (Codex + Gemini)

| Finding | Severity | Action |
|---|---|---|
| Booking widget strands Sunday users on empty week | Medium | **Fixed here** |
| `www.adrianwedd.com` not covered by worker route | Medium | Non-issue — GitHub Pages issues a 301 to apex before any HTML response; worker handles the redirect destination |
| Turnstile srcdoc hash is brittle (Cloudflare could change it) | Low | Accepted risk; no better alternative without Cloudflare documenting the hash |
| `img-src` only has `google.com.au`, not other regional TLDs | Low | Accepted; only `.au` has been observed in violations |

## Test plan

- [x] `node scripts/validate-content.js` — 0 errors
- [ ] Visit contact page on a Sunday and verify calendar opens on next week

🤖 Generated with [Claude Code](https://claude.com/claude-code)