### PR TITLE
fix(podcast): correct Apple Podcasts category structure

### DIFF
--- a/src/pages/audio/feed.xml.ts
+++ b/src/pages/audio/feed.xml.ts
@@ -99,7 +99,8 @@ export async function GET(context: APIContext) {
       <itunes:email>adrianwedd@gmail.com</itunes:email>
     </itunes:owner>
     <itunes:type>episodic</itunes:type>
-    <itunes:category text="Technology">
+    <itunes:category text="Technology" />
+    <itunes:category text="News">
       <itunes:category text="Tech News" />
     </itunes:category>
     <itunes:category text="Science">


### PR DESCRIPTION
## Summary
- `Technology` → standalone (Apple removed subcategories from it)
- `Tech News` → moved under `News` (its correct parent in Apple's current taxonomy)
- `Science > Social Sciences` → unchanged

Fixes castfeedvalidator warning: "Your feed uses an outdated category pair."

🤖 Generated with [Claude Code](https://claude.com/claude-code)