### PR TITLE
feat(schema): add embedUrl + url to VideoObject JSON-LD from youtubeUrl

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -112,23 +112,30 @@ const matchedProject = allProjects.find(
     })}
   />
   {
-    post.data.videoUrl && (
-      <script
-        is:inline
-        type="application/ld+json"
-        set:html={JSON.stringify({
-          '@context': 'https://schema.org',
-          '@type': 'VideoObject',
-          name: post.data.title,
-          description: post.data.description,
-          contentUrl: new URL(post.data.videoUrl, Astro.site).href,
-          uploadDate: post.data.date.toISOString(),
-          thumbnailUrl: post.data.heroImage
-            ? new URL(post.data.heroImage, Astro.site).href
-            : new URL('/og-default.png', Astro.site).href,
-        })}
-      />
-    )
+    (post.data.videoUrl || post.data.youtubeUrl) && (() => {
+      const ytId = post.data.youtubeUrl?.match(/[?&]v=([^&]+)/)?.[1];
+      return (
+        <script
+          is:inline
+          type="application/ld+json"
+          set:html={JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'VideoObject',
+            name: post.data.title,
+            description: post.data.description,
+            ...(post.data.videoUrl && { contentUrl: new URL(post.data.videoUrl, Astro.site).href }),
+            ...(ytId && {
+              embedUrl: `https://www.youtube.com/embed/${ytId}`,
+              url: post.data.youtubeUrl,
+            }),
+            uploadDate: post.data.date.toISOString(),
+            thumbnailUrl: post.data.heroImage
+              ? new URL(post.data.heroImage, Astro.site).href
+              : new URL('/og-default.png', Astro.site).href,
+          })}
+        />
+      );
+    })()
   }
   {
     post.data.faq && post.data.faq.length > 0 && (

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -109,23 +109,30 @@ const allBlogPosts = project.data.series
     })}
   />
   {
-    project.data.videoUrl && (
-      <script
-        is:inline
-        type="application/ld+json"
-        set:html={JSON.stringify({
-          '@context': 'https://schema.org',
-          '@type': 'VideoObject',
-          name: project.data.title,
-          description: project.data.description,
-          contentUrl: new URL(project.data.videoUrl, Astro.site).href,
-          uploadDate: project.data.date.toISOString(),
-          thumbnailUrl: project.data.heroImage
-            ? new URL(project.data.heroImage, Astro.site).href
-            : new URL('/og-default.png', Astro.site).href,
-        })}
-      />
-    )
+    (project.data.videoUrl || project.data.youtubeUrl) && (() => {
+      const ytId = project.data.youtubeUrl?.match(/[?&]v=([^&]+)/)?.[1];
+      return (
+        <script
+          is:inline
+          type="application/ld+json"
+          set:html={JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'VideoObject',
+            name: project.data.title,
+            description: project.data.description,
+            ...(project.data.videoUrl && { contentUrl: new URL(project.data.videoUrl, Astro.site).href }),
+            ...(ytId && {
+              embedUrl: `https://www.youtube.com/embed/${ytId}`,
+              url: project.data.youtubeUrl,
+            }),
+            uploadDate: project.data.date.toISOString(),
+            thumbnailUrl: project.data.heroImage
+              ? new URL(project.data.heroImage, Astro.site).href
+              : new URL('/og-default.png', Astro.site).href,
+          })}
+        />
+      );
+    })()
   }
   <article class="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
     <Breadcrumb


### PR DESCRIPTION
## Summary

- VideoObject schema on blog/project pages now includes `embedUrl` and `url` from `youtubeUrl` frontmatter
- Condition broadened: VideoObject emits when either `videoUrl` or `youtubeUrl` is set (previously only `videoUrl`)
- `contentUrl` (R2 CDN) and `embedUrl`/`url` (YouTube) are each conditional on their respective field being present
- Closes #138

## Before
```json
{ "@type": "VideoObject", "contentUrl": "https://cdn.../video.mp4" }
```

## After
```json
{
  "@type": "VideoObject",
  "contentUrl": "https://cdn.../video.mp4",
  "embedUrl": "https://www.youtube.com/embed/VIDEO_ID",
  "url": "https://www.youtube.com/watch?v=VIDEO_ID"
}
```