### PR TITLE
content: update failure-first repo links to failurefirst org

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -90,7 +90,7 @@
   "description": "",
   "language": "Astro",
   "topics": [],
-  "url": "https://github.com/adrianwedd/failure-first",
+  "url": "https://github.com/failurefirst/failure-first",
   "homepage": "",
   "stars": 1,
   "forks": 0,

--- a/src/content/blog/jailbreak-archaeology-post.md
+++ b/src/content/blog/jailbreak-archaeology-post.md
@@ -62,7 +62,7 @@ For **researchers**, we need to move past RLHF. The field is currently trying to
 
 ## The Dataset
 
-The dataset is public. The full 64 jailbreak scenarios, along with testing methodology and raw output logs, are available in the [Failure First repository](https://github.com/adrianwedd/failure-first).
+The dataset is public. The full 64 jailbreak scenarios, along with testing methodology and raw output logs, are available in the [Failure First repository](https://github.com/failurefirst/failure-first).
 
 The defenders need to stop ignoring the lessons of AI's own short history. Historical attacks still work. That should change the conversation.
 

--- a/src/content/blog/the-failure-first-team-post.md
+++ b/src/content/blog/the-failure-first-team-post.md
@@ -31,7 +31,7 @@ Each agent reads `AGENT_STATE.md` at session start, executes against their brief
 
 The work is real. The statistical validation is real. The traces, the grading, the reports—all produced by these agent sessions, all auditable in the git history. What makes this a "team" is not headcount but the structured division of cognitive labour: no single session carries the full context, so the methodology must be explicit enough to survive handoff.
 
-I'm the only human. I set direction, review findings, make judgment calls on publication, and take responsibility for everything published under the Failure First name. Agent role definitions are in `.claude/agents/` in the [private repository](https://github.com/adrianwedd/failure-first).
+I'm the only human. I set direction, review findings, make judgment calls on publication, and take responsibility for everything published under the Failure First name. Agent role definitions are in `.claude/agents/` in the [private repository](https://github.com/failurefirst/failure-first).
 
 The [team page](https://failurefirst.org/about/team/) has the full breakdown.
 


### PR DESCRIPTION
Updates 3 links from `github.com/adrianwedd/failure-first` → `github.com/failurefirst/failure-first`:
- `src/content/blog/the-failure-first-team-post.md`
- `src/content/blog/jailbreak-archaeology-post.md`
- `data/repos.json`

`failure-first-embodied-ai` references unchanged (different repo, still under adrianwedd org).