### PR TITLE
fix(new): remove dangling episodes reference

### DIFF
--- a/src/pages/new/index.astro
+++ b/src/pages/new/index.astro
@@ -91,8 +91,6 @@ function formatDate(d: Date) {
       <span class="opacity-30">/</span>
       <span>{galleries.length} galleries</span>
       <span class="opacity-30">/</span>
-      <span>{episodes.length} audio</span>
-      <span class="opacity-30">/</span>
       <span>{all.length} total</span>
     </div>
 


### PR DESCRIPTION
## Summary
Removes `{episodes.length} audio` stat from the What's New page stats bar.

The `episodes` variable was removed when audio was excluded from the feed, but the template reference was missed, causing `ts(2304): Cannot find name 'episodes'` and a failed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)