### PR TITLE
feat(content): add cinematic video to SPARK project

### DIFF
--- a/src/content/projects/spark.md
+++ b/src/content/projects/spark.md
@@ -11,6 +11,7 @@ series: 'PiCar-X'
 seriesOrder: 1
 heroImage: '/notebook-assets/spark/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/spark/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/spark/video.mp4'
 ---
 
 SPARK (Support Partner for Awareness, Regulation & Kindness) is a Raspberry Pi 4-based robotics platform powered by Claude Haiku, designed as a non-coercive companion for children with AuDHD (ADHD + ASD comorbid) profiles.


### PR DESCRIPTION
New cinematic video generated via NotebookLM with dark botanical aesthetic, replacing the old NLM-style video. Uploaded to R2 (44MB). The batch upload cron will pick up the `videoUrl` and push to YouTube.