### PR TITLE
ci: reduce artifact storage bloat

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,6 +105,7 @@ jobs:
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: dist
+          retention-days: 7
 
   worker-csp:
     runs-on: ubuntu-latest

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run Lighthouse
         uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # 12.6.2
         with:
-          uploadArtifacts: true
+          uploadArtifacts: false
           temporaryPublicStorage: true
           configPath: .github/lighthouse/lighthouserc.json
 


### PR DESCRIPTION
## Changes

- **lighthouse.yml**: `uploadArtifacts: false` — `temporaryPublicStorage: true` already provides a public report URL; GitHub artifact copies were redundant accumulation (9MB × every PR)
- **deploy.yml**: `retention-days: 7` on `upload-pages-artifact` — pages artifacts were accumulating indefinitely at 102MB per deploy

## Impact

- Freed **~1.26GB** of existing accumulated artifacts (171 deleted manually)
- Forward: lighthouse results no longer stored as artifacts; pages artifacts capped at 7 days
- No functionality change — Lighthouse report URL still available via `temporaryPublicStorage`