### PR TITLE
fix(nlm): harden export scripts with atomic writes, tab delimiters, and --update mode

### DIFF
--- a/scripts/notebooklm/configs/qwen3-tts-research.json
+++ b/scripts/notebooklm/configs/qwen3-tts-research.json
@@ -1,0 +1,14 @@
+{
+  "title": "Qwen3-TTS: Best Practices for Voice Synthesis & Audio Generation",
+  "sources": [
+    "https://github.com/QwenLM/Qwen3-TTS",
+    "https://huggingface.co/Qwen/Qwen3-TTS",
+    "https://github.com/adrianwedd/voice-cloning-qwen3-tts-mlx"
+  ],
+  "studio": [
+    {"type": "report"},
+    {"type": "audio"},
+    {"type": "quiz"},
+    {"type": "flashcards"}
+  ]
+}

--- a/scripts/notebooklm/keep-list.txt
+++ b/scripts/notebooklm/keep-list.txt
@@ -1,0 +1,149 @@
+# NLM local backup keep-list
+# Format: one folder-name prefix per line (matched as prefix against full-backup/ entries)
+# Rationale: keep = active project / client work / ongoing legal-business.
+# Everything else is already on gdrive:nlm-backup and safe to delete locally.
+
+# ── Prospector: active suburb notebooks ─────────────────────────────────────
+blackmans-bay-prospects
+bonnet-hill-prospects
+cygnet-prospects-castle-forbes-bay
+cygnet-prospects-cradoc
+cygnet-prospects-cygnet
+cygnet-prospects-franklin
+cygnet-prospects-gardners-bay
+cygnet-prospects-geeveston
+cygnet-prospects-grove
+cygnet-prospects-huonville
+cygnet-prospects-lonnavale
+cygnet-prospects-lucaston
+cygnet-prospects-lymington
+cygnet-prospects-mountain-river
+cygnet-prospects-pelverata
+cygnet-prospects-petcheys-bay
+cygnet-prospects-port-huon
+cygnet-prospects-ranelagh
+discover-cygnet
+cygnet-overview
+dover-prospects
+huntingfield-prospects
+kaoota-prospects
+kingston-prospects
+lower-wattle-grove-prospects
+margate-prospects
+nicholls-rivulet-prospects
+sandfly-prospects
+snug-prospects
+
+# ── Prospector: suburb prospect lists ───────────────────────────────────────
+prospects-cradoc
+prospects-cygnet
+prospects-cygnet-a
+prospects-franklin
+prospects-geeveston
+prospects-grove
+prospects-huonville
+prospects-ranelagh
+
+# ── Prospector: individual prospect intel ───────────────────────────────────
+prospect-bethany-smith-psychology-grove
+prospect-bioflex-nutrition-grove
+prospect-blue-river-cafe-franklin-franklin
+prospect-campo-de-flori-grove
+prospect-crosby-dance-co-motor-mechanics
+prospect-dm-jennings-sons
+prospect-dm-jennings-sons-cygnet
+prospect-far-south-mobile-hub-grove
+prospect-ferment-tasmania-fermentas-cygnet
+prospect-finite-elements-grove
+prospect-frank-s-ciderhouse-cafe-franklin
+prospect-franklin-marine-franklin
+prospect-haugland-constructions-cygnet
+prospect-huon-cabinets-carpentry-grove
+prospect-huon-valley-pcyc-grove
+prospect-jt-plumbing-franklin
+prospect-jt-plumbing-tasmania
+prospect-little-black-fridge-grove
+prospect-maple-grove-nursery-grove
+prospect-mototraderstasmania-grove
+prospect-natural-heat-grove
+prospect-phoenix-creations-grove
+prospect-pilates-in-the-valley
+prospect-port-cygnet-cannery-cygnet
+prospect-red-velvet-lounge-cygnet
+prospect-reel-to-reel-solutions-grove
+prospect-river-to-rainforest-franklin
+prospect-the-hobart-polo-academy-grove
+prospect-the-moorings-lady-franklin-franklin
+prospect-wheelhouse-grove
+prospect-willie-smith-s-apple-shed-grove
+prospect-willie-smith-s-cygnet
+
+# ── Pentest / competitive intel (active) ────────────────────────────────────
+pentest-competitor-intelligence-australia-2026
+pentest-competitor-tooling-analysis-2026-05-07
+pentest-tool-expansion-research-2026-05-07
+
+# ── Client work ─────────────────────────────────────────────────────────────
+artefacts-of-the-understory-the-jessica-jubb-brand-codex
+rowena-research-au-privacy-policy-template
+rowena-research-au-regional-spiritual-market
+rowena-research-au-regulatory-enforcement
+rowena-research-avalonian-rose-lineage
+rowena-research-bereavement-mediumship-advertising
+rowena-research-reiki-under-national-code-of-conduct
+rowena-research-scottish-seer-tradition
+rowena-research-uct-for-circles-deposits
+rowena-research-women-s-circles-business-models
+readings-with-rowena-full-proposal-qa
+beep-digital-support-services-proposal-qa
+bottom-pub-co-op-gap-analysis
+evolve-evolution-implementation-and-launch-framework
+
+# ── Business formation / legal ───────────────────────────────────────────────
+failure-first-pty-ltd-incorporation-research
+contractor-architect-legal-structure-ai-specialist-to-ndis-practice-au-2026
+
+# ── NDIS / compliance (active regulatory work) ──────────────────────────────
+ndis-2025-26-v1-1-claimability-for-digital-ai-and-at-services
+ndis-commission-enforcement-actions-2025-26-against-unregistered-providers-concr
+ndis-compliance-software-landscape-what-exists-what-s-missing-for-unregistered-a
+ndis-digital-platform-provider-definition-does-configuring-ai-tools-for-individu
+ndis-integrity-and-safeguarding-act-2026-unregistered-provider-impact
+ndis-plan-managed-claimability-are-unregistered-providers-bound-by-price-limits
+australian-foundational-supports-under-ndis-new-framework-scope-eligibility-prov
+i-can-v6-assessment-framework-what-evidence-providers-need-to-produce-under-the-
+differentiated-pricing-for-unregistered-ndis-providers-capacity-building-lower-c
+ai-tools-as-restrictive-practices-under-ndis-behavioural-shaping-environmental-l
+
+# ── Bali property (ongoing if still active) ─────────────────────────────────
+bali-real-estate-compliance-and-capital-repatriation-guide
+bali-hospitality-strategic-risk-management-for-scooter-provision
+safety-and-compliance-manual-dolphin-beach-apartments-bali
+regulatory-and-legislative-framework-for-the-operation-of-dolphin-beach-apartmen
+2026-strategic-compensation-and-compliance-framework-for-dolphin-beach-apartment
+
+# ── Ongoing research / safety work ──────────────────────────────────────────
+aisi-application-submission-manifest-and-compliance-checklist
+failure-first-overview
+embodied-ai-deployment-sites-recon-intel
+
+# ── Prospector: additional suburbs (missed first pass) ──────────────────────
+taroona-prospects
+woodstock-prospects
+
+# ── Legal / personal ────────────────────────────────────────────────────────
+tasmanian-workers-compensation-settlement-wedd-v-the-state
+
+# ── Active book project ──────────────────────────────────────────────────────
+this-wasn-t-in-the-brochure-2025-12-21-draft
+this-wasn-t-in-the-brochure-2025-12-25-en-au-draft
+this-wasn-t-in-the-brochure-a-book-about-parenting-neurodivergence-and-the-thing
+this-wasn-t-in-the-brochure-a-neurodivergent-co-parenting-guide-written-with-thr
+this-wasn-t-in-the-brochure-appendix-a-ai-and-authorship
+this-wasn-t-in-the-brochure-fresh
+this-wasn-t-in-the-brochure-overview
+this-wasnt-in-the-brochure-audio
+this-wasnt-in-the-brochure-infographic
+
+# ── NDIS compliance (additional) ────────────────────────────────────────────
+supported-decision-making-frameworks-for-ai-tool-deployment-consent-au-2026

--- a/scripts/notebooklm/scripts/export-all.sh
+++ b/scripts/notebooklm/scripts/export-all.sh
@@ -41,6 +41,8 @@ Options:
   --output <dir>       Output base directory (default: ./exports)
   --continue-on-error  Continue exporting if individual notebooks fail
   --no-retry           Disable retry/backoff for nlm operations
+  --update             Re-visit already-exported notebooks and download any new assets
+                       (append-only: existing files are preserved, not refreshed)
   -h, --help           Show this help message
 
 Examples:
@@ -54,6 +56,7 @@ EOF
 OUTPUT_BASE="./exports"
 CONTINUE_ON_ERROR=false
 NO_RETRY=false
+UPDATE_MODE=false
 EXTRA_EXPORT_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -85,6 +88,10 @@ while [[ $# -gt 0 ]]; do
       NO_RETRY=true
       shift
       ;;
+    --update)
+      UPDATE_MODE=true
+      shift
+      ;;
     -*)
       echo "Unknown option: $1" >&2
       exit 1
@@ -107,6 +114,10 @@ fi
 if [[ "$NO_RETRY" == true ]]; then
   export NLM_NO_RETRY=true
   EXTRA_EXPORT_ARGS+=(--no-retry)
+fi
+
+if [[ "$UPDATE_MODE" == true ]]; then
+  EXTRA_EXPORT_ARGS+=(--update)
 fi
 
 if [[ "$QUIET" == true ]]; then
@@ -158,8 +169,8 @@ while IFS='|' read -r notebook_id notebook_title; do
   fi
 
   export_dir="$OUTPUT_BASE/$slugified"
-  if [ -d "$export_dir" ] && [ -f "$export_dir/metadata.json" ]; then
-    log_info "  [↷] Already exported, skipping"
+  if [[ "$UPDATE_MODE" == false ]] && [ -d "$export_dir" ] && [ -f "$export_dir/metadata.json" ]; then
+    log_info "  [↷] Already exported, skipping (use --update to re-check for new assets)"
     skipped=$(<"$TEMP_DIR/skipped")
     echo "$((skipped + 1))" > "$TEMP_DIR/skipped"
     log_info ""
@@ -167,7 +178,7 @@ while IFS='|' read -r notebook_id notebook_title; do
   fi
 
   # Run export
-  if "$EXPORT_SCRIPT" --id "$notebook_id" --output "$OUTPUT_BASE" "${EXTRA_EXPORT_ARGS[@]}" 2>&1 | sed 's/^/  /' >&2; then
+  if "$EXPORT_SCRIPT" --id "$notebook_id" --output "$OUTPUT_BASE" "${EXTRA_EXPORT_ARGS[@]+"${EXTRA_EXPORT_ARGS[@]}"}" 2>&1 | sed 's/^/  /' >&2; then
     success=$(<"$TEMP_DIR/success")
     echo "$((success + 1))" > "$TEMP_DIR/success"
     log_info "  [✓] Export complete"

--- a/scripts/notebooklm/scripts/export-notebook.sh
+++ b/scripts/notebooklm/scripts/export-notebook.sh
@@ -75,6 +75,7 @@ Options:
   --name <string>    Explicit notebook name query (disables UUID parsing of positional arg)
   --dry-run          Print planned export actions and exit without downloading
   --no-retry         Disable retry/backoff for nlm operations
+  --update           Accepted for compatibility; existing files are preserved (append-only, not a refresh)
   -h, --help         Show this help message
 
 Examples:
@@ -142,6 +143,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --no-retry)
       NO_RETRY=true
+      shift
+      ;;
+    --update)
+      # Per-artifact skip is always active; --update is accepted for batch caller compatibility
       shift
       ;;
     -*)
@@ -340,18 +345,27 @@ echo "$SOURCES_SORTED" | python3 -c '
 import sys, json
 sources = json.load(sys.stdin)
 for s in sources:
-    print(s["id"] + "|" + s["title"] + "|" + s["type"])
-' 2>/dev/null | while IFS='|' read -r src_id src_title _src_type; do
+    # Tab delimiter — safe for titles containing pipe characters
+    print(s["id"] + "\t" + s["title"] + "\t" + s["type"])
+' 2>/dev/null | while IFS=$'\t' read -r src_id src_title _src_type; do
   safe_name=$(echo "$src_title" | sed 's/[^a-zA-Z0-9._-]/_/g' | head -c 100)
   content_file="$OUTPUT_DIR/sources/${safe_name}--${src_id}.md"
-  if retry_cmd "nlm content source" nlm content source "$src_id" -o "$content_file"; then
-    if [ -s "$content_file" ]; then
+  # Clean up stale .part files from interrupted runs
+  rm -f "${content_file}.part"
+  if [ -f "$content_file" ] && [ -s "$content_file" ]; then
+    log_info "  [↷] Already downloaded: sources/${safe_name}--${src_id}.md"
+    continue
+  fi
+  log_info "  [↓] Downloading: sources/${safe_name}--${src_id}.md"
+  if retry_cmd "nlm content source" nlm content source "$src_id" -o "${content_file}.part"; then
+    if [ -s "${content_file}.part" ]; then
+      mv -f "${content_file}.part" "$content_file"
       log_info "  [+] sources/${safe_name}--${src_id}.md"
     else
-      rm -f "$content_file"
+      rm -f "${content_file}.part"
     fi
   else
-    rm -f "$content_file"
+    rm -f "${content_file}.part"
   fi
 done
 
@@ -412,11 +426,17 @@ for n in notes:
             name = f"{base}--{i}"
             i += 1
     seen.add(name)
-    print(f"{name}|||{content}")
-' 2>/dev/null | while IFS='|||' read -r note_name note_content; do
+    # Tab delimiter — bash IFS splits on single chars, not multi-char strings
+    print(f"{name}\t{content}")
+' 2>/dev/null | while IFS=$'\t' read -r note_name note_content; do
     if [ -n "$note_name" ]; then
-      echo "$note_content" > "$OUTPUT_DIR/notes/${note_name}.md"
-      log_info "  [+] notes/${note_name}.md"
+      note_file="$OUTPUT_DIR/notes/${note_name}.md"
+      if [ -f "$note_file" ] && [ -s "$note_file" ]; then
+        log_info "  [↷] Already saved: notes/${note_name}.md"
+      else
+        printf '%s\n' "$note_content" > "$note_file"
+        log_info "  [+] notes/${note_name}.md"
+      fi
     fi
   done
 else
@@ -454,16 +474,35 @@ log_info "  [+] studio/manifest.json ($ARTIFACT_COUNT artifacts)"
 
 download_artifact() {
   local atype="$1" aid="$2" outpath="$3"
-  if retry_cmd_capture_fail_verbose "nlm download $atype" nlm download "$atype" "$NOTEBOOK_ID" --id "$aid" -o "$outpath" --no-progress; then
-    if [ -f "$outpath" ] && [ -s "$outpath" ]; then
+  # --no-progress is only supported by audio, video, infographic, slide-deck
+  local extra_args=()
+  case "$atype" in audio|video|infographic|slide-deck) extra_args=(--no-progress) ;; esac
+  # Atomic write: download to .part then mv into place
+  local part_file="${outpath}.part"
+  rm -f "$part_file"
+  if retry_cmd_capture_fail_verbose "nlm download $atype" nlm download "$atype" "$NOTEBOOK_ID" --id "$aid" -o "$part_file" "${extra_args[@]+"${extra_args[@]}"}"; then
+    if [ -f "$part_file" ] && [ -s "$part_file" ]; then
+      mv -f "$part_file" "$outpath"
       local size_bytes
       size_bytes=$(wc -c <"$outpath" | tr -d ' ')
       log_info "  [+] $outpath (${size_bytes} bytes)"
       return 0
     fi
   fi
-  rm -f "$outpath"
+  rm -f "$part_file" "$outpath"
   return 1
+}
+
+download_artifact_if_missing() {
+  local atype="$1" aid="$2" outpath="$3"
+  # Clean up stale .part files from interrupted runs
+  rm -f "${outpath}.part"
+  if [ -f "$outpath" ] && [ -s "$outpath" ]; then
+    log_info "  [↷] Already downloaded: $(basename "$outpath")"
+    return 0
+  fi
+  log_info "  [↓] Downloading: $(basename "$outpath")"
+  download_artifact "$atype" "$aid" "$outpath"
 }
 
 echo "$ARTIFACTS_SORTED" | python3 -c '
@@ -475,31 +514,31 @@ for a in sorted(artifacts, key=lambda a: (a.get("type",""), a.get("id",""))):
 ' 2>/dev/null | while IFS='|' read -r art_id art_type; do
   case "$art_type" in
     audio)
-      download_artifact audio "$art_id" "$OUTPUT_DIR/studio/audio/${art_id}.mp3" || true
+      download_artifact_if_missing audio "$art_id" "$OUTPUT_DIR/studio/audio/${art_id}.mp3" || true
       ;;
     video)
-      download_artifact video "$art_id" "$OUTPUT_DIR/studio/video/${art_id}.mp4" || true
+      download_artifact_if_missing video "$art_id" "$OUTPUT_DIR/studio/video/${art_id}.mp4" || true
       ;;
     report)
-      download_artifact report "$art_id" "$OUTPUT_DIR/studio/documents/${art_id}.md" || true
+      download_artifact_if_missing report "$art_id" "$OUTPUT_DIR/studio/documents/${art_id}.md" || true
       ;;
     slide_deck)
-      download_artifact slide-deck "$art_id" "$OUTPUT_DIR/studio/documents/${art_id}.pdf" || true
+      download_artifact_if_missing slide-deck "$art_id" "$OUTPUT_DIR/studio/documents/${art_id}.pdf" || true
       ;;
     infographic)
-      download_artifact infographic "$art_id" "$OUTPUT_DIR/studio/visual/${art_id}.png" || true
+      download_artifact_if_missing infographic "$art_id" "$OUTPUT_DIR/studio/visual/${art_id}.png" || true
       ;;
     mind_map)
-      download_artifact mind-map "$art_id" "$OUTPUT_DIR/studio/visual/${art_id}.json" || true
+      download_artifact_if_missing mind-map "$art_id" "$OUTPUT_DIR/studio/visual/${art_id}.json" || true
       ;;
     quiz)
-      download_artifact quiz "$art_id" "$OUTPUT_DIR/studio/interactive/${art_id}-quiz.json" || true
+      download_artifact_if_missing quiz "$art_id" "$OUTPUT_DIR/studio/interactive/${art_id}-quiz.json" || true
       ;;
     flashcards)
-      download_artifact flashcards "$art_id" "$OUTPUT_DIR/studio/interactive/${art_id}-flashcards.json" || true
+      download_artifact_if_missing flashcards "$art_id" "$OUTPUT_DIR/studio/interactive/${art_id}-flashcards.json" || true
       ;;
     data_table)
-      download_artifact data-table "$art_id" "$OUTPUT_DIR/studio/interactive/${art_id}-data-table.csv" || true
+      download_artifact_if_missing data-table "$art_id" "$OUTPUT_DIR/studio/interactive/${art_id}-data-table.csv" || true
       ;;
     *)
       log_warn "  [?] Unknown artifact type: $art_type ($art_id)"

--- a/scripts/notebooklm/scripts/export-notebook.sh
+++ b/scripts/notebooklm/scripts/export-notebook.sh
@@ -346,7 +346,7 @@ import sys, json
 sources = json.load(sys.stdin)
 for s in sources:
     # Tab delimiter — safe for titles containing pipe characters
-    print(s["id"] + "\t" + s["title"] + "\t" + s["type"])
+    print(s.get("id", "") + "\t" + s.get("title", "untitled") + "\t" + s.get("type", ""))
 ' 2>/dev/null | while IFS=$'\t' read -r src_id src_title _src_type; do
   safe_name=$(echo "$src_title" | sed 's/[^a-zA-Z0-9._-]/_/g' | head -c 100)
   content_file="$OUTPUT_DIR/sources/${safe_name}--${src_id}.md"
@@ -406,9 +406,12 @@ print()
   echo "$NOTES_SORTED" > "$OUTPUT_DIR/notes/index.json"
   NOTE_COUNT=$(echo "$NOTES_OUTPUT" | python3 "$SCRIPT_DIR/../lib/json_tools.py" len)
   log_info "  [+] notes/index.json ($NOTE_COUNT notes)"
-  echo "$NOTES_SORTED" | python3 -c '
-import sys, json
+  # Write note files directly from Python to handle multi-line content correctly.
+  # Bash read cannot safely pass multi-line strings across a pipe.
+  echo "$NOTES_SORTED" | NLM_NOTES_DIR="$OUTPUT_DIR/notes" python3 -c '
+import sys, json, os
 notes = json.load(sys.stdin)
+notes_dir = os.environ["NLM_NOTES_DIR"]
 seen = set()
 for n in notes:
     title = n.get("title", "untitled")
@@ -426,18 +429,20 @@ for n in notes:
             name = f"{base}--{i}"
             i += 1
     seen.add(name)
-    # Tab delimiter — bash IFS splits on single chars, not multi-char strings
-    print(f"{name}\t{content}")
-' 2>/dev/null | while IFS=$'\t' read -r note_name note_content; do
-    if [ -n "$note_name" ]; then
-      note_file="$OUTPUT_DIR/notes/${note_name}.md"
-      if [ -f "$note_file" ] && [ -s "$note_file" ]; then
-        log_info "  [↷] Already saved: notes/${note_name}.md"
-      else
-        printf '%s\n' "$note_content" > "$note_file"
-        log_info "  [+] notes/${note_name}.md"
-      fi
-    fi
+    note_path = os.path.join(notes_dir, f"{name}.md")
+    if os.path.isfile(note_path) and os.path.getsize(note_path) > 0:
+        print(f"SKIP:{name}.md")
+    else:
+        with open(note_path, "w") as f:
+            f.write(content)
+            if not content.endswith("\n"):
+                f.write("\n")
+        print(f"WRITE:{name}.md")
+' 2>/dev/null | while IFS=':' read -r action filename; do
+    case "$action" in
+      SKIP) log_info "  [↷] Already saved: notes/${filename}" ;;
+      WRITE) log_info "  [+] notes/${filename}" ;;
+    esac
   done
 else
   log_info "  [.] No notes found"

--- a/scripts/notebooklm/scripts/export-notebook.sh
+++ b/scripts/notebooklm/scripts/export-notebook.sh
@@ -358,7 +358,7 @@ for s in sources:
   fi
   log_info "  [↓] Downloading: sources/${safe_name}--${src_id}.md"
   if retry_cmd "nlm content source" nlm content source "$src_id" -o "${content_file}.part"; then
-    if [ -s "${content_file}.part" ]; then
+    if [ -f "${content_file}.part" ] && [ -s "${content_file}.part" ]; then
       mv -f "${content_file}.part" "$content_file"
       log_info "  [+] sources/${safe_name}--${src_id}.md"
     else
@@ -438,7 +438,7 @@ for n in notes:
             if not content.endswith("\n"):
                 f.write("\n")
         print(f"WRITE:{name}.md")
-' 2>/dev/null | while IFS=':' read -r action filename; do
+' | while IFS=':' read -r action filename; do
     case "$action" in
       SKIP) log_info "  [↷] Already saved: notes/${filename}" ;;
       WRITE) log_info "  [+] notes/${filename}" ;;


### PR DESCRIPTION
## Summary

- Fix `IFS='|||'` bug where bash doesn't support multi-char IFS, causing `||` to be prepended to every note's content
- Fix source delimiter from `|` to tab to handle titles containing pipe characters
- Replace `echo` with `printf '%s\n'` for note content (handles `-n`/`-e` edge cases)
- Add atomic writes: download to `.part` then `mv` into place, preventing interrupted downloads from leaving partial files that satisfy the skip guard
- Add `--update` flag to `export-all.sh` to re-visit already-exported notebooks (append-only: preserves existing files, downloads new ones)
- Add `download_artifact_if_missing()` to skip already-downloaded artifacts
- Add skip guards for source content and note files
- Fix `--no-progress` to only apply to artifact types that support it (audio, video, infographic, slide-deck)
- Add `[↓] Downloading:` log line for observability during `--update` runs
- Fix empty array expansion under `set -u`
- Add qwen3-tts-research config and keep-list

## Test plan

- [ ] Run `bash -n` on both scripts — passes
- [ ] Verify tab-delimited note parsing: `echo 'name	tab content' | while IFS=$'\t' read -r a b; do echo "a=[$a] b=[$b]"; done` — no `||` prefix
- [ ] Run `export-all.sh --update` against a notebook with existing exports — should skip present files and download only missing ones
- [ ] Interrupt a download mid-progress, then re-run — the `.part` file should be cleaned up and the download retried
- [ ] Verify that notes containing `-n` or `-e` in their content are written correctly (no interpretation by `echo`)