### PR TITLE
fix(worker): update publish test mock for getConfiguredPlatforms refactor

### DIFF
--- a/worker/src/__tests__/publish.test.ts
+++ b/worker/src/__tests__/publish.test.ts
@@ -18,6 +18,7 @@ vi.mock('../platforms/factory', () => ({
     getPageIdentity: vi.fn().mockReturnValue('page_123'),
     debugAuth: mockDebugAuth,
   }),
+  getConfiguredPlatforms: () => ['facebook'],
   CONFIGURED_PLATFORMS: ['facebook'],
 }));
 


### PR DESCRIPTION
## Summary
- Adds `getConfiguredPlatforms: () => ['facebook']` to the `vi.mock('../platforms/factory')` in `publish.test.ts`

## Problem
`factory.ts` was refactored to replace the `CONFIGURED_PLATFORMS` static export with `getConfiguredPlatforms(env)`. The test mock was never updated, causing 8 test failures:

```
Error: [vitest] No "getConfiguredPlatforms" export is defined on the "../platforms/factory" mock.
```

## Result
84/84 tests passing.