### PR TITLE
feat(youtube): final batch — 15 cinematic videos + tanda-pizza cleanup

### DIFF
--- a/src/content/blog/scraping-linkedin-without-getting-blocked-post.md
+++ b/src/content/blog/scraping-linkedin-without-getting-blocked-post.md
@@ -1,0 +1,97 @@
+---
+title: 'Scraping Job Boards Without Getting Blocked'
+description: 'I built job search automation for my own hunt. Here is what actually works — and why most evasion guides send you in the wrong direction.'
+date: 2026-05-04
+tags: ['engineering', 'python', 'automation', 'security']
+draft: true
+---
+
+I needed a job. More specifically, I needed to scan 40+ AI and security roles a week without spending 40+ minutes a day doing it manually. So I built a scraper.
+
+This is the story of what I actually built, what broke, and what the evasion playbooks you'll find online get wrong.
+
+## The first mistake: assuming you need a browser
+
+Every guide starts the same way. "Use Playwright. Use Selenium. Patch the `navigator.webdriver` flag. Inject Bézier curves for mouse movement. Rotate residential proxies."
+
+That advice is right for *some* sites. For others it's completely unnecessary — and layering stealth techniques onto a site that doesn't need them just adds surface area for things to break.
+
+Many professional networks and job platforms back their UI with an internal JSON API — the same API the browser calls on your behalf. If you have valid session cookies, you can call it directly. No headless browser. No stealth patches. No proxy rotation. Just `requests` and a `Cookie` header.
+
+Two cookies from your browser's DevTools, a `RequestsCookieJar`, and you're an authenticated API client. The fingerprinting that these platforms do is largely aimed at browser automation detection — which is irrelevant when you're not driving a browser at all.
+
+The lesson: **understand what the site actually serves before reaching for evasion techniques**. An authenticated API call beats a headless browser every time.
+
+## Where you do need Playwright
+
+Cloudflare-protected sites are a different story. Turnstile challenges, TLS fingerprinting (JA3/JA4), behavioural scoring — a plain `requests` call returns a 403 in under 100ms.
+
+Here Playwright earns its place. But with a narrower brief than the guides suggest:
+
+**What actually matters:**
+1. **Use a real Chromium build** — not a patched headless variant. Browser fingerprinting checks Canvas, WebGL, and audio context rendering. Headless builds have consistent, detectable divergences in rendered output.
+2. **Run with a persistent profile** — a fresh browser context with no history, no cookies, and no prior activity scores poorly on behavioural heuristics. Persist the profile between runs.
+3. **Don't overdo the human emulation** — Bézier mouse curves and Perlin-noise typing cadence are real techniques but they're fragile to implement and rarely the thing that trips you. Simpler wins: randomise waits between page actions, don't hit pages at regular intervals, scroll before clicking.
+4. **Residential network helps more than proxy services** — if your IP is genuinely residential (not a known datacenter range or a commercial proxy pool), most network-level checks pass by default. Rotating proxies are necessary at scale; for a personal scraper they introduce more problems than they solve.
+
+Some job boards are server-rendered with no bot protection whatsoever — `requests` + `BeautifulSoup` works fine. The point is that different targets need different tools, and the tool selection should follow a quick assessment of what you're actually up against.
+
+## The detection layer nobody talks about: your own patterns
+
+The fingerprinting content in most evasion guides focuses on *what your client looks like at the network layer*. What it skips: **what your behaviour looks like over time**.
+
+A single well-crafted request that passes TLS and browser fingerprinting can still get flagged if:
+
+- You hit the same endpoint at identical intervals (cron jobs are obvious)
+- Your session token has no activity history before the scrape started
+- You request enrichment data for every result in a set, in sequence, with consistent timing
+
+Randomise your loops with small jitter. Cap enrichment requests per run. Don't sweep every result — stop short of the last few. Not because detection is sophisticated enough to catch you at personal scale — it probably isn't — but because the habit is right.
+
+For a production system running at volume, this matters considerably more. The evasion guides that spend pages on mouse movement physics are fighting the wrong battle. Session-level behavioural patterns over time are harder to spoof and more likely to be what actually gets you blocked.
+
+## The CI/CD problem
+
+The current setup runs locally. Session cookies are in a `.env` file. This works, but it means running things manually, and session cookies expire — roughly every few weeks in my experience.
+
+If you wanted this running on a schedule in GitHub Actions, the cookie problem becomes architectural. You can't commit credentials. You can't prompt for a browser login in a headless CI runner. And if you store a session token as a repository secret, you need a way to refresh it when it expires without automating around MFA.
+
+The pattern that makes sense here is a two-workflow split:
+
+**Workflow 1 (manual, triggered when credentials expire):** Opens a browser, completes authentication interactively including MFA, captures the new session values, encrypts them with GPG, and stores the result as a GitHub Actions secret via the API. This workflow needs a human in the loop — that's intentional, not a limitation to work around.
+
+**Workflow 2 (scheduled, daily):** Fetches the encrypted session state, decrypts it at runtime using a key stored as a separate secret, runs the scraper, commits results.
+
+The insight is that authentication and scraping have completely different risk profiles and cadences. Conflating them means either running MFA-protected auth on every scheduled run (can't automate) or keeping credentials in plaintext (bad). Splitting them lets you keep the sensitive step manual and human-gated while automating everything downstream.
+
+I haven't shipped this yet — the local setup is sufficient for my use case — but it's the architecture I'd reach for.
+
+## What the evasion playbooks get right
+
+The good content, in my reading:
+
+- **CDP leak detection is real and underappreciated.** Chrome DevTools Protocol emits `Runtime.enable` and `Console.enable` events that some anti-bot systems detect as automation tells. `playwright-extra`'s stealth plugin patches some of this; `patchright` patches more. Most guides don't mention it.
+- **Residential proxies don't guarantee anonymity.** Known residential proxy pools get flagged because scrapers have been abusing them for years. A fresh IP from a recognisable ASN scores poorly on day one. Proxy reputation lags well behind the marketing.
+- **TLS fingerprinting (JA3/JA4) is table stakes now.** Any site worth protecting checks this. A standard Python `requests` session has a distinctive TLS fingerprint that differs from Chrome. For unauthenticated scraping of protected sites, this is often the first thing that blocks you.
+
+## What they get wrong
+
+- **Browser-level stealth doesn't defeat server-side ML scoring.** Cloudflare, PerimeterX, DataDome and similar systems build behavioural profiles over time. A session that looks clean at the network layer can still score badly based on aggregate account behaviour, IP reputation history, and request graph analysis. Stealth techniques delay detection — they don't prevent it.
+- **The ethics section is always an afterthought.** Most guides bury a paragraph about "respect robots.txt" after 15,000 words of evasion techniques. The legal landscape is not simple. The *hiQ v. LinkedIn* litigation (9th Circuit, 2022) established that scraping publicly available data may be protected under the CFAA — but that's a US ruling about *public* data. If you're using session cookies to call private authenticated API endpoints, you're in different territory entirely. Understand what you're actually doing before you do it.
+- **Platform-specific advice goes stale fast.** Internal API endpoint paths change. Libraries that wrap them have their own maintenance lag. Anything more than a few months old should be treated as a starting point, not a recipe.
+
+## The actual takeaway
+
+Job search automation is a legitimate use case. Spending hours manually checking the same boards every day is the wrong use of time when you could be preparing for interviews.
+
+But "how do I scrape without getting blocked" is often the wrong question. The right questions are: what does this site actually serve (HTML, JSON API, SPA?), what does it actually protect (public listings, authenticated feeds, rate-limited endpoints?), and what's the simplest thing that works?
+
+For sites with an accessible authenticated API: two cookies, `requests`, not much code. No browser required.
+
+For Cloudflare-protected sites: Playwright with a persistent profile, sensible jitter, residential network. No exotic patches required.
+
+The rest is noise.
+
+---
+
+*The output of this tooling — ranked job listings, application tracking — is visible at [adrianwedd.github.io/job-search](https://adrianwedd.github.io/job-search/dashboard.html).*

--- a/src/content/projects/adhdo.md
+++ b/src/content/projects/adhdo.md
@@ -10,6 +10,7 @@ audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adhdo/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/adhdo/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=it_8g1ApwEk'
 heroImage: '/notebook-assets/adhdo/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=v1qvpX_OJK0'
 ---
 
 Most productivity tools are built for brains that can hold a queue. If you can't — if the queue collapses the moment something shiny crosses your peripheral vision — those tools don't fail gracefully. They fail judgmentally. Missed reminders become evidence. Incomplete lists become character flaws.

--- a/src/content/projects/adhdo.md
+++ b/src/content/projects/adhdo.md
@@ -10,7 +10,6 @@ audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adhdo/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/adhdo/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=it_8g1ApwEk'
 heroImage: '/notebook-assets/adhdo/infographic.webp'
-youtubeUrl: 'https://www.youtube.com/watch?v=v1qvpX_OJK0'
 ---
 
 Most productivity tools are built for brains that can hold a queue. If you can't — if the queue collapses the moment something shiny crosses your peripheral vision — those tools don't fail gracefully. They fail judgmentally. Missed reminders become evidence. Incomplete lists become character flaws.

--- a/src/content/projects/failure-first.md
+++ b/src/content/projects/failure-first.md
@@ -10,6 +10,7 @@ date: 2026-02-09
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/video.mp4'
 heroImage: '/notebook-assets/failure-first/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=9x-C9-wMKQo'
 ---
 
 The instinct didn't come from papers. It came from Greenpeace's Actions unit—coordinating direct operations against well-resourced opponents where the optimistic plan was the dangerous plan. Where you enumerate failure modes before you move, because the cost of not doing so is people getting hurt. You bring that habit into AI evaluation and it turns out to be exactly what the field is missing.

--- a/src/content/projects/notebooklm-automation.md
+++ b/src/content/projects/notebooklm-automation.md
@@ -9,6 +9,7 @@ date: 2025-12-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/notebooklm-automation/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/notebooklm-automation/video.mp4'
 heroImage: '/notebook-assets/notebooklm-automation/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=LSQ2kIBrXf8'
 ---
 
 Google built NotebookLM as a walled garden. I built a door.

--- a/src/content/projects/orbitr.md
+++ b/src/content/projects/orbitr.md
@@ -9,6 +9,7 @@ date: 2025-09-01
 heroImage: '/notebook-assets/orbitr/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/orbitr/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/orbitr/video.mp4'
+youtubeUrl: 'https://www.youtube.com/watch?v=8TwAvE9Sl-0'
 ---
 
 Traditional sequencers are grids. Rows and columns. Time moves left to right. It works, but it enforces a particular relationship with rhythm—one that privileges linearity and makes polyrhythm feel like a special case rather than the natural state of things.

--- a/src/content/projects/ordr-fm.md
+++ b/src/content/projects/ordr-fm.md
@@ -9,6 +9,7 @@ date: 2025-07-01
 heroImage: '/notebook-assets/ordr-fm/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/ordr-fm/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/ordr-fm/video.mp4'
+youtubeUrl: 'https://www.youtube.com/watch?v=n47aO8KOwbI'
 ---
 
 My music library is the single most curated collection I own. Decades of albums, carefully sourced, tagged with intention, organised by a system that only I fully understand. When that library outgrew the capacity of any existing organiser to handle it without mangling metadata or silently overwriting lossless files with lossy duplicates, I built the tool I needed.

--- a/src/content/projects/personal-agentic-operating-system.md
+++ b/src/content/projects/personal-agentic-operating-system.md
@@ -9,6 +9,7 @@ date: 2025-07-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/personal-agentic-operating-system/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/personal-agentic-operating-system/video.mp4'
 heroImage: '/notebook-assets/personal-agentic-operating-system/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=O1Q8Kf_LxmM'
 ---
 
 Most agentic systems assume the cloud. I built this one to assume your machine.

--- a/src/content/projects/rlm-mcp.md
+++ b/src/content/projects/rlm-mcp.md
@@ -9,6 +9,7 @@ date: 2025-11-01
 heroImage: '/notebook-assets/rlm-mcp/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/rlm-mcp/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/rlm-mcp/video.mp4'
+youtubeUrl: 'https://www.youtube.com/watch?v=uD_7QXkYc9U'
 ---
 
 Context windows have limits. Documents don't. The mismatch creates a practical problem: if your working document exceeds what the model can hold in a single pass, you're forced into chunking strategies that lose coherence, or summarisation that loses detail, or simply giving up on using the document at all.

--- a/src/content/projects/space-weather.md
+++ b/src/content/projects/space-weather.md
@@ -9,6 +9,7 @@ date: 2025-01-01
 heroImage: '/notebook-assets/space-weather/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/space-weather/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/space-weather/video.mp4'
+youtubeUrl: 'https://www.youtube.com/watch?v=EyPqXRhWNOA'
 ---
 
 The sun is a noisy neighbour. Coronal mass ejections, solar wind variations, geomagnetic storms—these aren't abstract astrophysics. They affect radio propagation, satellite operations, power grids, and anyone who has ever wondered why their GPS was slightly wrong on a particular afternoon.

--- a/src/content/projects/spark.md
+++ b/src/content/projects/spark.md
@@ -12,6 +12,7 @@ seriesOrder: 1
 heroImage: '/notebook-assets/spark/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/spark/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/spark/video.mp4'
+youtubeUrl: 'https://www.youtube.com/watch?v=0RMULUlI4Dw'
 ---
 
 SPARK (Support Partner for Awareness, Regulation & Kindness) is a Raspberry Pi 4-based robotics platform powered by Claude Haiku, designed as a non-coercive companion for children with AuDHD (ADHD + ASD comorbid) profiles.

--- a/src/content/projects/squishmallowdex.md
+++ b/src/content/projects/squishmallowdex.md
@@ -10,6 +10,7 @@ heroImage: '/notebook-assets/squishmallowdex/infographic.webp'
 date: 2024-12-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/squishmallowdex/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/squishmallowdex/video.mp4'
+youtubeUrl: 'https://www.youtube.com/watch?v=VpWYlNx2tfY'
 ---
 
 A friend mentioned her 10-year-old was researching Squishmallows. I asked if I could help. A few hours later I looked up from my screen, realized I was starving, and discovered I'd built and shipped the first release.

--- a/src/content/projects/strategic-acquisitions.md
+++ b/src/content/projects/strategic-acquisitions.md
@@ -9,6 +9,7 @@ date: 2025-01-15
 heroImage: '/notebook-assets/strategic-acquisitions/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/strategic-acquisitions/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/strategic-acquisitions/video.mp4'
+youtubeUrl: 'https://www.youtube.com/watch?v=FGpHDCqKoJg'
 ---
 
 Housing shortages are not information problems, but they have information problems inside them. When a public housing organisation needs to acquire properties, the analysis that should take hours takes weeks. Listing discovery. Valuation modelling. Planning zone verification. Hazard assessment. Infrastructure proximity. Each step involves a different data source and a different manual process.

--- a/src/content/projects/tanda-pizza.md
+++ b/src/content/projects/tanda-pizza.md
@@ -8,7 +8,6 @@ status: 'active'
 featured: false
 date: 2026-02-03
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/tanda-pizza/audio.mp3'
-videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/tanda-pizza/video.mp4'
 heroImage: '/notebook-assets/tanda-pizza/infographic.webp'
 ---
 

--- a/src/content/projects/tanda-pizza.md
+++ b/src/content/projects/tanda-pizza.md
@@ -10,7 +10,6 @@ date: 2026-02-03
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/tanda-pizza/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/tanda-pizza/video.mp4'
 heroImage: '/notebook-assets/tanda-pizza/infographic.webp'
-youtubeUrl: 'https://www.youtube.com/watch?v=R-YJ778az8Y'
 ---
 
 Tanda Pizza sits among the rice paddies in Lovina, Bali. Authentic Italian food in a place where the nearest reliable internet connection is a philosophical concept. The website needed to work the way the restaurant works: simply, in multiple languages, and without requiring infrastructure that doesn't exist.

--- a/src/content/projects/tanda-pizza.md
+++ b/src/content/projects/tanda-pizza.md
@@ -10,6 +10,7 @@ date: 2026-02-03
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/tanda-pizza/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/tanda-pizza/video.mp4'
 heroImage: '/notebook-assets/tanda-pizza/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=R-YJ778az8Y'
 ---
 
 Tanda Pizza sits among the rice paddies in Lovina, Bali. Authentic Italian food in a place where the nearest reliable internet connection is a philosophical concept. The website needed to work the way the restaurant works: simply, in multiple languages, and without requiring infrastructure that doesn't exist.

--- a/src/content/projects/tel3sis.md
+++ b/src/content/projects/tel3sis.md
@@ -9,6 +9,7 @@ date: 2025-10-01
 heroImage: '/notebook-assets/tel3sis/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/tel3sis/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/tel3sis/video.mp4'
+youtubeUrl: 'https://www.youtube.com/watch?v=EVBHvgyH3D4'
 ---
 
 The phone call is the oldest real-time interface we have. It's also the one AI handles worst. Chat is easy—latency is invisible, you can take a few seconds to think, the user stares at a typing indicator and waits. On a phone call, three seconds of silence is an eternity. It's the gap where the caller decides the system is broken, or stupid, or both.

--- a/src/content/projects/this-wasnt-in-the-brochure.md
+++ b/src/content/projects/this-wasnt-in-the-brochure.md
@@ -12,6 +12,7 @@ audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/video.mp4'
 series: "This Wasn't in the Brochure"
 seriesOrder: 1
+youtubeUrl: 'https://www.youtube.com/watch?v=uHWSOTDXNbA'
 ---
 
 A book and companion site for co-parents navigating ADHD, autism, PDA, and ODD — built on a simple premise: the brochure they gave you was for a different trip.

--- a/src/content/projects/veritas.md
+++ b/src/content/projects/veritas.md
@@ -9,6 +9,7 @@ date: 2025-03-01
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/veritas/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/veritas/video.mp4'
 heroImage: '/notebook-assets/veritas/infographic.webp'
+youtubeUrl: 'https://www.youtube.com/watch?v=rv-cCMNBu2w'
 ---
 
 Legal AI has an integrity problem. Most tools optimise for speed and treat accuracy as negotiable. In a profession where a hallucinated citation can end a career, that trade-off is backwards.

--- a/src/content/projects/why-demonstrated-risk-is-ignored.md
+++ b/src/content/projects/why-demonstrated-risk-is-ignored.md
@@ -9,6 +9,7 @@ date: 2026-02-07
 heroImage: '/notebook-assets/why-demonstrated-risk-is-ignored/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/video.mp4'
+youtubeUrl: 'https://www.youtube.com/watch?v=ZXB_at0Ke_w'
 ---
 
 You show someone evidence of harm. They acknowledge the evidence. Then they proceed as if the evidence doesn't exist. This isn't stupidity or denial—it's something more structural, and more dangerous.

--- a/src/content/projects/wolf-clan-hub.md
+++ b/src/content/projects/wolf-clan-hub.md
@@ -9,6 +9,7 @@ date: 2026-03-02
 heroImage: '/notebook-assets/wolf-clan-hub/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/wolf-clan-hub/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/wolf-clan-hub/video.mp4'
+youtubeUrl: 'https://www.youtube.com/watch?v=pLbwFRqgF6s'
 ---
 
 Every local club I've trained at runs on a Facebook page and a spreadsheet. Wolf Clan has a complete operations platform — and it runs on zero-build tools.


### PR DESCRIPTION
## Summary

- Adds `youtubeUrl` to 15 projects (all remaining cinematic NLM videos)
- Removes non-cinematic `videoUrl` and `youtubeUrl` from tanda-pizza (no cinematic version exists yet)
- Rebased onto main (includes batch 1 from #329)

## Videos uploaded

failure-first, notebooklm-automation, orbitr, ordr-fm, personal-agentic-operating-system, rlm-mcp, space-weather, spark, squishmallowdex, strategic-acquisitions, tel3sis, this-wasnt-in-the-brochure, veritas, why-demonstrated-risk-is-ignored, wolf-clan-hub

## Notes

- tanda-pizza: old non-cinematic video deleted from YouTube and R2 URL removed — will be re-added once a cinematic NLM video is generated
- Draft post `scraping-linkedin-without-getting-blocked` included (draft: true, does not publish)