### PR TITLE
fix(podcast): use .jpg for episode artwork (WebP unsupported by Apple)

### DIFF
--- a/src/pages/audio/feed.xml.ts
+++ b/src/pages/audio/feed.xml.ts
@@ -52,10 +52,12 @@ export async function GET(context: APIContext) {
       const relatedPost = ep.data.relatedPost ? blogById.get(ep.data.relatedPost.replace(/-post$/, '')) : undefined;
       const relatedProject = ep.data.relatedProject ? projectById.get(ep.data.relatedProject) : undefined;
       const heroImage = relatedPost?.data.heroImage ?? relatedProject?.data.heroImage;
-      const episodeImage = heroImage
-        ? heroImage.startsWith('http')
-          ? heroImage
-          : `${site}${heroImage}`
+      // Apple Podcasts requires JPEG or PNG — swap .webp for .jpg
+      const heroImageJpeg = heroImage?.replace(/\.webp$/, '.jpg');
+      const episodeImage = heroImageJpeg
+        ? heroImageJpeg.startsWith('http')
+          ? heroImageJpeg
+          : `${site}${heroImageJpeg}`
         : podcastCover;
 
       return `


### PR DESCRIPTION
## Summary
Apple Podcasts does not support WebP for artwork. Per-episode `<itunes:image>` tags were pointing to `.webp` infographics — swapped to `.jpg` (67 JPEG versions already exist alongside every WebP in `public/notebook-assets/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)