### PR TITLE
fix(podcast): per-episode author/description + R2 MIME types

### DIFF
--- a/scripts/upload-media-to-r2.sh
+++ b/scripts/upload-media-to-r2.sh
@@ -60,12 +60,28 @@ SKIPPED=0
 
 : > "$FAILED_LOG"
 
+mime_type() {
+  case "${1##*.}" in
+    mp3) echo "audio/mpeg" ;;
+    mp4) echo "video/mp4" ;;
+    webm) echo "video/webm" ;;
+    webp) echo "image/webp" ;;
+    jpg|jpeg) echo "image/jpeg" ;;
+    png) echo "image/png" ;;
+    pdf) echo "application/pdf" ;;
+    json) echo "application/json" ;;
+    *) echo "application/octet-stream" ;;
+  esac
+}
+
 upload_file() {
   local file="$1"
   local key="$2"
   local attempt=1
   local size
   size=$(du -h "$file" | cut -f1)
+  local content_type
+  content_type=$(mime_type "$file")
 
   while [ $attempt -le $MAX_RETRIES ]; do
     local http_code
@@ -73,7 +89,7 @@ upload_file() {
       -X PUT \
       "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/r2/buckets/${BUCKET}/objects/${key}" \
       -H "@${AUTH_HEADER_FILE}" \
-      -H "Content-Type: application/octet-stream" \
+      -H "Content-Type: ${content_type}" \
       --data-binary "@${file}" \
       --max-time 600)
 

--- a/src/pages/audio/feed.xml.ts
+++ b/src/pages/audio/feed.xml.ts
@@ -45,6 +45,8 @@ export async function GET(context: APIContext) {
       <title>${escapeXml(ep.data.title)}</title>
       <description>${escapeXml(ep.data.description)}</description>
       <itunes:summary>${escapeXml(ep.data.description)}</itunes:summary>
+      <content:encoded><![CDATA[${ep.data.description}]]></content:encoded>
+      <itunes:author>Adrian Wedd</itunes:author>
       <link>${episodeUrl}</link>
       <guid isPermaLink="true">${episodeUrl}</guid>
       <pubDate>${ep.data.date.toUTCString()}</pubDate>


### PR DESCRIPTION
## Summary
- Adds `<itunes:author>` and `<content:encoded>` per episode — fixes "60 episodes missing author/description" warnings from castfeedvalidator
- Fixes `upload-media-to-r2.sh` to derive Content-Type from extension — was hardcoded to `application/octet-stream`, causing "invalid content type for media" fatal in feed validator
- Existing 9 MP3/MP4 objects on R2 already re-uploaded with corrected MIME types

## Remaining validator warnings (not blocking)
- Cloudflare caching quirks (ETag/user-agent) — normal for CF-hosted sites
- Subscribe links on episode pages — enhancement, not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)