### PR TITLE
fix(content): remove stale youtubeUrl from robot-refuses-orders post

### DIFF
--- a/src/content/blog/the-robot-that-refuses-to-give-orders-post.md
+++ b/src/content/blog/the-robot-that-refuses-to-give-orders-post.md
@@ -8,7 +8,6 @@ audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-robot-that-refuses-to-
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-robot-that-refuses-to-give-orders/video.mp4'
 series: 'PiCar-X'
 seriesOrder: 1
-youtubeUrl: 'https://www.youtube.com/watch?v=nzZ83pc_E9Y'
 ---
 
 ## The missing manual for the human mind


### PR DESCRIPTION
Video `nzZ83pc_E9Y` was deleted from YouTube (old-style NLM upload). Clearing `youtubeUrl` so the batch cron can queue a cinematic replacement upload.