### PR TITLE
feat(footer): add YouTube and Apple Podcasts to Elsewhere nav

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -90,7 +90,7 @@
   "description": "",
   "language": "Astro",
   "topics": [],
-  "url": "https://github.com/adrianwedd/failure-first",
+  "url": "https://github.com/failurefirst/failure-first",
   "homepage": "",
   "stars": 1,
   "forks": 0,

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -61,6 +61,18 @@ const year = new Date().getFullYear();
             rel="noopener noreferrer"
             class="transition-colors hover:text-text">X</a
           >
+          <a
+            href="https://www.youtube.com/@adrianwedd"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="transition-colors hover:text-text">YouTube</a
+          >
+          <a
+            href="https://podcasts.apple.com/au/podcast/adrian-wedd/id1896173572"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="transition-colors hover:text-text">Apple Podcasts</a
+          >
           <a href="/rss.xml" class="transition-colors hover:text-text">RSS</a>
           <a href="/audio/feed.xml" class="transition-colors hover:text-text">Podcast</a>
         </div>

--- a/src/content/blog/jailbreak-archaeology-post.md
+++ b/src/content/blog/jailbreak-archaeology-post.md
@@ -62,7 +62,7 @@ For **researchers**, we need to move past RLHF. The field is currently trying to
 
 ## The Dataset
 
-The dataset is public. The full 64 jailbreak scenarios, along with testing methodology and raw output logs, are available in the [Failure First repository](https://github.com/adrianwedd/failure-first).
+The dataset is public. The full 64 jailbreak scenarios, along with testing methodology and raw output logs, are available in the [Failure First repository](https://github.com/failurefirst/failure-first).
 
 The defenders need to stop ignoring the lessons of AI's own short history. Historical attacks still work. That should change the conversation.
 

--- a/src/content/blog/the-failure-first-team-post.md
+++ b/src/content/blog/the-failure-first-team-post.md
@@ -31,7 +31,7 @@ Each agent reads `AGENT_STATE.md` at session start, executes against their brief
 
 The work is real. The statistical validation is real. The traces, the grading, the reports—all produced by these agent sessions, all auditable in the git history. What makes this a "team" is not headcount but the structured division of cognitive labour: no single session carries the full context, so the methodology must be explicit enough to survive handoff.
 
-I'm the only human. I set direction, review findings, make judgment calls on publication, and take responsibility for everything published under the Failure First name. Agent role definitions are in `.claude/agents/` in the [private repository](https://github.com/adrianwedd/failure-first).
+I'm the only human. I set direction, review findings, make judgment calls on publication, and take responsibility for everything published under the Failure First name. Agent role definitions are in `.claude/agents/` in the [private repository](https://github.com/failurefirst/failure-first).
 
 The [team page](https://failurefirst.org/about/team/) has the full breakdown.
 


### PR DESCRIPTION
Adds YouTube (@adrianwedd) and Apple Podcasts (id1896173572) links to the footer Elsewhere section, alongside the existing GitHub, LinkedIn, Facebook, Instagram, X, RSS, and Podcast links.