### PR TITLE
chore: pin typescript to <6 (tsconfck peer dep incompatibility)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "preact": "^10.29.1",
     "satori": "^0.26.0",
     "tailwindcss": "^4.2.4",
-    "typescript": "^5.9.3"
+    "typescript": ">=5.0.0 <6.0.0"
   },
   "overrides": {
     "fast-xml-parser": "^5.5.6"


### PR DESCRIPTION
## Summary

- Pin typescript to `>=5.0.0 <6.0.0` in package.json
- Astro's bundled `tsconfck` declares `peerDependencies.typescript = ^5.0.0`, which excludes TypeScript 6.x
- Closes the loop after declining Dependabot PR #284 (which would have broken CI)

## Test plan
- [ ] CI passes with existing TypeScript 5.x