### PR TITLE
content(adhdo): replace with cinematic video (dark botanical aesthetic)

### DIFF
--- a/src/content/projects/adhdo.md
+++ b/src/content/projects/adhdo.md
@@ -8,6 +8,7 @@ featured: true
 date: 2026-02-05
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adhdo/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/adhdo/video.mp4'
+youtubeUrl: 'https://www.youtube.com/watch?v=it_8g1ApwEk'
 heroImage: '/notebook-assets/adhdo/infographic.webp'
 ---
 


### PR DESCRIPTION
Replaces the old non-branded ADHDo NLM video with the cinematic version using the canonical dark botanical aesthetic focus prompt.

- Old YouTube video `v1qvpX_OJK0` deleted
- New cinematic video uploaded: `it_8g1ApwEk`
- R2 `notebook-assets/adhdo/video.mp4` replaced with new 44MB cinematic render
- Added `youtubeUrl` field to frontmatter
- Added to adrianwedd.com YouTube playlist