### PR TITLE
ci: reduce pages artifact retention from 7 to 1 day

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: dist
-          retention-days: 7
+          retention-days: 1
 
   worker-csp:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pages artifacts are only needed for the deployment step immediately after upload — they're never retrieved again. 7-day retention accumulates ~103MB × multiple deploys/day, creating ~831MB of billed artifact storage.

Reducing to 1 day keeps one day's worth as a safety net while cutting ongoing storage ~7×.