### PR TITLE
fix: autopublish exit-code + Turnstile widget cleanup

### DIFF
--- a/.github/workflows/social-autopublish.yml
+++ b/.github/workflows/social-autopublish.yml
@@ -99,7 +99,7 @@ jobs:
               HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
               BODY=$(echo "$RESPONSE" | sed '$d')
               echo "[$PLATFORM] HTTP $HTTP_CODE — $BODY"
-              [ "$HTTP_CODE" != "200" ] && echo "::warning::[$PLATFORM] Publish returned HTTP $HTTP_CODE for $SLUG"
+              if [ "$HTTP_CODE" != "200" ]; then echo "::warning::[$PLATFORM] Publish returned HTTP $HTTP_CODE for $SLUG"; fi
             done
           done
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -713,6 +713,7 @@ import HeroCanvas from '../components/HeroCanvas.astro';
       document.documentElement.dataset.enquiryDelegateInit = '1';
 
       var turnstileVerified = false;
+      window.__turnstileWidgetId = null;
 
       window.onTurnstileSuccess = function () {
         turnstileVerified = true;
@@ -863,8 +864,12 @@ import HeroCanvas from '../components/HeroCanvas.astro';
         // the widget isn't rendered into it. Explicitly render if present.
         var container = document.querySelector('.cf-turnstile');
         if (container && typeof turnstile !== 'undefined') {
+          if (window.__turnstileWidgetId) {
+            try { turnstile.remove(window.__turnstileWidgetId); } catch (e) {}
+            window.__turnstileWidgetId = null;
+          }
           while (container.firstChild) container.removeChild(container.firstChild);
-          turnstile.render(container, {
+          window.__turnstileWidgetId = turnstile.render(container, {
             sitekey: '0x4AAAAAAABtkfyqFbFmIaPO',
             theme: 'dark',
             callback: function () { window.onTurnstileSuccess(); },


### PR DESCRIPTION
## Summary
- **social-autopublish.yml**: `[ ... ] && echo ::warning::` returns exit 1 when the test is false (successful publish), which `bash -e` interprets as a script failure. Replaced with `if/then`. This was causing the spurious CI failure on every successful autopublish run (including the Learning Mechanics post).
- **contact.astro**: Call `turnstile.remove(widgetId)` before re-rendering on View Transition swap, so old widget IDs are properly deregistered and the "Cannot find Widget" console warning stops.

## Test plan
- [ ] Next autopublish run exits 0 on success
- [ ] No "Cannot find Widget" warning on /contact/ after VT navigation