### PR TITLE
feat(youtube): cinematic NLM videos batch 1 — 16 items

### DIFF
--- a/src/content/blog/the-robot-that-refuses-to-give-orders-post.md
+++ b/src/content/blog/the-robot-that-refuses-to-give-orders-post.md
@@ -8,6 +8,7 @@ audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-robot-that-refuses-to-
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-robot-that-refuses-to-give-orders/video.mp4'
 series: 'PiCar-X'
 seriesOrder: 1
+youtubeUrl: 'https://www.youtube.com/watch?v=SOUJUti2oDw'
 ---
 
 ## The missing manual for the human mind

--- a/src/content/projects/auditory-spiral.md
+++ b/src/content/projects/auditory-spiral.md
@@ -8,6 +8,7 @@ date: 1992-01-01
 heroImage: '/notebook-assets/auditory-spiral/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/auditory-spiral/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/auditory-spiral/video.mp4'
+youtubeUrl: 'https://www.youtube.com/watch?v=TyttZAAO8gs'
 ---
 
 _Auditory Spiral_ was an overnight electronic music programme on [RTRFM 92.1](https://rtrfm.com.au), Perth's community radio station. Broadcasting Sunday nights into Monday mornings from midnight to 6 AM, the show was a six-hour immersion in minimal techno, dark ambient, industrial, and experimental electronic music during an era when those sounds were virtually inaccessible in Western Australia.

--- a/src/content/projects/before-the-words-existed.md
+++ b/src/content/projects/before-the-words-existed.md
@@ -10,6 +10,7 @@ date: 2026-02-10
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/before-the-words-existed/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/before-the-words-existed/video.mp4'
 heroImage: '/notebook-assets/before-the-words-existed/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=ZZDPvTlA4Xw'
 ---
 
 What if _Neuromancer_ wasn't about addiction? What if it was about ADHD?

--- a/src/content/projects/cv.md
+++ b/src/content/projects/cv.md
@@ -9,6 +9,7 @@ date: 2026-02-04
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/cv/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/cv/video.mp4'
 heroImage: '/notebook-assets/cv/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=1Zg7I5Awymc'
 ---
 
 A CV is a strange document. It claims to summarise a career, but the format enforces a lie: that work is linear, that skills accumulate neatly, that the most recent role is the most important one. Every static résumé is a snapshot that begins decaying the moment you export the PDF.

--- a/src/content/projects/cygnet.md
+++ b/src/content/projects/cygnet.md
@@ -9,6 +9,7 @@ date: 2025-04-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/cygnet/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/cygnet/video.mp4'
 heroImage: '/notebook-assets/cygnet/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=F_wgoUYlXYY'
 ---
 
 Housing in Australia is broken in ways that conventional construction cannot fix. The economics don't work. The timelines don't work. The waste is staggering. And the people who need homes most urgently are the ones least served by the industry's existing incentive structures.

--- a/src/content/projects/dodgylegally.md
+++ b/src/content/projects/dodgylegally.md
@@ -9,6 +9,7 @@ date: 2026-02-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dodgylegally/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/dodgylegally/video.mp4'
 heroImage: '/notebook-assets/dodgylegally/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=xF-BklkSqoI'
 ---
 
 The best samples come from places you weren't looking. That's the premise—and the entire workflow. Type a random word. Get a sample pack. dodgylegally generates audio instruments from chaotic search phrases, pulling from YouTube, local files, and a five-thousand-word dictionary with weighted source mixing.

--- a/src/content/projects/dx0.md
+++ b/src/content/projects/dx0.md
@@ -9,6 +9,7 @@ date: 2025-05-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dx0/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/dx0/video.mp4'
 heroImage: '/notebook-assets/dx0/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=h9H9TnoI8hk'
 ---
 
 The question everyone asks about AI in medicine is whether it can diagnose. That's the wrong question. The right question is whether it can diagnose responsibly—within resource constraints, with appropriate uncertainty, without the kind of confident hallucination that in a clinical context becomes malpractice.

--- a/src/content/projects/emdr-agent.md
+++ b/src/content/projects/emdr-agent.md
@@ -9,6 +9,7 @@ date: 2025-06-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/emdr-agent/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/emdr-agent/video.mp4'
 heroImage: '/notebook-assets/emdr-agent/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=owXdPDifuQE'
 ---
 
 Therapy has a pacing problem. A human therapist reads the room—breath, posture, the micro-expressions that signal when to slow down or when to press forward. Software does not get that for free.

--- a/src/content/projects/footnotes-at-the-edge-of-reality.md
+++ b/src/content/projects/footnotes-at-the-edge-of-reality.md
@@ -10,6 +10,7 @@ date: 2026-02-06
 heroImage: '/notebook-assets/footnotes-at-the-edge-of-reality/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/video.mp4'
+youtubeUrl: 'https://www.youtube.com/watch?v=3jYi9NvK5qY'
 ---
 
 Matter tells Space how to curve. Space tells Matter how to move. The poem begins where Wheeler's formulation begins — with a dialogue, not a command. No force imposes order. There is no throne at the centre of things. There is only a conversation, reciprocal and ongoing, between two things that cannot exist without each other.

--- a/src/content/projects/freedom-engine.md
+++ b/src/content/projects/freedom-engine.md
@@ -9,6 +9,7 @@ date: 2025-04-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/freedom-engine/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/freedom-engine/video.mp4'
 heroImage: '/notebook-assets/freedom-engine/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=DiUEJScqN8I'
 ---
 
 Over 264,000 people are held in the US federal prison system. Many are eligible for reduced sentences under the First Step Act. The provisions exist. The information is public. But the legal complexity makes it inaccessible to most inmates without outside help. The information gap is not theoretical—it costs people months or years of their lives.

--- a/src/content/projects/grid2.md
+++ b/src/content/projects/grid2.md
@@ -9,6 +9,7 @@ date: 2025-05-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/grid2/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/grid2/video.mp4'
 heroImage: '/notebook-assets/grid2/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=HB4bZPOv3NI'
 ---
 
 The problem with AI website builders is hallucination. Ask a language model to generate a page and you get something that looks plausible until you inspect it—broken layouts, invented components, styles that conflict. The output is probabilistic. Probability is not what you want from a build system.

--- a/src/content/projects/home-assistant-obsidian.md
+++ b/src/content/projects/home-assistant-obsidian.md
@@ -9,6 +9,7 @@ date: 2024-06-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/home-assistant-obsidian/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/home-assistant-obsidian/video.mp4'
 heroImage: '/notebook-assets/home-assistant-obsidian/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=Z9GNQlp9g0A'
 ---
 
 I keep two systems running at home that shape how I think: Obsidian for knowledge, Home Assistant for the physical environment. They existed on separate machines, with separate maintenance windows, separate failure modes. The obvious question was why.

--- a/src/content/projects/latent-self.md
+++ b/src/content/projects/latent-self.md
@@ -9,6 +9,7 @@ date: 2025-02-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/latent-self/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/latent-self/video.mp4'
 heroImage: '/notebook-assets/latent-self/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=03vYwCXjckQ'
 ---
 
 A mirror shows you what you are. This installation shows you what you almost are.

--- a/src/content/projects/lunar-tools-prototypes.md
+++ b/src/content/projects/lunar-tools-prototypes.md
@@ -9,6 +9,7 @@ date: 2025-06-15
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/lunar-tools-prototypes/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lunar-tools-prototypes/video.mp4'
 heroImage: '/notebook-assets/lunar-tools-prototypes/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=QIN1nHFvPMQ'
 ---
 
 A visitor speaks into a microphone. Their voice becomes a brushstroke. An ambient sound becomes a fractal branch. A dream described aloud becomes an image that did not exist until they said it.

--- a/src/content/projects/modelatlas.md
+++ b/src/content/projects/modelatlas.md
@@ -9,6 +9,7 @@ date: 2025-04-15
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/modelatlas/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/modelatlas/video.mp4'
 heroImage: '/notebook-assets/modelatlas/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=Y9o5Iy_daps'
 ---
 
 There are thousands of foundation models now. New ones appear daily. Most metadata about them is incomplete, inconsistent, or wrong. Context lengths are missing. Base model lineage is ambiguous. Quantisation details are buried in config blobs that nobody parses. If you want to choose a model for a production system, you are assembling the picture yourself from fragments.

--- a/src/content/projects/neuroconnect.md
+++ b/src/content/projects/neuroconnect.md
@@ -9,6 +9,7 @@ date: 2025-05-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/neuroconnect/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/neuroconnect/video.mp4'
 heroImage: '/notebook-assets/neuroconnect/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=HZnnK4bLub4'
 ---
 
 A person with ADHD calls a helpline. They trail off mid-sentence. There is a pause—maybe they lost the word, maybe they lost the thread, maybe they are in crisis. The system has to know the difference. It has to know in under a second.


### PR DESCRIPTION
## Summary

- Adds `youtubeUrl` to 16 blog posts and projects with newly uploaded cinematic NLM videos
- All videos are dark botanical style (generated with `--focus` botanical prompt)
- Correct robot video re-uploaded after old non-cinematic version was deleted

## Videos uploaded

| Slug | YouTube |
|------|---------|
| the-robot-that-refuses-to-give-orders | SOUJUti2oDw |
| auditory-spiral | TyttZAAO8gs |
| before-the-words-existed | ZZDPvTlA4Xw |
| cv | 1Zg7I5Awymc |
| cygnet | F_wgoUYlXYY |
| dodgylegally | xF-BklkSqoI |
| dx0 | h9H9TnoI8hk |
| emdr-agent | owXdPDifuQE |
| footnotes-at-the-edge-of-reality | 3jYi9NvK5qY |
| freedom-engine | DiUEJScqN8I |
| grid2 | HB4bZPOv3NI |
| home-assistant-obsidian | Z9GNQlp9g0A |
| latent-self | 03vYwCXjckQ |
| lunar-tools-prototypes | QIN1nHFvPMQ |
| modelatlas | Y9o5Iy_daps |
| neuroconnect | HZnnK4bLub4 |

## Remaining

~15 slugs still need uploading (quota hit on notebooklm-automation). Run `python3 /tmp/cinematic-upload-pipeline.py` after midnight PT to continue.
`failure-first` skipped — no cinematic NLM video found.