### PR TITLE
fix(deps): bump wrangler to ^4.88.0 — OS Command Injection CVE

### DIFF
--- a/worker-csp/package-lock.json
+++ b/worker-csp/package-lock.json
@@ -12,7 +12,7 @@
         "@cloudflare/workers-types": "^4.20260504.1",
         "typescript": "^5.8.0",
         "vitest": "~3.0.0",
-        "wrangler": "^4.87.0"
+        "wrangler": "^4.88.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -3328,9 +3328,9 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.87.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.87.0.tgz",
-      "integrity": "sha512-lfhfKwLfQlowwgV0xhlYgE9fU3n0I30d4ccGY/rTCEm/n42Mjvlr0Ng3ZPNqlsrsKBcDR531V7dsPkgELvrk/Q==",
+      "version": "4.88.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.88.0.tgz",
+      "integrity": "sha512-f470QwbeT/JM1S0duq+sLtkss7UBxIFDtYHgujv9tdQUyA/dLGDq51am0rqrsuFtCi97lTM1P5sqtt8xra1AlA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -3338,10 +3338,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260430.0",
+        "miniflare": "4.20260504.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260430.1"
+        "workerd": "1.20260504.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -3354,7 +3354,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260430.1"
+        "@cloudflare/workers-types": "^4.20260504.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -3363,9 +3363,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260430.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260430.1.tgz",
-      "integrity": "sha512-ADohZUHf7NBvPp2PdZig2Opxx+hDkk3ve7jrTne3JRx9kDSB73zc4LzcEeEN8LKkbAcqZmvfRJfpChSlusu0lA==",
+      "version": "1.20260504.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260504.1.tgz",
+      "integrity": "sha512-IOMjYoftNRXabFt+QzY2Bo2mR2TNl8xsGvE0HnQ+K0S2c61VOUGUkr9gpJjnwrJ65yA9Qed4xfg0RRqXHO+nfA==",
       "cpu": [
         "x64"
       ],
@@ -3380,9 +3380,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260430.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260430.1.tgz",
-      "integrity": "sha512-/DoYC/1wHs+YRZzzqSQg1/EHB4hiv1yV5U8FnmapRRIzVaPtnt+ApeOXeMrIdKidgKOI8TqQzgBU8xbIM7Cl4Q==",
+      "version": "1.20260504.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260504.1.tgz",
+      "integrity": "sha512-7iMXxIU0N5KklZpQm2kuwTm0XtrpHXNqhejJyGquky8gSTnm31zBdutjMekH8VRr6ckbvZIl6lvqXzXdfOEojg==",
       "cpu": [
         "arm64"
       ],
@@ -3397,9 +3397,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260430.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260430.1.tgz",
-      "integrity": "sha512-koJhBWvEVZPKCVFtMLp2iMHlYr+lFCF47wGbnlKdHVlemV0zTxJEyHI8aLlrhPLhBmOmYLp46rXw09/qJkRIhQ==",
+      "version": "1.20260504.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260504.1.tgz",
+      "integrity": "sha512-YLB0EH5FQV++oWlalFgPF3p2Bp3dn/D6RWNMw0ukEC8gKnNX6o61A+dlFUl8hRD35ja1zKRxGFUojs4U2+MoJA==",
       "cpu": [
         "x64"
       ],
@@ -3414,9 +3414,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260430.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260430.1.tgz",
-      "integrity": "sha512-hMdapNAzNQZDXGGkg4Slydc3fRJP5FUZLJVVcZCW/+imhhJro9Z1rv5n/wfR+txKoSWhTYR8eOp8Pyi2bzLzlw==",
+      "version": "1.20260504.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260504.1.tgz",
+      "integrity": "sha512-FAh/82jDXDArfn9xDih6f/IJfF2SHXBb4nFeQAyHyvXrn18zM6Q3yl2Vj0U7LybbNbmu7TNGghwaM2NoSQS+0A==",
       "cpu": [
         "arm64"
       ],
@@ -3431,9 +3431,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260430.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260430.1.tgz",
-      "integrity": "sha512-jS3ffixjb5USOwz4frw4WzCz0HrjVxkgyU3WiYb06N7hBAfN6eOrveAJ4QRef0+suK4V1vQFoB1oKdRBsXe9Dw==",
+      "version": "1.20260504.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260504.1.tgz",
+      "integrity": "sha512-QUg/B3dfrK/KHHHhiJzdkLkTg5mG7lA3t8iplbBoUa3XKCLOHOOXhbU4WSYlLqg8YnsQ6XLZ1HVA99fmZhJh7A==",
       "cpu": [
         "x64"
       ],
@@ -4348,16 +4348,16 @@
       }
     },
     "node_modules/wrangler/node_modules/miniflare": {
-      "version": "4.20260430.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260430.0.tgz",
-      "integrity": "sha512-MWvMm3Siho9Yj7lbJZidLs8hbrRvIcOrif2mnsHQZdvoKfedpea+GaN8XJxbpRcq0B2WzNI1BB1ihdnqes3/ZA==",
+      "version": "4.20260504.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260504.0.tgz",
+      "integrity": "sha512-HeI/HLx+rbeo/UB4qb6NsNcFdUVD7xDzyCexZJTVtFMlfpfexUKEDmdeTRRpzeHrJseZFGua+v9JO1kfPublUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "^0.34.5",
         "undici": "7.24.8",
-        "workerd": "1.20260430.1",
+        "workerd": "1.20260504.1",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10"
       },
@@ -4424,9 +4424,9 @@
       }
     },
     "node_modules/wrangler/node_modules/workerd": {
-      "version": "1.20260430.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260430.1.tgz",
-      "integrity": "sha512-KEgIWyiw3Jmn+DCd/L3ePo5fmiiYb/UcwKvDWPf/nLLOiwShDFzDSsegU5NY/JcwgvO/QsLHVi2FYrbkcXNY5Q==",
+      "version": "1.20260504.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260504.1.tgz",
+      "integrity": "sha512-AQTXSHbYNP9tLPgJNn0TmizyE4aDh2VuZZXlTAL0uu4fbCY436NAnQSJIzZbaFHM3DnAtVs9G8tkiJztSdYqDg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -4437,11 +4437,11 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260430.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260430.1",
-        "@cloudflare/workerd-linux-64": "1.20260430.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260430.1",
-        "@cloudflare/workerd-windows-64": "1.20260430.1"
+        "@cloudflare/workerd-darwin-64": "1.20260504.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260504.1",
+        "@cloudflare/workerd-linux-64": "1.20260504.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260504.1",
+        "@cloudflare/workerd-windows-64": "1.20260504.1"
       }
     },
     "node_modules/ws": {

--- a/worker-csp/package.json
+++ b/worker-csp/package.json
@@ -15,6 +15,6 @@
     "@cloudflare/workers-types": "^4.20260504.1",
     "typescript": "^5.8.0",
     "vitest": "~3.0.0",
-    "wrangler": "^4.87.0"
+    "wrangler": "^4.88.0"
   }
 }

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -14,28 +14,28 @@
         "@cloudflare/workers-types": "^4.20260301.0",
         "typescript": "^5.8.0",
         "vitest": "^3.1.0",
-        "wrangler": "^4.5.0"
+        "wrangler": "^4.88.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
-      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.0.tgz",
-      "integrity": "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
+        "workerd": ">1.20260305.0 <2.0.0-0"
       },
       "peerDependenciesMeta": {
         "workerd": {
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260317.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260317.1.tgz",
-      "integrity": "sha512-8hjh3sPMwY8M/zedq3/sXoA2Q4BedlGufn3KOOleIG+5a4ReQKLlUah140D7J6zlKmYZAFMJ4tWC7hCuI/s79g==",
+      "version": "1.20260504.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260504.1.tgz",
+      "integrity": "sha512-IOMjYoftNRXabFt+QzY2Bo2mR2TNl8xsGvE0HnQ+K0S2c61VOUGUkr9gpJjnwrJ65yA9Qed4xfg0RRqXHO+nfA==",
       "cpu": [
         "x64"
       ],
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260317.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260317.1.tgz",
-      "integrity": "sha512-M/MnNyvO5HMgoIdr3QHjdCj2T1ki9gt0vIUnxYxBu9ISXS/jgtMl6chUVPJ7zHYBn9MyYr8ByeN6frjYxj0MGg==",
+      "version": "1.20260504.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260504.1.tgz",
+      "integrity": "sha512-7iMXxIU0N5KklZpQm2kuwTm0XtrpHXNqhejJyGquky8gSTnm31zBdutjMekH8VRr6ckbvZIl6lvqXzXdfOEojg==",
       "cpu": [
         "arm64"
       ],
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260317.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260317.1.tgz",
-      "integrity": "sha512-1ltuEjkRcS3fsVF7CxsKlWiRmzq2ZqMfqDN0qUOgbUwkpXsLVJsXmoblaLf5OP00ELlcgF0QsN0p2xPEua4Uug==",
+      "version": "1.20260504.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260504.1.tgz",
+      "integrity": "sha512-YLB0EH5FQV++oWlalFgPF3p2Bp3dn/D6RWNMw0ukEC8gKnNX6o61A+dlFUl8hRD35ja1zKRxGFUojs4U2+MoJA==",
       "cpu": [
         "x64"
       ],
@@ -95,9 +95,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260317.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260317.1.tgz",
-      "integrity": "sha512-3QrNnPF1xlaNwkHpasvRvAMidOvQs2NhXQmALJrEfpIJ/IDL2la8g499yXp3eqhG3hVMCB07XVY149GTs42Xtw==",
+      "version": "1.20260504.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260504.1.tgz",
+      "integrity": "sha512-FAh/82jDXDArfn9xDih6f/IJfF2SHXBb4nFeQAyHyvXrn18zM6Q3yl2Vj0U7LybbNbmu7TNGghwaM2NoSQS+0A==",
       "cpu": [
         "arm64"
       ],
@@ -112,9 +112,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260317.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260317.1.tgz",
-      "integrity": "sha512-MfZTz+7LfuIpMGTa3RLXHX8Z/pnycZLItn94WRdHr8LPVet+C5/1Nzei399w/jr3+kzT4pDKk26JF/tlI5elpQ==",
+      "version": "1.20260504.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260504.1.tgz",
+      "integrity": "sha512-QUg/B3dfrK/KHHHhiJzdkLkTg5mG7lA3t8iplbBoUa3XKCLOHOOXhbU4WSYlLqg8YnsQ6XLZ1HVA99fmZhJh7A==",
       "cpu": [
         "x64"
       ],
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260329.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260329.1.tgz",
-      "integrity": "sha512-LxBHrYYI/AZ6OCbUzRqRgg6Rt1qev2KxN2NNd3saye41AO2g52cYvHV+ohts5oPnrIUD7YRjbgN/J3NU7e7m5A==",
+      "version": "4.20260506.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260506.1.tgz",
+      "integrity": "sha512-IKv/C08utEbAqEu2zr0/3CMf1MbYrl7x0Z1UsrnMs4xxfIN81vtGTRduCZb7xJQpaICQPe0Sa6fhHlZmUXrMjw==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -149,9 +149,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -699,6 +699,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -716,6 +719,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -733,6 +739,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -750,6 +759,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -767,6 +779,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -784,6 +799,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -801,6 +819,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -818,6 +839,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -835,6 +859,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -858,6 +885,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -881,6 +911,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -904,6 +937,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -927,6 +963,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -950,6 +989,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -973,6 +1015,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -996,6 +1041,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1920,16 +1968,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260317.3",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260317.3.tgz",
-      "integrity": "sha512-tK78D3X4q30/SXqVwMhWrUfH+ffRou9dJLC+jkhNy5zh1I7i7T4JH6xihOvYxdCSBavJ5fQXaaxDJz6orh09BA==",
+      "version": "4.20260504.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260504.0.tgz",
+      "integrity": "sha512-HeI/HLx+rbeo/UB4qb6NsNcFdUVD7xDzyCexZJTVtFMlfpfexUKEDmdeTRRpzeHrJseZFGua+v9JO1kfPublUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "^0.34.5",
-        "undici": "7.24.4",
-        "workerd": "1.20260317.1",
+        "undici": "7.24.8",
+        "workerd": "1.20260504.1",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10"
       },
@@ -1937,7 +1985,7 @@
         "miniflare": "bootstrap.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/ms": {
@@ -2283,9 +2331,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2491,9 +2539,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260317.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260317.1.tgz",
-      "integrity": "sha512-ZuEq1OdrJBS+NV+L5HMYPCzVn49a2O60slQiiLpG44jqtlOo+S167fWC76kEXteXLLLydeuRrluRel7WdOUa4g==",
+      "version": "1.20260504.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260504.1.tgz",
+      "integrity": "sha512-AQTXSHbYNP9tLPgJNn0TmizyE4aDh2VuZZXlTAL0uu4fbCY436NAnQSJIzZbaFHM3DnAtVs9G8tkiJztSdYqDg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -2504,41 +2552,41 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260317.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260317.1",
-        "@cloudflare/workerd-linux-64": "1.20260317.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260317.1",
-        "@cloudflare/workerd-windows-64": "1.20260317.1"
+        "@cloudflare/workerd-darwin-64": "1.20260504.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260504.1",
+        "@cloudflare/workerd-linux-64": "1.20260504.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260504.1",
+        "@cloudflare/workerd-windows-64": "1.20260504.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.78.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.78.0.tgz",
-      "integrity": "sha512-He/vUhk4ih0D0eFmtNnlbT6Od8j+BEokaSR+oYjbVsH0SWIrIch+eHqfLRSBjBQaOoh6HCNxcafcIkBm2u0Hag==",
+      "version": "4.88.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.88.0.tgz",
+      "integrity": "sha512-f470QwbeT/JM1S0duq+sLtkss7UBxIFDtYHgujv9tdQUyA/dLGDq51am0rqrsuFtCi97lTM1P5sqtt8xra1AlA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.4.2",
-        "@cloudflare/unenv-preset": "2.16.0",
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260317.3",
+        "miniflare": "4.20260504.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260317.1"
+        "workerd": "1.20260504.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
         "wrangler2": "bin/wrangler.js"
       },
       "engines": {
-        "node": ">=20.3.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260317.1"
+        "@cloudflare/workers-types": "^4.20260504.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -15,6 +15,6 @@
     "@cloudflare/workers-types": "^4.20260301.0",
     "typescript": "^5.8.0",
     "vitest": "^3.1.0",
-    "wrangler": "^4.5.0"
+    "wrangler": "^4.88.0"
   }
 }


### PR DESCRIPTION
## Summary
- Bumps `wrangler` from `^4.5.0` → `^4.88.0` in `worker/`
- Bumps `wrangler` from `^4.87.0` → `^4.88.0` in `worker-csp/`

Fixes Dependabot alert #57: OS Command Injection in `wrangler pages deploy`.

Closes #337. Closes #333.

## Notes
- 8 pre-existing test failures in `worker/` are unrelated (mock factory refactor) — not introduced by this change, confirmed by stash test.
- Workers will need manual redeploy after merge: `cd worker && npx wrangler deploy`