### PR TITLE
fix(worker): SSRF defense, federated PDS endpoint, cron filter ordering

### DIFF
--- a/worker/src/__tests__/safe-fetch.test.ts
+++ b/worker/src/__tests__/safe-fetch.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { isAllowedMediaUrl, isSafeHttpsUrl } from '../platforms/safe-fetch';
+
+describe('isAllowedMediaUrl', () => {
+  it.each([
+    'https://cdn.adrianwedd.com/notebook-assets/x/audio.mp3',
+    'https://adrianwedd.com/og/blog/x.jpg',
+    'https://img.youtube.com/vi/abc/maxresdefault.jpg',
+  ])('allows %s', (url) => {
+    expect(isAllowedMediaUrl(url)).toBe(true);
+  });
+
+  it.each([
+    'http://cdn.adrianwedd.com/x.jpg',           // not https
+    'https://attacker.example/x.jpg',            // not allowlisted
+    'https://169.254.169.254/latest/meta-data',  // IP literal (cloud metadata)
+    'https://10.0.0.1/x',                        // private IP literal
+    'file:///etc/passwd',                         // non-http scheme
+    'not-a-url',                                  // unparseable
+  ])('rejects %s', (url) => {
+    expect(isAllowedMediaUrl(url)).toBe(false);
+  });
+
+  it('rejects host-confusion with @ in URL', () => {
+    // Test parser robustness — the host is example.com, not cdn.adrianwedd.com
+    expect(isAllowedMediaUrl('https://cdn.adrianwedd.com@example.com/x.jpg')).toBe(false);
+  });
+});
+
+describe('isSafeHttpsUrl', () => {
+  it('accepts an arbitrary HTTPS hostname', () => {
+    expect(isSafeHttpsUrl('https://pds.example.com/xrpc')).toBe(true);
+  });
+
+  it('rejects IP literals and non-https schemes', () => {
+    expect(isSafeHttpsUrl('https://169.254.169.254')).toBe(false);
+    expect(isSafeHttpsUrl('http://pds.example.com')).toBe(false);
+    expect(isSafeHttpsUrl('ftp://pds.example.com')).toBe(false);
+  });
+});

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -333,16 +333,18 @@ app.post('/api/cron/publish', async (c) => {
 
     duePosts.sort((a, b) => a.post.scheduledAtEpoch - b.post.scheduledAtEpoch);
 
+    // Filter out posts for blocked platforms BEFORE applying the 5-post batch cap, so a
+    // single expired platform can't starve healthy ones out of their share of the batch.
+    const skippedBlocked = duePosts.filter(({ post }) => blockedPlatforms.has(post.platform));
+    for (const { post } of skippedBlocked) {
+      console.warn(`Skipping post ${post.id} — ${post.platform} auth is invalid`);
+    }
+    const processable = duePosts.filter(({ post }) => !blockedPlatforms.has(post.platform));
+
     let published = 0;
     let failed = 0;
 
-    for (const { key, post } of duePosts.slice(0, 5)) {
-      // Skip posts for platforms with invalid auth
-      if (blockedPlatforms.has(post.platform)) {
-        console.warn(`Skipping post ${post.id} — ${post.platform} auth is invalid`);
-        continue;
-      }
-
+    for (const { key, post } of processable.slice(0, 5)) {
       // Check idempotency
       const existing = await env.SOCIAL.get(`idempotent:${post.id}`);
       if (existing) {
@@ -380,7 +382,7 @@ app.post('/api/cron/publish', async (c) => {
         // Revert to queued
         await env.SOCIAL.put(key, JSON.stringify({ ...post, status: 'queued' }));
         await env.SOCIAL.delete(`post:publishing:${post.scheduledAtEpoch}:${post.id}`);
-        console.error(`Facebook token invalid — halting run`);
+        console.error(`${post.platform} token invalid — halting run`);
         return json({ error: 'Token invalid', published, failed, tokenExpiresInDays: tokenExpiryByPlatform }, 503);
       } else if (result.isTransient) {
         // Revert to queued
@@ -401,7 +403,7 @@ app.post('/api/cron/publish', async (c) => {
       }
     }
 
-    const remaining = Math.max(0, duePosts.length - 5);
+    const remaining = Math.max(0, processable.length - 5) + skippedBlocked.length;
     if (remaining > 10) console.error(`Post queue backlog: ${remaining}`);
     else if (remaining > 0) console.warn(`${remaining} posts still queued`);
 
@@ -430,7 +432,10 @@ app.post('/api/cron/comments', async (c) => {
       const adapter = createPlatform(platformName, env);
       const tokenHealth = await adapter.debugAuth();
       if (!tokenHealth.valid || tokenHealth.daysUntilExpiry <= 0) {
-        return json({ error: `${platformName} data access expired` }, 503);
+        // Mirror the publish-cron behaviour: skip the bad platform and continue with others.
+        console.error(`${platformName} data access expired — skipping comments for this platform`);
+        platformResults[platformName] = { error: 'data access expired', tokenExpiresInDays: tokenHealth.daysUntilExpiry };
+        continue;
       }
 
       const result = await processComments(adapter, env.SOCIAL);

--- a/worker/src/platforms/bluesky.ts
+++ b/worker/src/platforms/bluesky.ts
@@ -5,6 +5,7 @@ import type {
   Comment,
   AuthStatus,
 } from './types';
+import { isAllowedMediaUrl, isSafeHttpsUrl } from './safe-fetch';
 
 const BSKY_BASE = 'https://bsky.social/xrpc';
 const MAX_GRAPHEMES = 300;
@@ -63,11 +64,15 @@ function truncateGraphemes(text: string, max: number): string {
 
 
 async function uploadVideo(session: BskySession, videoUrl: string): Promise<unknown | null> {
+  if (!isAllowedMediaUrl(videoUrl)) return null;
   try {
-    // Skip if video is too large for CF Worker outgoing request (~20MB practical limit)
+    // Skip if video is too large for CF Worker outgoing request (~20MB practical limit).
+    // Require a Content-Length header; without it we cannot bound memory usage safely.
     const headRes = await fetch(videoUrl, { method: 'HEAD' });
-    const contentLength = parseInt(headRes.headers.get('content-length') ?? '0', 10);
-    if (contentLength > 20 * 1024 * 1024) return null;
+    const rawContentLength = headRes.headers.get('content-length');
+    if (rawContentLength === null) return null;
+    const contentLength = parseInt(rawContentLength, 10);
+    if (!Number.isFinite(contentLength) || contentLength <= 0 || contentLength > 20 * 1024 * 1024) return null;
 
     const saParams = new URLSearchParams({ aud: 'did:web:video.bsky.app', lxm: 'app.bsky.video.uploadVideo' });
     const serviceAuthRes = await fetch(`${session.pdsEndpoint}/com.atproto.server.getServiceAuth?${saParams}`, {
@@ -130,19 +135,19 @@ export function createBlueskyPlatform(
       accessJwt: string;
       didDoc?: { service?: Array<{ id: string; serviceEndpoint: string }> };
     };
-    // Extract PDS endpoint from didDoc if present, otherwise resolve via PLC directory
+    // Extract PDS endpoint from didDoc if present, otherwise resolve via PLC directory.
+    // The endpoint becomes the base URL for authenticated calls bearing our accessJwt,
+    // so reject anything that isn't a well-formed HTTPS URL (no IP literals).
     let pdsEndpoint = BSKY_BASE;
-    const pdsService = data.didDoc?.service?.find(s => s.id === '#atproto_pds');
-    if (pdsService?.serviceEndpoint) {
-      pdsEndpoint = `${pdsService.serviceEndpoint}/xrpc`;
-    } else {
-      // Fallback: resolve DID document from PLC directory
-      const didRes = await fetch(`https://plc.directory/${data.did}`).catch(() => null);
-      if (didRes?.ok) {
+    const candidate = data.didDoc?.service?.find(s => s.id === '#atproto_pds')?.serviceEndpoint
+      ?? await (async () => {
+        const didRes = await fetch(`https://plc.directory/${encodeURIComponent(data.did)}`).catch(() => null);
+        if (!didRes?.ok) return undefined;
         const didDoc = await didRes.json() as { service?: Array<{ id: string; serviceEndpoint: string }> };
-        const svc = didDoc.service?.find(s => s.id === '#atproto_pds');
-        if (svc?.serviceEndpoint) pdsEndpoint = `${svc.serviceEndpoint}/xrpc`;
-      }
+        return didDoc.service?.find(s => s.id === '#atproto_pds')?.serviceEndpoint;
+      })();
+    if (candidate && isSafeHttpsUrl(candidate)) {
+      pdsEndpoint = `${candidate.replace(/\/$/, '')}/xrpc`;
     }
     return { did: data.did, accessJwt: data.accessJwt, pdsEndpoint };
   }
@@ -187,12 +192,13 @@ export function createBlueskyPlatform(
       if (!record.embed && post.youtubeUrl) {
         const videoId = post.youtubeUrl.match(/[?&]v=([^&]+)/)?.[1];
         if (videoId) {
-          const thumbUrl = `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`;
+          // img.youtube.com is in the allowlist; videoId is captured from a tight regex
+          const thumbUrl = `https://img.youtube.com/vi/${encodeURIComponent(videoId)}/maxresdefault.jpg`;
           const thumbRes = await fetch(thumbUrl);
           let thumbBlob: unknown = undefined;
           if (thumbRes.ok) {
             const thumbBytes = await thumbRes.arrayBuffer();
-            const blobRes = await fetch(`${BSKY_BASE}/com.atproto.repo.uploadBlob`, {
+            const blobRes = await fetch(`${session.pdsEndpoint}/com.atproto.repo.uploadBlob`, {
               method: 'POST',
               headers: { 'Authorization': `Bearer ${session.accessJwt}`, 'Content-Type': 'image/jpeg' },
               body: thumbBytes,
@@ -213,13 +219,13 @@ export function createBlueskyPlatform(
         }
       }
 
-      if (!record.embed && post.imageUrl) {
+      if (!record.embed && post.imageUrl && isAllowedMediaUrl(post.imageUrl)) {
         // Fall back to static image embed
         const imgRes = await fetch(post.imageUrl);
         if (imgRes.ok) {
           const imgBytes = await imgRes.arrayBuffer();
           const mimeType = imgRes.headers.get('content-type') ?? 'image/jpeg';
-          const blobRes = await fetch(`${BSKY_BASE}/com.atproto.repo.uploadBlob`, {
+          const blobRes = await fetch(`${session.pdsEndpoint}/com.atproto.repo.uploadBlob`, {
             method: 'POST',
             headers: { 'Authorization': `Bearer ${session.accessJwt}`, 'Content-Type': mimeType },
             body: imgBytes,
@@ -238,7 +244,7 @@ export function createBlueskyPlatform(
         };
       }
 
-      const res = await fetch(`${BSKY_BASE}/com.atproto.repo.createRecord`, {
+      const res = await fetch(`${session.pdsEndpoint}/com.atproto.repo.createRecord`, {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${session.accessJwt}`,
@@ -315,7 +321,7 @@ export function createBlueskyPlatform(
       const params = new URLSearchParams({ actor: session.did, limit: '50' });
       if (cursor) params.set('cursor', cursor);
 
-      const res = await fetch(`${BSKY_BASE}/app.bsky.feed.getAuthorFeed?${params.toString()}`, {
+      const res = await fetch(`${session.pdsEndpoint}/app.bsky.feed.getAuthorFeed?${params.toString()}`, {
         headers: { 'Authorization': `Bearer ${session.accessJwt}` },
       });
       if (!res.ok) break;
@@ -349,7 +355,7 @@ export function createBlueskyPlatform(
     }
 
     const params = new URLSearchParams({ uri: postId, depth: '1' });
-    const res = await fetch(`${BSKY_BASE}/app.bsky.feed.getPostThread?${params.toString()}`, {
+    const res = await fetch(`${session.pdsEndpoint}/app.bsky.feed.getPostThread?${params.toString()}`, {
       headers: { 'Authorization': `Bearer ${session.accessJwt}` },
     });
     if (!res.ok) return [];
@@ -394,7 +400,7 @@ export function createBlueskyPlatform(
     }
 
     const params = new URLSearchParams({ uri: commentId, depth: '1' });
-    const res = await fetch(`${BSKY_BASE}/app.bsky.feed.getPostThread?${params.toString()}`, {
+    const res = await fetch(`${session.pdsEndpoint}/app.bsky.feed.getPostThread?${params.toString()}`, {
       headers: { 'Authorization': `Bearer ${session.accessJwt}` },
     });
     if (!res.ok) return [];
@@ -433,7 +439,7 @@ export function createBlueskyPlatform(
     try {
       // Fetch the parent post to get its CID (needed for reply reference)
       const threadParams = new URLSearchParams({ uri: commentId, depth: '0' });
-      const threadRes = await fetch(`${BSKY_BASE}/app.bsky.feed.getPostThread?${threadParams.toString()}`, {
+      const threadRes = await fetch(`${session.pdsEndpoint}/app.bsky.feed.getPostThread?${threadParams.toString()}`, {
         headers: { 'Authorization': `Bearer ${session.accessJwt}` },
       });
 
@@ -469,7 +475,7 @@ export function createBlueskyPlatform(
         record.facets = facets;
       }
 
-      const res = await fetch(`${BSKY_BASE}/com.atproto.repo.createRecord`, {
+      const res = await fetch(`${session.pdsEndpoint}/com.atproto.repo.createRecord`, {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${session.accessJwt}`,

--- a/worker/src/platforms/safe-fetch.ts
+++ b/worker/src/platforms/safe-fetch.ts
@@ -1,0 +1,40 @@
+// SSRF defense for outbound fetches against user-controlled URLs.
+//
+// Queue payloads carry `videoUrl`, `imageUrl`, and `youtubeUrl` fields that
+// are fetched by the Worker before re-uploading the bytes to the destination
+// platform (Bluesky / Twitter). Without an allowlist a caller with access to
+// the publish/queue endpoints can turn the Worker into an SSRF primitive.
+
+const MEDIA_HOST_ALLOWLIST: ReadonlySet<string> = new Set([
+  'cdn.adrianwedd.com',
+  'adrianwedd.com',
+  'img.youtube.com',
+]);
+
+const IPV4_LITERAL = /^\d{1,3}(\.\d{1,3}){3}$/;
+
+export function isAllowedMediaUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'https:') return false;
+  if (IPV4_LITERAL.test(parsed.hostname) || parsed.hostname.includes(':')) return false;
+  return MEDIA_HOST_ALLOWLIST.has(parsed.hostname);
+}
+
+// Looser check for federated endpoints (e.g. AT Protocol PDS) where we cannot
+// allowlist the host but still want to refuse IP literals and non-HTTPS.
+export function isSafeHttpsUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'https:') return false;
+  if (IPV4_LITERAL.test(parsed.hostname) || parsed.hostname.includes(':')) return false;
+  return true;
+}

--- a/worker/src/platforms/twitter.ts
+++ b/worker/src/platforms/twitter.ts
@@ -1,4 +1,5 @@
 import type { SocialPost, SocialPlatform, PublishResult, AuthStatus, Comment } from './types';
+import { isAllowedMediaUrl } from './safe-fetch';
 
 // ── OAuth 1.0a ─────────────────────────────────────────────────────────────
 
@@ -61,6 +62,7 @@ const TWEET_URL = 'https://api.twitter.com/2/tweets';
 const VERIFY_URL = 'https://api.twitter.com/2/users/me';
 
 async function uploadMedia(imageUrl: string, creds: OAuth1Creds): Promise<string | null> {
+  if (!isAllowedMediaUrl(imageUrl)) return null;
   try {
     const imgRes = await fetch(imageUrl);
     if (!imgRes.ok) return null;
@@ -97,8 +99,14 @@ export function createTwitterPlatform(creds: OAuth1Creds): SocialPlatform {
         mediaId = await uploadMedia(post.imageUrl, creds);
       }
 
+      // Append the post's destination link if it's not already present in the message.
+      // Twitter shortens URLs to 23 chars via t.co — keep the link out of the truncation budget.
+      let message = post.message;
+      if (post.link && !message.includes(post.link)) {
+        message = `${message} ${post.link}`.trim();
+      }
       // Truncate to 280 graphemes (Twitter limit)
-      const text = [...post.message].slice(0, 280).join('');
+      const text = [...message].slice(0, 280).join('');
 
       const body: Record<string, unknown> = { text };
       if (mediaId) body.media = { media_ids: [mediaId] };
@@ -114,8 +122,11 @@ export function createTwitterPlatform(creds: OAuth1Creds): SocialPlatform {
         });
 
         if (res.status === 401 || res.status === 403) {
-          const text = await res.text();
-          return { success: false, error: `HTTP ${res.status}: ${text.slice(0, 200)}`, isTransient: false, isAuthError: true };
+          // Drain body to keep the socket clean but don't include it in the error —
+          // OAuth response bodies can leak signature data into KV idempotency records.
+          await res.text().catch(() => '');
+          console.error(`Twitter publish auth failure: HTTP ${res.status}`);
+          return { success: false, error: `HTTP ${res.status}`, isTransient: false, isAuthError: true };
         }
         if (res.status === 429 || res.status >= 500) {
           return { success: false, error: `HTTP ${res.status}`, isTransient: true, isAuthError: false };
@@ -144,8 +155,9 @@ export function createTwitterPlatform(creds: OAuth1Creds): SocialPlatform {
       try {
         const res = await fetch(VERIFY_URL, { headers: { Authorization: auth } });
         if (!res.ok) {
-          const body = await res.text().catch(() => '');
-          console.error(`Twitter debugAuth HTTP ${res.status}: ${body.slice(0, 200)}`);
+          // Drain body but don't log it — OAuth response bodies can leak signature data.
+          await res.text().catch(() => '');
+          console.error(`Twitter debugAuth HTTP ${res.status}`);
           return { valid: false, platform: 'twitter', expiresAt: 0, dataAccessExpiresAt: 0, daysUntilExpiry: 0 };
         }
         return { valid: true, platform: 'twitter', expiresAt: 0, dataAccessExpiresAt: 0, daysUntilExpiry: 999 };


### PR DESCRIPTION
## Summary

Multi-engine QA pass (codex + gemini + hermes) on `HEAD~30..HEAD` surfaced several latent issues in the new Bluesky / Twitter platform code and the multi-platform cron-publish refactor. All three engines independently flagged the SSRF on the media-fetch paths.

### Fixes

**Security**
- **SSRF defense (codex MED, gemini HIGH, hermes HIGH — 3-engine consensus).** New `worker/src/platforms/safe-fetch.ts` exposes `isAllowedMediaUrl` (https + hostname allowlist + IP-literal rejection). Applied to `videoUrl` / `imageUrl` in `bluesky.ts` and `imageUrl` in `twitter.ts`. Without this, a caller with `/api/publish` access can turn the Worker into an SSRF primitive against internal metadata services.
- **Untrusted PDS endpoint (hermes HIGH).** The federated `serviceEndpoint` from `createSession` / `plc.directory` was used as the base URL for authenticated calls bearing our `accessJwt`. Now validated through `isSafeHttpsUrl` (https-only, no IP literals) before use.
- **Content-Length bypass on video upload (gemini MED).** `uploadVideo` was loading the full payload via `arrayBuffer()` whenever the `Content-Length` header was absent — the 20MB cap relied on `parseInt('0', 10) > 20*1024*1024` which is false. Now requires the header and a positive finite value within the cap.
- **OAuth response-body leak in Twitter errors (hermes MED).** 401/403 paths included `text.slice(0, 200)` of the response body in the error string, which is persisted in KV idempotency records and Worker logs. Drained but not interpolated.

**Correctness**
- **Cron loop batch-cap ordering (codex MED).** `duePosts.slice(0, 5)` was applied before filtering out blocked-platform posts, so a single expired token could starve healthy platforms out of their batch share. Now filters first, then slices. `remaining` recalculated to count both unprocessed healthy posts and skipped blocked posts.
- **Hardcoded "Facebook token invalid" log (hermes MED).** Cron-publish auth-error branch logged `Facebook` regardless of platform; now uses `${post.platform}`.
- **Comments cron 503-on-any-auth-failure (hermes MED).** Previously, one platform's expired data-access halted the entire run. Now skip-and-continue, matching the publish cron's behaviour. Per-platform status surfaces in the response.
- **`BSKY_BASE` vs `session.pdsEndpoint` inconsistency (hermes MED).** Only `uploadVideo` honoured the federated PDS endpoint — all other authenticated calls hit hardcoded `bsky.social`, breaking the flow for non-bsky.social PDS hosts. Unified.
- **Twitter `link` silently dropped (codex MED).** `publishPost` ignored `post.link` entirely. Now appended to message text (URLs auto-shorten to 23 chars via t.co).

### Out of scope (deferred to follow-up issues)

| Finding | Source | Why deferred |
|---|---|---|
| Cron KV-lock atomicity (TOCTOU) | gemini HIGH, hermes MED | KV is eventually-consistent by design; fix needs Durable Objects or D1 |
| Permanent-failure idempotency TTL | hermes MED | Architectural — needs force-retry mechanism on the queue endpoint |
| Multi-platform test mock weakness | gemini MED | Test refactor, not a bug |
| jpg-twin CI regex breadth | gemini MED | Works for current content paths; tightening could break valid external `heroImage` |
| OG image dimensions hardcoded by filename | hermes MED | Specific to bottom-pub-co-op; needs image regen or build-time dimension detection |

## Test plan

- [x] `worker/ npm test` — 96/96 pass (84 existing + 12 new safe-fetch tests)
- [x] `npx tsc --noEmit` — clean
- [x] `npx wrangler deploy --dry-run` — bundles at 120.84 KiB / 26.23 KiB gzip
- [ ] CI confirms `worker/` test step from PR #357 catches any regression
- [ ] Smoke: queue a Twitter link-type post after deploy and confirm the link lands in the tweet body