### PR TITLE
fix: worker hardening (DO cron lock, force-retry) + build-time OG dims

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"a83ab6e9-501d-4b62-8dfb-bb60b8715a9c","pid":31414,"procStart":"Thu Apr 23 23:50:03 2026","acquiredAt":1776995536481}
+{"sessionId":"40f50e37-d16d-488a-9ad6-239f8b55067a","pid":43617,"procStart":"Sat May 16 04:26:54 2026","acquiredAt":1778913314915}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Personal website for Adrian Wedd. Astro 6 (static) on GitHub Pages. Dark-first d
 - **DNS/Proxy:** Cloudflare
 - **Media CDN:** Cloudflare R2 at `cdn.adrianwedd.com` (audio/video); infographics in git
 - **CSP Worker:** `worker-csp/` — per-request nonce injection + strict CSP header. Route: `adrianwedd.com/*`
-- **Social Worker:** `worker/` — Facebook automation at `social.adrianwedd.com`
+- **Social Worker:** `worker/` — multi-platform social posting (Facebook, Instagram, Bluesky, X) at `social.adrianwedd.com`. Atomic cron locking via `CronLock` Durable Object.
 - **Booking API:** `~/repos/book-api/` — Google Calendar slots at `api.book.adrianwedd.com`
 
 ## Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,9 @@ Components using this pattern: ThemeToggle, ConsentBanner, Lightbox, ScrollRevea
 - **services.astro:** ProfessionalService schema
 - **Breadcrumb.astro:** BreadcrumbList on all detail pages
 
+### OG image dimensions
+`og:image:width` / `og:image:height` are read from the actual file at build time via `src/lib/image-dimensions.ts` — a 256 KB header parser for PNG/JPEG/WebP/GIF. Avoids the old filename-heuristic (`heroImage.includes('infographic')`) which mis-sized any hero whose path didn't match the convention. Build-time only (uses `node:fs`); never import into a Worker.
+
 ## CI/CD Pipeline
 
 ### Deploy (`deploy.yml`) — triggers on push to main
@@ -97,18 +100,27 @@ Components using this pattern: ThemeToggle, ConsentBanner, Lightbox, ScrollRevea
 
 ## Worker (Cloudflare)
 
-Located in `worker/`. Hono framework, TypeScript, KV namespace for state.
+Located in `worker/`. Hono framework, TypeScript. State lives in KV (`SOCIAL`) plus a single Durable Object class (`CronLock`) used for atomic locking.
 
 **Endpoints:**
-- `POST /api/publish` — immediate Facebook publish (posts, photos, links)
+- `POST /api/publish` — immediate multi-platform publish (`platform` ∈ `facebook|instagram|bluesky|twitter`). Optional `forceRetry: true` bypasses a `failed` idempotency record but never a `published` one. Returns `409` if another publish for the same `idempotencyKey` holds the per-key lock.
 - `POST /api/queue` + `POST /api/queue/sync` — scheduled post queue (JSON seed in `social/facebook-posts.json`, KV is authoritative)
 - `POST /api/cron/publish` — hourly publish from queue
 - `POST /api/cron/comments` — comment monitor with classification (crisis detection, auto-reply)
 - `GET /api/health` — token health + queue status
 
-**Auth:** Timing-safe bearer token (`PUBLISH_SECRET` / `CLI_SECRET`). Idempotency via KV with 30-day TTL.
+**Auth:** Timing-safe bearer token (`PUBLISH_SECRET` / `CLI_SECRET`). Idempotency via KV with 30-day TTL (failed records bypassable via `forceRetry`).
 
-**Deploy:** `cd worker && npx wrangler deploy`. CLI posting: `scripts/fb-post.sh`.
+**Cron locking:** `CronLock` Durable Object provides atomic named locks via `blockConcurrencyWhile` + fencing tokens. Used in three places:
+- `cron-lock:publish` (300s TTL) — serialises `/api/cron/publish`
+- `cron-lock:comments` (300s TTL) — serialises `/api/cron/comments`
+- `publish:<idempotencyKey>` (60s TTL) — serialises the read-decide-publish window in `/api/publish` so concurrent `forceRetry` calls can't double-post
+
+KV-based locks have a TOCTOU window between `get` and `put`; the DO closes that. `release()` requires the fencing token returned by `tryAcquire`, so a run that exceeds its TTL can't release the successor's lock.
+
+**Tests:** Vitest with a per-platform mock registry (`getPlatformMocks(name)`) — each platform has independent `publishPost`/`debugAuth` mocks so multi-platform scenarios (e.g. one healthy + one expired) can be tested in a single run. `cloudflare:workers` is aliased to `worker/test-shims/cloudflare-workers.ts` for vitest.
+
+**Deploy:** `cd worker && npx wrangler deploy`. CLI posting: `scripts/fb-post.sh`. Validate locally with `npx wrangler deploy --dry-run` before pushing.
 
 ## Key patterns
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -11,7 +11,7 @@ Personal website for Adrian Wedd. Astro 6 (static) on GitHub Pages. Dark-first d
 - **Hosting:** GitHub Pages (fully static).
 - **Media:** Cloudflare R2 for audio/video (`cdn.adrianwedd.com`). Infographics in git (`public/notebook-assets/`).
 - **CSP Worker:** Cloudflare Worker in `worker-csp/` — per-request nonce injection, strict CSP header, Permissions-Policy. Route: `adrianwedd.com/*`.
-- **Social Worker:** Cloudflare Worker in `worker/` — Facebook automation (publish, queue, comment monitor).
+- **Social Worker:** Cloudflare Worker in `worker/` — multi-platform social posting (Facebook, Instagram, Bluesky, X), publish/queue/comment monitor. Uses `CronLock` Durable Object for atomic cron locking with fencing tokens.
 - **Booking API:** Cloudflare Worker in `~/repos/book-api/` — Google Calendar slots + booking at `api.book.adrianwedd.com`.
 
 ## Building and Running

--- a/README.md
+++ b/README.md
@@ -127,15 +127,17 @@ Turnstile widget re-renders on View Transition navigation via explicit `turnstil
 
 ## Social Media Worker
 
-Cloudflare Worker (`worker/`) at `social.adrianwedd.com` manages the Facebook page.
+Cloudflare Worker (`worker/`) at `social.adrianwedd.com` manages cross-platform social posting.
 
 **Features:**
 
-- Auto-publish new blog posts and projects to Facebook on push to `main`
+- Auto-publish new blog posts and projects on push to `main`
+- Multi-platform: Facebook, Instagram, Bluesky, X/Twitter
 - Scheduled and ad-hoc post queue (JSON seed in `social/`, KV for state)
 - Comment monitoring with crisis detection, classification, and auto-reply
 - Backdated posting to match original publication dates
-- Idempotency via commit-SHA-based keys
+- Idempotency via commit-SHA-based keys (force-retry via `forceRetry: true` for failed records)
+- Atomic cron locking via Durable Object (`CronLock`) with fencing tokens — prevents concurrent cron tick races
 
 **CLI:**
 
@@ -150,13 +152,13 @@ scripts/fb-post.sh --sync                               # sync queue JSON to KV
 
 **Worker endpoints:**
 
-- `POST /api/publish` — immediate publish
+- `POST /api/publish` — immediate publish on the platform named in the request body (`platform` ∈ `facebook|instagram|bluesky|twitter`). `forceRetry: true` retries a `failed` idempotency entry. Returns `409` if another publish for the same `idempotencyKey` is already in flight.
 - `POST /api/queue` + `POST /api/queue/sync` — scheduled queue
-- `POST /api/cron/publish` — hourly publish from queue
-- `POST /api/cron/comments` — comment monitor (2-hourly)
+- `POST /api/cron/publish` — hourly publish from queue (DO-locked)
+- `POST /api/cron/comments` — comment monitor, 2-hourly (DO-locked)
 - `GET /api/health` — token health and queue status
 
-Worker tests: `cd worker && npm test`
+Worker tests: `cd worker && npm test`. Local validation: `cd worker && npx wrangler deploy --dry-run`.
 
 ## NotebookLM Automation
 

--- a/src/lib/image-dimensions.ts
+++ b/src/lib/image-dimensions.ts
@@ -121,23 +121,34 @@ function parseDimensions(buf: Buffer): ImageDimensions | null {
     return null;
   }
 
-  // JPEG: scan markers, skipping APP/COM segments by declared length. Stop at
-  // SOS (0xFFDA) — past that point is entropy-coded data where 0xFF doesn't
-  // mark segment boundaries.
+  // JPEG: scan markers, skipping segments by declared length. Stop at SOS
+  // (0xFFDA) — past that point is entropy-coded data. Handles 0xFF fill bytes
+  // (valid padding per ITU-T T.81 §B.1.1.2) and standalone markers that
+  // carry no length field (RSTn 0xD0-0xD7, TEM 0x01, SOI 0xD8, EOI 0xD9).
   if (buf.length >= 4 && buf[0] === 0xff && buf[1] === 0xd8) {
     let i = 2;
-    while (i + 9 < buf.length) {
+    while (i < buf.length) {
       if (buf[i] !== 0xff) return null;
-      const marker = buf[i + 1];
+      // Skip 0xFF fill bytes to find the actual marker type byte.
+      let j = i + 1;
+      while (j < buf.length && buf[j] === 0xff) j++;
+      if (j >= buf.length) return null;
+      const marker = buf[j];
       if (marker === 0xda) return null; // SOS: no SOF found before scan data
       // SOFn markers: 0xC0–0xCF except 0xC4 (DHT), 0xC8 (JPG), 0xCC (DAC).
       if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
-        const height = buf.readUInt16BE(i + 5);
-        const width = buf.readUInt16BE(i + 7);
-        return { width, height };
+        if (j + 7 >= buf.length) return null;
+        return { width: buf.readUInt16BE(j + 6), height: buf.readUInt16BE(j + 4) };
       }
-      const segmentLength = buf.readUInt16BE(i + 2);
-      i += 2 + segmentLength;
+      // Standalone markers (no length field): TEM (0x01), RSTn (0xD0-0xD7),
+      // SOI (0xD8), EOI (0xD9).
+      if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd9)) {
+        i = j + 1;
+        continue;
+      }
+      if (j + 2 >= buf.length) return null;
+      const segmentLength = buf.readUInt16BE(j + 1);
+      i = j + 1 + segmentLength;
     }
   }
 

--- a/src/lib/image-dimensions.ts
+++ b/src/lib/image-dimensions.ts
@@ -1,0 +1,110 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+const cache = new Map<string, ImageDimensions | null>();
+
+// Astro runs SSG with the project root as cwd, so this resolves to public/.
+const PUBLIC_DIR = resolve(process.cwd(), 'public');
+
+/**
+ * Read pixel dimensions of an image referenced by a site-rooted path (e.g.
+ * `/notebook-assets/foo/infographic.jpg`). Returns null if the file is
+ * missing or the format isn't recognised. Build-time only — runs at SSG
+ * time when Astro renders the page.
+ *
+ * Supports JPEG, PNG, WebP, and GIF — the formats this site actually ships
+ * for OG images. Reads only the header bytes, not the full file.
+ */
+export function getImageDimensions(publicPath: string): ImageDimensions | null {
+  if (cache.has(publicPath)) return cache.get(publicPath) ?? null;
+
+  const trimmed = publicPath.replace(/^\//, '');
+  const fsPath = resolve(PUBLIC_DIR, trimmed);
+
+  if (!existsSync(fsPath)) {
+    cache.set(publicPath, null);
+    return null;
+  }
+
+  try {
+    // 64 KB is plenty for SOF markers in even very large JPEGs.
+    const buf = readFileSync(fsPath, { flag: 'r' }).subarray(0, 65536);
+    const dims = parseDimensions(buf);
+    cache.set(publicPath, dims);
+    return dims;
+  } catch {
+    cache.set(publicPath, null);
+    return null;
+  }
+}
+
+function parseDimensions(buf: Buffer): ImageDimensions | null {
+  // PNG: 8-byte signature, then IHDR at offset 16 (width) and 20 (height), big-endian uint32.
+  if (
+    buf.length >= 24 &&
+    buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47
+  ) {
+    return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+  }
+
+  // GIF: "GIF87a" or "GIF89a", then width/height little-endian uint16 at offsets 6/8.
+  if (
+    buf.length >= 10 &&
+    buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46
+  ) {
+    return { width: buf.readUInt16LE(6), height: buf.readUInt16LE(8) };
+  }
+
+  // WebP: "RIFF" .... "WEBP" header at offset 8.
+  if (
+    buf.length >= 30 &&
+    buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
+    buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
+  ) {
+    const chunk = buf.toString('ascii', 12, 16);
+    if (chunk === 'VP8 ') {
+      // Lossy: width/height are 14-bit values at offset 26/28 (little-endian), minus reserved bits.
+      const w = buf.readUInt16LE(26) & 0x3fff;
+      const h = buf.readUInt16LE(28) & 0x3fff;
+      return { width: w, height: h };
+    }
+    if (chunk === 'VP8L') {
+      // Lossless: dimensions packed into bytes 21–24.
+      const b0 = buf[21], b1 = buf[22], b2 = buf[23], b3 = buf[24];
+      const w = 1 + (((b1 & 0x3f) << 8) | b0);
+      const h = 1 + (((b3 & 0x0f) << 10) | (b2 << 2) | ((b1 & 0xc0) >> 6));
+      return { width: w, height: h };
+    }
+    if (chunk === 'VP8X') {
+      // Extended: 24-bit width-1, height-1 at offsets 24 and 27.
+      const w = 1 + (buf[24] | (buf[25] << 8) | (buf[26] << 16));
+      const h = 1 + (buf[27] | (buf[28] << 8) | (buf[29] << 16));
+      return { width: w, height: h };
+    }
+  }
+
+  // JPEG: scan for SOFn markers (0xFFC0–0xFFC3, 0xFFC5–0xFFC7, 0xFFC9–0xFFCB, 0xFFCD–0xFFCF).
+  // Skip APP/COM segments by their declared length.
+  if (buf.length >= 4 && buf[0] === 0xff && buf[1] === 0xd8) {
+    let i = 2;
+    while (i + 9 < buf.length) {
+      if (buf[i] !== 0xff) return null;
+      const marker = buf[i + 1];
+      if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
+        // SOFn: height at offset i+5 (big-endian uint16), width at i+7.
+        const height = buf.readUInt16BE(i + 5);
+        const width = buf.readUInt16BE(i + 7);
+        return { width, height };
+      }
+      const segmentLength = buf.readUInt16BE(i + 2);
+      i += 2 + segmentLength;
+    }
+  }
+
+  return null;
+}

--- a/src/lib/image-dimensions.ts
+++ b/src/lib/image-dimensions.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync } from 'node:fs';
+import { openSync, readSync, closeSync, existsSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 export interface ImageDimensions {
@@ -11,14 +11,18 @@ const cache = new Map<string, ImageDimensions | null>();
 // Astro runs SSG with the project root as cwd, so this resolves to public/.
 const PUBLIC_DIR = resolve(process.cwd(), 'public');
 
+// 256 KB header window covers JPEGs with multi-segment EXIF + ICC profiles
+// (real-world cameras rarely exceed ~64 KB, but ICC profiles can push past it).
+const HEADER_BYTES = 256 * 1024;
+
 /**
  * Read pixel dimensions of an image referenced by a site-rooted path (e.g.
  * `/notebook-assets/foo/infographic.jpg`). Returns null if the file is
  * missing or the format isn't recognised. Build-time only — runs at SSG
  * time when Astro renders the page.
  *
- * Supports JPEG, PNG, WebP, and GIF — the formats this site actually ships
- * for OG images. Reads only the header bytes, not the full file.
+ * Supports JPEG, PNG, WebP (VP8/VP8L/VP8X), and GIF. Reads only the first
+ * 256 KB of the file, never the whole image.
  */
 export function getImageDimensions(publicPath: string): ImageDimensions | null {
   if (cache.has(publicPath)) return cache.get(publicPath) ?? null;
@@ -31,28 +35,39 @@ export function getImageDimensions(publicPath: string): ImageDimensions | null {
     return null;
   }
 
+  let fd: number | null = null;
   try {
-    // 64 KB is plenty for SOF markers in even very large JPEGs.
-    const buf = readFileSync(fsPath, { flag: 'r' }).subarray(0, 65536);
+    const size = statSync(fsPath).size;
+    const want = Math.min(size, HEADER_BYTES);
+    const buf = Buffer.alloc(want);
+    fd = openSync(fsPath, 'r');
+    readSync(fd, buf, 0, want, 0);
     const dims = parseDimensions(buf);
     cache.set(publicPath, dims);
     return dims;
   } catch {
     cache.set(publicPath, null);
     return null;
+  } finally {
+    if (fd !== null) {
+      try { closeSync(fd); } catch { /* ignore close errors */ }
+    }
   }
 }
 
 function parseDimensions(buf: Buffer): ImageDimensions | null {
-  // PNG: 8-byte signature, then IHDR at offset 16 (width) and 20 (height), big-endian uint32.
+  // PNG: signature, then 4-byte length, then "IHDR", then width/height (BE uint32).
   if (
     buf.length >= 24 &&
-    buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47
+    buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47 &&
+    // Validate that bytes 12–15 are actually "IHDR" — otherwise the file has
+    // a valid PNG signature but a corrupt chunk layout.
+    buf[12] === 0x49 && buf[13] === 0x48 && buf[14] === 0x44 && buf[15] === 0x52
   ) {
     return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
   }
 
-  // GIF: "GIF87a" or "GIF89a", then width/height little-endian uint16 at offsets 6/8.
+  // GIF87a / GIF89a: width/height little-endian uint16 at offsets 6/8.
   if (
     buf.length >= 10 &&
     buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46
@@ -60,43 +75,60 @@ function parseDimensions(buf: Buffer): ImageDimensions | null {
     return { width: buf.readUInt16LE(6), height: buf.readUInt16LE(8) };
   }
 
-  // WebP: "RIFF" .... "WEBP" header at offset 8.
+  // WebP: "RIFF" .... "WEBP" then variable chunks. Scan for the dimension-
+  // bearing chunk (VP8, VP8L, VP8X) rather than assuming a fixed offset,
+  // because extended files can have ALPHA/ANIM chunks before VP8/VP8L.
   if (
     buf.length >= 30 &&
     buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
     buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
   ) {
-    const chunk = buf.toString('ascii', 12, 16);
-    if (chunk === 'VP8 ') {
-      // Lossy: width/height are 14-bit values at offset 26/28 (little-endian), minus reserved bits.
-      const w = buf.readUInt16LE(26) & 0x3fff;
-      const h = buf.readUInt16LE(28) & 0x3fff;
-      return { width: w, height: h };
+    let off = 12;
+    while (off + 8 <= buf.length) {
+      const fourcc = buf.toString('ascii', off, off + 4);
+      const chunkSize = buf.readUInt32LE(off + 4);
+      const dataStart = off + 8;
+      if (fourcc === 'VP8 ' && dataStart + 10 <= buf.length) {
+        // Lossy: width/height (LE uint16, 14-bit) at offset dataStart+6/8.
+        return {
+          width: buf.readUInt16LE(dataStart + 6) & 0x3fff,
+          height: buf.readUInt16LE(dataStart + 8) & 0x3fff,
+        };
+      }
+      if (fourcc === 'VP8L' && dataStart + 5 <= buf.length) {
+        // Signature byte 0x2F validates we're really at a VP8L chunk.
+        if (buf[dataStart] !== 0x2f) return null;
+        const b0 = buf[dataStart + 1];
+        const b1 = buf[dataStart + 2];
+        const b2 = buf[dataStart + 3];
+        const b3 = buf[dataStart + 4];
+        const w = 1 + (((b1 & 0x3f) << 8) | b0);
+        const h = 1 + (((b3 & 0x0f) << 10) | (b2 << 2) | ((b1 & 0xc0) >> 6));
+        return { width: w, height: h };
+      }
+      if (fourcc === 'VP8X' && dataStart + 10 <= buf.length) {
+        // Extended: 24-bit (width-1, height-1) starting at dataStart+4 / +7.
+        const w = 1 + (buf[dataStart + 4] | (buf[dataStart + 5] << 8) | (buf[dataStart + 6] << 16));
+        const h = 1 + (buf[dataStart + 7] | (buf[dataStart + 8] << 8) | (buf[dataStart + 9] << 16));
+        return { width: w, height: h };
+      }
+      // RIFF chunks are word-aligned: bump odd sizes up by 1.
+      off = dataStart + chunkSize + (chunkSize & 1);
     }
-    if (chunk === 'VP8L') {
-      // Lossless: dimensions packed into bytes 21–24.
-      const b0 = buf[21], b1 = buf[22], b2 = buf[23], b3 = buf[24];
-      const w = 1 + (((b1 & 0x3f) << 8) | b0);
-      const h = 1 + (((b3 & 0x0f) << 10) | (b2 << 2) | ((b1 & 0xc0) >> 6));
-      return { width: w, height: h };
-    }
-    if (chunk === 'VP8X') {
-      // Extended: 24-bit width-1, height-1 at offsets 24 and 27.
-      const w = 1 + (buf[24] | (buf[25] << 8) | (buf[26] << 16));
-      const h = 1 + (buf[27] | (buf[28] << 8) | (buf[29] << 16));
-      return { width: w, height: h };
-    }
+    return null;
   }
 
-  // JPEG: scan for SOFn markers (0xFFC0–0xFFC3, 0xFFC5–0xFFC7, 0xFFC9–0xFFCB, 0xFFCD–0xFFCF).
-  // Skip APP/COM segments by their declared length.
+  // JPEG: scan markers, skipping APP/COM segments by declared length. Stop at
+  // SOS (0xFFDA) — past that point is entropy-coded data where 0xFF doesn't
+  // mark segment boundaries.
   if (buf.length >= 4 && buf[0] === 0xff && buf[1] === 0xd8) {
     let i = 2;
     while (i + 9 < buf.length) {
       if (buf[i] !== 0xff) return null;
       const marker = buf[i + 1];
+      if (marker === 0xda) return null; // SOS: no SOF found before scan data
+      // SOFn markers: 0xC0–0xCF except 0xC4 (DHT), 0xC8 (JPG), 0xCC (DAC).
       if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
-        // SOFn: height at offset i+5 (big-endian uint16), width at i+7.
         const height = buf.readUInt16BE(i + 5);
         const width = buf.readUInt16BE(i + 7);
         return { width, height };

--- a/src/lib/image-dimensions.ts
+++ b/src/lib/image-dimensions.ts
@@ -18,8 +18,11 @@ const HEADER_BYTES = 256 * 1024;
 /**
  * Read pixel dimensions of an image referenced by a site-rooted path (e.g.
  * `/notebook-assets/foo/infographic.jpg`). Returns null if the file is
- * missing or the format isn't recognised. Build-time only — runs at SSG
- * time when Astro renders the page.
+ * missing or the format isn't recognised.
+ *
+ * **Build-time only.** Uses `node:fs` and `process.cwd()`. Importing into
+ * a Cloudflare Worker (or anything other than the Astro SSG build) will
+ * fail at module load.
  *
  * Supports JPEG, PNG, WebP (VP8/VP8L/VP8X), and GIF. Reads only the first
  * 256 KB of the file, never the whole image.

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -9,6 +9,7 @@ import NotebookAssets from '../../components/NotebookAssets.astro';
 import AudioPlayer from '../../components/islands/AudioPlayer';
 import { getCollection, render } from 'astro:content';
 import { slug } from '../../lib/utils';
+import { getImageDimensions } from '../../lib/image-dimensions';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog');
@@ -43,12 +44,12 @@ const postSlug = slug(post.id);
 const ogImage = post.data.heroImage
   ? post.data.heroImage.replace(/\.webp$/, '.jpg')
   : `/og/blog/${postSlug}.png`;
-// Infographic hero images are portrait 1536x2752; the auto-generated text
-// cards are 1200x630 landscape. Pass the right dimensions.
-const ogImageIsInfographic =
-  typeof post.data.heroImage === 'string' && post.data.heroImage.includes('infographic');
-const ogImageWidth = ogImageIsInfographic ? 1536 : 1200;
-const ogImageHeight = ogImageIsInfographic ? 2752 : 630;
+// Read the actual image dimensions at build time (covers infographics, text
+// cards, and any future OG image shape without filename-based heuristics).
+// Falls back to standard 1200x630 if the file is missing or unreadable.
+const ogDimensions = getImageDimensions(ogImage);
+const ogImageWidth = ogDimensions?.width ?? 1200;
+const ogImageHeight = ogDimensions?.height ?? 630;
 
 // Series support
 const seriesPosts = post.data.series

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -8,6 +8,7 @@ import NotebookAssets from '../../components/NotebookAssets.astro';
 import AudioPlayer from '../../components/islands/AudioPlayer';
 import { getCollection, render } from 'astro:content';
 import { slug } from '../../lib/utils';
+import { getImageDimensions } from '../../lib/image-dimensions';
 import { Picture } from 'astro:assets';
 
 export async function getStaticPaths() {
@@ -30,9 +31,11 @@ const projectSlug = slug(project.id);
 const ogImage = project.data.heroImage
   ? project.data.heroImage.replace(/\.webp$/, '.jpg')
   : `/og/projects/${projectSlug}.png`;
-const isPortraitHero = typeof project.data.heroImage === 'string' && project.data.heroImage.includes('infographic');
-const ogImageWidth = isPortraitHero ? 1536 : 1200;
-const ogImageHeight = isPortraitHero ? 2752 : 630;
+// Read actual image dimensions at build time — covers infographics, text
+// cards, and any future OG image shape without filename-based heuristics.
+const ogDimensions = getImageDimensions(ogImage);
+const ogImageWidth = ogDimensions?.width ?? 1200;
+const ogImageHeight = ogDimensions?.height ?? 630;
 const allAudio = await getCollection('audio');
 const relatedEpisodes = allAudio.filter((ep) => !ep.data.draft && ep.data.relatedProject === projectSlug);
 

--- a/test-do.ts
+++ b/test-do.ts
@@ -1,4 +1,0 @@
-export class CronLock {
-  constructor(state: any) {}
-  async foo() { return "bar"; }
-}

--- a/test-do.ts
+++ b/test-do.ts
@@ -1,0 +1,4 @@
+export class CronLock {
+  constructor(state: any) {}
+  async foo() { return "bar"; }
+}

--- a/worker-csp/package-lock.json
+++ b/worker-csp/package-lock.json
@@ -62,550 +62,6 @@
         "vitest": "2.0.x - 3.2.x"
       }
     },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.0.tgz",
-      "integrity": "sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "mime": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/unenv-preset": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.7.3.tgz",
-      "integrity": "sha512-tsQQagBKjvpd9baa6nWVIv399ejiqcrUBBW6SZx6Z22+ymm+Odv5+cFimyuCsD/fC1fQTwfRmwXBNpzvHSeGCw==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peerDependencies": {
-        "unenv": "2.0.0-rc.21",
-        "workerd": "^1.20250828.1"
-      },
-      "peerDependenciesMeta": {
-        "workerd": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.4.tgz",
-      "integrity": "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.4.tgz",
-      "integrity": "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.4.tgz",
-      "integrity": "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.4.tgz",
-      "integrity": "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.4.tgz",
-      "integrity": "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.4.tgz",
-      "integrity": "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.4.tgz",
-      "integrity": "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.4.tgz",
-      "integrity": "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.4.tgz",
-      "integrity": "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.4.tgz",
-      "integrity": "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.4.tgz",
-      "integrity": "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.4.tgz",
-      "integrity": "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.4.tgz",
-      "integrity": "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.4.tgz",
-      "integrity": "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.4.tgz",
-      "integrity": "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.4.tgz",
-      "integrity": "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.4.tgz",
-      "integrity": "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.4.tgz",
-      "integrity": "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.4.tgz",
-      "integrity": "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.4.tgz",
-      "integrity": "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.4.tgz",
-      "integrity": "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.4.tgz",
-      "integrity": "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.4.tgz",
-      "integrity": "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.4.tgz",
-      "integrity": "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz",
-      "integrity": "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.4.tgz",
-      "integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.4",
-        "@esbuild/android-arm": "0.25.4",
-        "@esbuild/android-arm64": "0.25.4",
-        "@esbuild/android-x64": "0.25.4",
-        "@esbuild/darwin-arm64": "0.25.4",
-        "@esbuild/darwin-x64": "0.25.4",
-        "@esbuild/freebsd-arm64": "0.25.4",
-        "@esbuild/freebsd-x64": "0.25.4",
-        "@esbuild/linux-arm": "0.25.4",
-        "@esbuild/linux-arm64": "0.25.4",
-        "@esbuild/linux-ia32": "0.25.4",
-        "@esbuild/linux-loong64": "0.25.4",
-        "@esbuild/linux-mips64el": "0.25.4",
-        "@esbuild/linux-ppc64": "0.25.4",
-        "@esbuild/linux-riscv64": "0.25.4",
-        "@esbuild/linux-s390x": "0.25.4",
-        "@esbuild/linux-x64": "0.25.4",
-        "@esbuild/netbsd-arm64": "0.25.4",
-        "@esbuild/netbsd-x64": "0.25.4",
-        "@esbuild/openbsd-arm64": "0.25.4",
-        "@esbuild/openbsd-x64": "0.25.4",
-        "@esbuild/sunos-x64": "0.25.4",
-        "@esbuild/win32-arm64": "0.25.4",
-        "@esbuild/win32-ia32": "0.25.4",
-        "@esbuild/win32-x64": "0.25.4"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/unenv": {
-      "version": "2.0.0-rc.21",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.21.tgz",
-      "integrity": "sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defu": "^6.1.4",
-        "exsolve": "^1.0.7",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "ufo": "^1.6.1"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.35.0.tgz",
-      "integrity": "sha512-HbyXtbrh4Fi3mU8ussY85tVdQ74qpVS1vctUgaPc+bPrXBTqfDLkZ6VRtHAVF/eBhz4SFmhJtCQpN1caY2Ak8A==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.4.0",
-        "@cloudflare/unenv-preset": "2.7.3",
-        "blake3-wasm": "2.1.5",
-        "esbuild": "0.25.4",
-        "miniflare": "4.20250906.0",
-        "path-to-regexp": "6.3.0",
-        "unenv": "2.0.0-rc.21",
-        "workerd": "1.20250906.0"
-      },
-      "bin": {
-        "wrangler": "bin/wrangler.js",
-        "wrangler2": "bin/wrangler.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      },
-      "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20250906.0"
-      },
-      "peerDependenciesMeta": {
-        "@cloudflare/workers-types": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@cloudflare/workerd-darwin-64": {
       "version": "1.20250906.0",
       "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250906.0.tgz",
@@ -1296,6 +752,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1313,6 +772,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1444,6 +906,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1467,6 +932,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2408,13 +1876,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/defu": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
-      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2524,13 +1985,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2605,19 +2059,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/miniflare": {
       "version": "4.20250906.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250906.0.tgz",
@@ -2680,13 +2121,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/ohash": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -3007,13 +2441,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/undici": {
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
@@ -3241,9 +2668,9 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.90.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.90.0.tgz",
-      "integrity": "sha512-bmNIykl59TfCUn5xQgU7IWylSsPx3LQaPLMSAq2VQHt89CBrcj9qXQ0eYfjBCWA5XTBVgten391evt7xxtXwcA==",
+      "version": "4.92.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.92.0.tgz",
+      "integrity": "sha512-/DKpQHPxkuZbQsO9dFW2700VTD/4DSZMHjy92fO/frNoDRi/zQsFCAd2ONCV6TGqcUoXcP3D8Bo2gj/L4M0qQQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -3251,10 +2678,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260507.1",
+        "miniflare": "4.20260515.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260507.1"
+        "workerd": "1.20260515.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -3267,7 +2694,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260507.1"
+        "@cloudflare/workers-types": "^4.20260515.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -3276,9 +2703,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260507.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260507.1.tgz",
-      "integrity": "sha512-S85aMwcaPJUjKWDiG6iMMnioKWtPLACa6m0j/EhHR1GYfVpnxb974cBc6d25L+sf7jHWHJI2u5hGp0UTJ7MtXQ==",
+      "version": "1.20260515.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260515.1.tgz",
+      "integrity": "sha512-Wtw44el2pNbzixvTkWdfeBDTrQwQbJRz7/JUvPKV27I0pQWXbhNJPpM8cstq/pbrU5AGcA/HjFH6yPMRTIRKig==",
       "cpu": [
         "x64"
       ],
@@ -3293,9 +2720,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260507.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260507.1.tgz",
-      "integrity": "sha512-GMEBu8Zp9Q97HLnf7bWJN4KjWpN5MxpeqdvHjBGWNl8UYprJI0k+Jkp89+Wh5S8vIon+HoVbDfOzPa7VwgL6Eg==",
+      "version": "1.20260515.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260515.1.tgz",
+      "integrity": "sha512-X8EqkZej6FfmhF9AVAQ3FhyQRr9acS4RcDunMU2YiuxKHF1IU8zzH3vY30/POaG+rUu9vGDp/VgUl49VPenHJQ==",
       "cpu": [
         "arm64"
       ],
@@ -3310,9 +2737,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260507.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260507.1.tgz",
-      "integrity": "sha512-QlrKEBdgA3uVc0Ok0Q3+0/CW0CTjgj5ySir1i1YY5FXVv0X6GpwtnB5umjunjF2MFprss+L+iFGZzxcSvMC1nA==",
+      "version": "1.20260515.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260515.1.tgz",
+      "integrity": "sha512-CDC89QxQ7Y7t7RG1Jd9vj/qolE1sQRkI2OSEuV5BMJi0vW/gV4OVG6xjpdK3b1OYnSWDzF7NpvlR5Yg86q7k4g==",
       "cpu": [
         "x64"
       ],
@@ -3327,9 +2754,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260507.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260507.1.tgz",
-      "integrity": "sha512-eGbbupEtK2nh9V9Dhcx3vv3GTKeXqSVNgAEYVCCN0NGS9tl9HbMoHRX/4JL181FKXROMigWBCQVL//qPhsAzBQ==",
+      "version": "1.20260515.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260515.1.tgz",
+      "integrity": "sha512-WxbW/PToYES4fvHXzsr/5qOiETQs/Z9iZ0mjSZAiEwq5cMLZemzGN0COx+uFb9OvQwzh6Pg159qPFnw3+i9FuA==",
       "cpu": [
         "arm64"
       ],
@@ -3344,9 +2771,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260507.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260507.1.tgz",
-      "integrity": "sha512-dmClJ/E0BAcuDetQIZFqbeAXejWrG5pysGRMQ6T83Y0IW/7IAamY2zFEkAJ10I5xwZsdHuYsZtzlOxpEXpJs7A==",
+      "version": "1.20260515.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260515.1.tgz",
+      "integrity": "sha512-WmV/iv+MHjYsvkcMVzpM2B5/mf06UUkdpVhZrtMfV9graWjBGPYFvE/eab8748RPVGKh1Xe1vXofLzDSwc08lA==",
       "cpu": [
         "x64"
       ],
@@ -3890,6 +3317,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3907,6 +3337,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3924,6 +3357,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3941,6 +3377,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3958,6 +3397,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3975,6 +3417,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3992,6 +3437,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4015,6 +3463,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4038,6 +3489,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4061,6 +3515,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4084,6 +3541,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4107,6 +3567,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4225,16 +3688,16 @@
       }
     },
     "node_modules/wrangler/node_modules/miniflare": {
-      "version": "4.20260507.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260507.1.tgz",
-      "integrity": "sha512-PSXBiLExTdZ4UGO/raKCHQauUpYL7F880ZRB7j0+78Rv8h7TsdN2E/iEDK9sK2Y+SPQ5wJSeAa+rDeVKoZZoEw==",
+      "version": "4.20260515.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260515.0.tgz",
+      "integrity": "sha512-2j0oQWizk1Eu4Cm8tDX7Z+Nsjd0nebIj1TQcQ+Oy1QKeo0Ay9+bdn8wfLAtOj9znDCybDCUlnS1+nYvKXEdfNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "^0.34.5",
         "undici": "7.24.8",
-        "workerd": "1.20260507.1",
+        "workerd": "1.20260515.1",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10"
       },
@@ -4301,9 +3764,9 @@
       }
     },
     "node_modules/wrangler/node_modules/workerd": {
-      "version": "1.20260507.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260507.1.tgz",
-      "integrity": "sha512-z7JhsFSe6+X1b5fUHaVpo15VM1IRMJiLofEkq8iKdCo+Veqc+FUg5lIsuz8NwePxuSKrXtO4ZQpGkQLbPVXFhg==",
+      "version": "1.20260515.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260515.1.tgz",
+      "integrity": "sha512-MjKOJLcvU45xXedQowvuiHtJTxu4WTHYQeIlF7YmjuqhiI6dImTFxWCEoRQHiskztxuVSNEmdO7/0UfDu6OMnQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -4314,11 +3777,11 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260507.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260507.1",
-        "@cloudflare/workerd-linux-64": "1.20260507.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260507.1",
-        "@cloudflare/workerd-windows-64": "1.20260507.1"
+        "@cloudflare/workerd-darwin-64": "1.20260515.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260515.1",
+        "@cloudflare/workerd-linux-64": "1.20260515.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260515.1",
+        "@cloudflare/workerd-windows-64": "1.20260515.1"
       }
     },
     "node_modules/ws": {

--- a/worker-csp/package.json
+++ b/worker-csp/package.json
@@ -16,5 +16,8 @@
     "typescript": "^5.8.0",
     "vitest": "~3.0.0",
     "wrangler": "^4.90.0"
+  },
+  "overrides": {
+    "wrangler": "^4.90.0"
   }
 }

--- a/worker/src/__tests__/publish.test.ts
+++ b/worker/src/__tests__/publish.test.ts
@@ -93,16 +93,26 @@ function makePost(id: string, epochOffset = 0): SocialPost {
 }
 
 function mockCronLock(initialHeldNames: string[] = []) {
-  const held = new Map<string, number>();
+  // Each entry stores { expiresAt, token } — mirrors the real DO's state.
+  const held = new Map<string, { expiresAt: number; token: string }>();
   const now = Date.now();
-  for (const name of initialHeldNames) held.set(name, now + 300_000);
+  for (const name of initialHeldNames) {
+    held.set(name, { expiresAt: now + 300_000, token: `pre-held-${name}` });
+  }
+  let tokenCounter = 0;
   const tryAcquire = vi.fn(async (name: string, ttlMs: number) => {
-    const expires = held.get(name);
-    if (expires && expires > Date.now()) return { acquired: false };
-    held.set(name, Date.now() + ttlMs);
-    return { acquired: true };
+    const existing = held.get(name);
+    if (existing && existing.expiresAt > Date.now()) {
+      return { acquired: false, token: null };
+    }
+    const token = `tok-${++tokenCounter}`;
+    held.set(name, { expiresAt: Date.now() + ttlMs, token });
+    return { acquired: true, token };
   });
-  const release = vi.fn(async (name: string) => { held.delete(name); });
+  const release = vi.fn(async (name: string, token: string) => {
+    const existing = held.get(name);
+    if (existing && existing.token === token) held.delete(name);
+  });
   const stub = { tryAcquire, release };
   return {
     held,
@@ -319,8 +329,8 @@ describe('POST /api/cron/publish', () => {
     // publishing key should be deleted
     expect(kv.store.has(`post:publishing:${post.scheduledAtEpoch}:${post.id}`)).toBe(false);
 
-    // Cron lock released in finally
-    expect(cronLock.release).toHaveBeenCalledWith('publish');
+    // Cron lock released in finally (with the fencing token the run acquired)
+    expect(cronLock.release).toHaveBeenCalledWith('publish', expect.any(String));
   });
 
   it('breaks loop on transient error, reverts post to queued, does not process remaining', async () => {
@@ -403,7 +413,28 @@ describe('POST /api/cron/publish', () => {
     } catch { /* swallow — finally is what we're testing */ }
 
     // Lock must be released regardless of how the error surfaced
-    expect(cronLock.release).toHaveBeenCalledWith('publish');
+    expect(cronLock.release).toHaveBeenCalledWith('publish', expect.any(String));
+    expect(cronLock.held.has('publish')).toBe(false);
+  });
+
+  it('release with a mismatched fencing token does NOT clear another holder\'s lock', async () => {
+    // Simulates: run A acquires, exceeds TTL, lock entry expires, run B acquires
+    // a fresh lock with a new token, then run A finally fires release.
+    const cronLock = mockCronLock();
+    const a = await cronLock.tryAcquire('publish', 1);     // acquire then "expire"
+    expect(a.acquired).toBe(true);
+    cronLock.held.get('publish')!.expiresAt = Date.now() - 1; // force-expire
+    const b = await cronLock.tryAcquire('publish', 300_000);
+    expect(b.acquired).toBe(true);
+    expect(b.token).not.toBe(a.token);
+
+    // Run A's stale release: must be a no-op
+    await cronLock.release('publish', a.token!);
+    expect(cronLock.held.has('publish')).toBe(true);
+    expect(cronLock.held.get('publish')!.token).toBe(b.token);
+
+    // Run B's release should actually clear
+    await cronLock.release('publish', b.token!);
     expect(cronLock.held.has('publish')).toBe(false);
   });
 
@@ -540,5 +571,34 @@ describe('POST /api/publish forceRetry', () => {
     expect(body.alreadyPublished).toBe(true);
     expect(body.platformPostId).toBe('fb_already');
     expect(mockPublishPost).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when a concurrent publish holds the per-key lock', async () => {
+    const kv = mockKV();
+    // Simulate concurrent publish: pre-populate the held set with this key's lock name.
+    const cronLock = mockCronLock(['publish:concurrent-key']);
+
+    const res = await app.fetch(
+      publishRequest({ type: 'text', message: 'hi', idempotencyKey: 'concurrent-key' }),
+      makeEnv(kv, cronLock),
+    );
+    expect(res.status).toBe(409);
+    expect(mockPublishPost).not.toHaveBeenCalled();
+  });
+
+  it('releases the per-key lock after a successful publish', async () => {
+    const kv = mockKV();
+    const cronLock = mockCronLock();
+    mockPublishPost.mockResolvedValueOnce({
+      success: true, platformPostId: 'fb_ok', isTransient: false, isAuthError: false,
+    });
+
+    const res = await app.fetch(
+      publishRequest({ type: 'text', message: 'hi', idempotencyKey: 'release-test' }),
+      makeEnv(kv, cronLock),
+    );
+    expect(res.status).toBe(200);
+    expect(cronLock.release).toHaveBeenCalledWith('publish:release-test', expect.any(String));
+    expect(cronLock.held.has('publish:release-test')).toBe(false);
   });
 });

--- a/worker/src/__tests__/publish.test.ts
+++ b/worker/src/__tests__/publish.test.ts
@@ -3,24 +3,59 @@ import app from '../index';
 import type { SocialPost, AuthStatus } from '../platforms/types';
 
 // ── Mock createPlatform factory ──────────────────────────────────────────────
+//
+// Registry pattern: each platform gets its own publishPost/debugAuth pair, so
+// tests can independently script per-platform behaviour (e.g. facebook healthy,
+// bluesky expired). `mockPublishPost` and `mockDebugAuth` remain bound to the
+// default platform ('facebook') for backward compatibility with existing tests.
 
-const mockPublishPost = vi.fn();
-const mockDebugAuth = vi.fn();
+interface PlatformMocks {
+  publishPost: ReturnType<typeof vi.fn>;
+  debugAuth: ReturnType<typeof vi.fn>;
+  getPageIdentity: ReturnType<typeof vi.fn>;
+}
+
+const platformRegistry = new Map<string, PlatformMocks>();
+let configuredPlatformsList: string[] = ['facebook'];
+
+function getPlatformMocks(platform: string): PlatformMocks {
+  let mocks = platformRegistry.get(platform);
+  if (!mocks) {
+    mocks = {
+      publishPost: vi.fn(),
+      debugAuth: vi.fn(),
+      getPageIdentity: vi.fn().mockReturnValue(`${platform}_identity`),
+    };
+    platformRegistry.set(platform, mocks);
+  }
+  return mocks;
+}
+
+// Default platform mocks (preserves existing test ergonomics)
+const mockPublishPost = getPlatformMocks('facebook').publishPost;
+const mockDebugAuth = getPlatformMocks('facebook').debugAuth;
 
 vi.mock('../platforms/factory', () => ({
-  createPlatform: () => ({
-    platform: 'facebook',
-    publishPost: mockPublishPost,
-    listRecentPosts: vi.fn().mockResolvedValue([]),
-    getComments: vi.fn().mockResolvedValue([]),
-    getCommentReplies: vi.fn().mockResolvedValue([]),
-    replyToComment: vi.fn(),
-    getPageIdentity: vi.fn().mockReturnValue('page_123'),
-    debugAuth: mockDebugAuth,
-  }),
-  getConfiguredPlatforms: () => ['facebook'],
-  CONFIGURED_PLATFORMS: ['facebook'],
+  createPlatform: (platform: string) => {
+    const m = getPlatformMocks(platform);
+    return {
+      platform,
+      publishPost: m.publishPost,
+      listRecentPosts: vi.fn().mockResolvedValue([]),
+      getComments: vi.fn().mockResolvedValue([]),
+      getCommentReplies: vi.fn().mockResolvedValue([]),
+      replyToComment: vi.fn(),
+      getPageIdentity: m.getPageIdentity,
+      debugAuth: m.debugAuth,
+    };
+  },
+  getConfiguredPlatforms: () => configuredPlatformsList,
+  get CONFIGURED_PLATFORMS() { return configuredPlatformsList; },
 }));
+
+function setConfiguredPlatforms(platforms: string[]) {
+  configuredPlatformsList = platforms;
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -57,9 +92,31 @@ function makePost(id: string, epochOffset = 0): SocialPost {
   };
 }
 
-function makeEnv(kv: ReturnType<typeof mockKV>) {
+function mockCronLock(initialHeldNames: string[] = []) {
+  const held = new Map<string, number>();
+  const now = Date.now();
+  for (const name of initialHeldNames) held.set(name, now + 300_000);
+  const tryAcquire = vi.fn(async (name: string, ttlMs: number) => {
+    const expires = held.get(name);
+    if (expires && expires > Date.now()) return { acquired: false };
+    held.set(name, Date.now() + ttlMs);
+    return { acquired: true };
+  });
+  const release = vi.fn(async (name: string) => { held.delete(name); });
+  const stub = { tryAcquire, release };
+  return {
+    held,
+    tryAcquire,
+    release,
+    get: vi.fn(() => stub),
+    idFromName: vi.fn((n: string) => n),
+  };
+}
+
+function makeEnv(kv: ReturnType<typeof mockKV>, cronLock: ReturnType<typeof mockCronLock> = mockCronLock()) {
   return {
     SOCIAL: kv as unknown as KVNamespace,
+    CRON_LOCK: cronLock as unknown as DurableObjectNamespace,
     FACEBOOK_PAGE_ID: 'page_123',
     FACEBOOK_PAGE_TOKEN: 'fake-page-token',
     FACEBOOK_APP_TOKEN: 'fake-app-token',
@@ -91,8 +148,11 @@ const healthyToken: AuthStatus = {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
-  mockPublishPost.mockReset();
-  mockDebugAuth.mockReset();
+  for (const mocks of platformRegistry.values()) {
+    mocks.publishPost.mockReset();
+    mocks.debugAuth.mockReset();
+  }
+  setConfiguredPlatforms(['facebook']);
 });
 
 describe('POST /api/cron/publish', () => {
@@ -109,15 +169,18 @@ describe('POST /api/cron/publish', () => {
 
   it('skips when cron lock exists', async () => {
     const kv = mockKV();
-    kv.store.set('cron-lock:publish', '1');
+    const cronLock = mockCronLock(['publish']);
 
-    const res = await app.fetch(cronRequest(), makeEnv(kv));
+    const res = await app.fetch(cronRequest(), makeEnv(kv, cronLock));
     expect(res.status).toBe(200);
     const body = await res.json() as Record<string, unknown>;
     expect(body.skipped).toBe(true);
     expect(body.reason).toBe('locked');
+    expect(cronLock.tryAcquire).toHaveBeenCalledWith('publish', 300_000);
     // Should not have called debugAuth (bailed out before fb usage)
     expect(mockDebugAuth).not.toHaveBeenCalled();
+    // Release must NOT be called when acquire failed (we never held it)
+    expect(cronLock.release).not.toHaveBeenCalled();
   });
 
   it('skips posts for a platform whose token is invalid (valid: false)', async () => {
@@ -136,8 +199,6 @@ describe('POST /api/cron/publish', () => {
     expect((body.tokenExpiresInDays as Record<string, number>).facebook).toBe(0);
     // Platform with invalid auth must not be invoked
     expect(mockPublishPost).not.toHaveBeenCalled();
-    // Lock must be released
-    expect(kv.delete).toHaveBeenCalledWith('cron-lock:publish');
   });
 
   it('skips posts for a platform whose token expires today (daysUntilExpiry <= 0)', async () => {
@@ -243,7 +304,8 @@ describe('POST /api/cron/publish', () => {
     kv.store.set(queueKey, JSON.stringify(post));
     kv.list.mockResolvedValueOnce({ keys: [{ name: queueKey }], list_complete: true });
 
-    const res = await app.fetch(cronRequest(), makeEnv(kv));
+    const cronLock = mockCronLock();
+    const res = await app.fetch(cronRequest(), makeEnv(kv, cronLock));
     expect(res.status).toBe(503);
     const body = await res.json() as Record<string, unknown>;
     expect(body.error).toContain('Token invalid');
@@ -258,7 +320,7 @@ describe('POST /api/cron/publish', () => {
     expect(kv.store.has(`post:publishing:${post.scheduledAtEpoch}:${post.id}`)).toBe(false);
 
     // Cron lock released in finally
-    expect(kv.delete).toHaveBeenCalledWith('cron-lock:publish');
+    expect(cronLock.release).toHaveBeenCalledWith('publish');
   });
 
   it('breaks loop on transient error, reverts post to queued, does not process remaining', async () => {
@@ -329,24 +391,154 @@ describe('POST /api/cron/publish', () => {
 
   it('releases cron lock in finally block even on unexpected error', async () => {
     const kv = mockKV();
+    const cronLock = mockCronLock();
     // debugAuth throws unexpectedly
     mockDebugAuth.mockRejectedValueOnce(new Error('Unexpected KV failure'));
 
     // We need list to not interfere, but debugAuth throws before list is called
     // so list mock doesn't matter
 
-    let errorThrown = false;
     try {
-      await app.fetch(cronRequest(), makeEnv(kv));
-    } catch {
-      errorThrown = true;
-    }
+      await app.fetch(cronRequest(), makeEnv(kv, cronLock));
+    } catch { /* swallow — finally is what we're testing */ }
 
-    // Whether the error propagates or is caught, the cron lock delete should be called
-    // (The Hono framework may catch and return 500, or propagate — either way finally runs)
-    expect(kv.delete).toHaveBeenCalledWith('cron-lock:publish');
-    // The lock itself should be cleared from the store
-    expect(kv.store.has('cron-lock:publish')).toBe(false);
+    // Lock must be released regardless of how the error surfaced
+    expect(cronLock.release).toHaveBeenCalledWith('publish');
+    expect(cronLock.held.has('publish')).toBe(false);
   });
 
+  it('skips posts only for the platform with expired auth, publishes the healthy platform', async () => {
+    const kv = mockKV();
+    setConfiguredPlatforms(['facebook', 'bluesky']);
+
+    const fbMocks = getPlatformMocks('facebook');
+    const bskyMocks = getPlatformMocks('bluesky');
+
+    fbMocks.debugAuth.mockResolvedValueOnce(healthyToken);
+    bskyMocks.debugAuth.mockResolvedValueOnce({
+      valid: false, platform: 'bluesky', expiresAt: 0, dataAccessExpiresAt: 0, daysUntilExpiry: 0,
+    });
+    fbMocks.publishPost.mockResolvedValueOnce({
+      success: true, platformPostId: 'fb_ok', isTransient: false, isAuthError: false,
+    });
+
+    const fbPost: SocialPost = { ...makePost('fb-1'), platform: 'facebook' };
+    const bskyPost: SocialPost = { ...makePost('bsky-1'), platform: 'bluesky' };
+    const fbKey = `post:queued:${fbPost.scheduledAtEpoch}:${fbPost.id}`;
+    const bskyKey = `post:queued:${bskyPost.scheduledAtEpoch}:${bskyPost.id}`;
+    kv.store.set(fbKey, JSON.stringify(fbPost));
+    kv.store.set(bskyKey, JSON.stringify(bskyPost));
+    kv.list.mockResolvedValueOnce({
+      keys: [{ name: fbKey }, { name: bskyKey }],
+      list_complete: true,
+    });
+
+    const res = await app.fetch(cronRequest(), makeEnv(kv));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.published).toBe(1);
+
+    // Healthy platform was invoked; expired platform was not
+    expect(fbMocks.publishPost).toHaveBeenCalledOnce();
+    expect(bskyMocks.publishPost).not.toHaveBeenCalled();
+
+    // Bluesky post remains queued for next run (not consumed)
+    expect(kv.store.has(bskyKey)).toBe(true);
+  });
+
+});
+
+describe('POST /api/publish forceRetry', () => {
+  function publishRequest(body: Record<string, unknown>) {
+    return new Request('http://localhost/api/publish', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Bearer test-publish-secret',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('returns alreadyFailed when failed idempotency record exists and forceRetry is absent', async () => {
+    const kv = mockKV();
+    kv.store.set('idempotent:key-1', JSON.stringify({
+      key: 'key-1', status: 'failed', platformPostId: null,
+      completedAt: new Date().toISOString(), error: 'Original failure',
+    }));
+
+    const res = await app.fetch(
+      publishRequest({ type: 'text', message: 'hi', idempotencyKey: 'key-1' }),
+      makeEnv(kv),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.alreadyFailed).toBe(true);
+    expect(body.error).toBe('Original failure');
+    expect(mockPublishPost).not.toHaveBeenCalled();
+  });
+
+  it('bypasses failed idempotency record when forceRetry: true', async () => {
+    const kv = mockKV();
+    kv.store.set('idempotent:key-2', JSON.stringify({
+      key: 'key-2', status: 'failed', platformPostId: null,
+      completedAt: new Date().toISOString(), error: 'Original failure',
+    }));
+    mockPublishPost.mockResolvedValueOnce({
+      success: true, platformPostId: 'fb_retry_ok', isTransient: false, isAuthError: false,
+    });
+
+    const res = await app.fetch(
+      publishRequest({ type: 'text', message: 'hi', idempotencyKey: 'key-2', forceRetry: true }),
+      makeEnv(kv),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.published).toBe(true);
+    expect(body.platformPostId).toBe('fb_retry_ok');
+    expect(mockPublishPost).toHaveBeenCalledOnce();
+
+    // Idempotency record replaced with new published entry
+    const newRecord = JSON.parse(kv.store.get('idempotent:key-2')!);
+    expect(newRecord.status).toBe('published');
+    expect(newRecord.platformPostId).toBe('fb_retry_ok');
+  });
+
+  it('publishes via the platform named in the request body, not the default', async () => {
+    const kv = mockKV();
+    setConfiguredPlatforms(['facebook', 'bluesky']);
+    const blueskyMocks = getPlatformMocks('bluesky');
+    blueskyMocks.publishPost.mockResolvedValueOnce({
+      success: true, platformPostId: 'bsky_post_1', isTransient: false, isAuthError: false,
+    });
+
+    const res = await app.fetch(
+      publishRequest({ platform: 'bluesky', type: 'text', message: 'hi', idempotencyKey: 'multi-1' }),
+      makeEnv(kv),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.platformPostId).toBe('bsky_post_1');
+    // Bluesky was called, facebook was not
+    expect(blueskyMocks.publishPost).toHaveBeenCalledOnce();
+    expect(mockPublishPost).not.toHaveBeenCalled();
+  });
+
+  it('forceRetry does NOT bypass a published idempotency record', async () => {
+    const kv = mockKV();
+    kv.store.set('idempotent:key-3', JSON.stringify({
+      key: 'key-3', status: 'published', platformPostId: 'fb_already',
+      completedAt: new Date().toISOString(), error: null,
+    }));
+
+    const res = await app.fetch(
+      publishRequest({ type: 'text', message: 'hi', idempotencyKey: 'key-3', forceRetry: true }),
+      makeEnv(kv),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.alreadyPublished).toBe(true);
+    expect(body.platformPostId).toBe('fb_already');
+    expect(mockPublishPost).not.toHaveBeenCalled();
+  });
 });

--- a/worker/src/cron-lock.ts
+++ b/worker/src/cron-lock.ts
@@ -26,8 +26,8 @@ export class CronLock {
     return this.state.blockConcurrencyWhile(async () => {
       const key = `lock:${name}`;
       const now = Date.now();
-      const existing = await this.state.storage.get<LockState>(key);
-      if (existing && existing.expiresAt > now) {
+      const existing = await this.state.storage.get<unknown>(key);
+      if (isLockState(existing) && existing.expiresAt > now) {
         return { acquired: false, token: null };
       }
       const token = crypto.randomUUID();
@@ -39,12 +39,21 @@ export class CronLock {
   async release(name: string, token: string): Promise<void> {
     return this.state.blockConcurrencyWhile(async () => {
       const key = `lock:${name}`;
-      const existing = await this.state.storage.get<LockState>(key);
-      if (existing && existing.token === token) {
+      const existing = await this.state.storage.get<unknown>(key);
+      if (isLockState(existing) && existing.token === token) {
         await this.state.storage.delete(key);
       }
-      // Mismatched token = our run exceeded its TTL and someone else now holds
-      // the lock. Silently no-op so we don't release the new owner's lock.
+      // Mismatched / malformed entry = our run exceeded its TTL and someone
+      // else (or no one) now holds the lock. Silently no-op so we don't
+      // release the new owner's lock or corrupt their state.
     });
   }
+}
+
+function isLockState(v: unknown): v is LockState {
+  return (
+    typeof v === 'object' && v !== null &&
+    typeof (v as LockState).expiresAt === 'number' &&
+    typeof (v as LockState).token === 'string'
+  );
 }

--- a/worker/src/cron-lock.ts
+++ b/worker/src/cron-lock.ts
@@ -1,10 +1,20 @@
 /**
  * Atomic named locks via a single-instance Durable Object.
  *
- * KV-based locks have a TOCTOU window between get and put: two concurrent
- * invocations can both observe an empty value and both write '1'. DO methods
- * are serialized per-instance, so acquire/release runs without interleaving.
+ * KV-based locks have a TOCTOU window between get and put. DO instances are
+ * single-threaded, but `await` between get and put still yields the input
+ * gate — two concurrent fetches can interleave there. `blockConcurrencyWhile`
+ * holds the gate closed for the entire read-check-write sequence.
+ *
+ * Each successful acquire returns a fencing token. `release()` is a no-op
+ * unless the caller's token matches the stored token, so a slow run that
+ * exceeds its TTL cannot release the lock that the next acquirer holds.
  */
+interface LockState {
+  expiresAt: number;
+  token: string;
+}
+
 export class CronLock {
   private state: DurableObjectState;
 
@@ -12,18 +22,29 @@ export class CronLock {
     this.state = state;
   }
 
-  async tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean }> {
-    const key = `lock:${name}`;
-    const now = Date.now();
-    const existing = await this.state.storage.get<number>(key);
-    if (existing && existing > now) {
-      return { acquired: false };
-    }
-    await this.state.storage.put(key, now + ttlMs);
-    return { acquired: true };
+  async tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean; token: string | null }> {
+    return this.state.blockConcurrencyWhile(async () => {
+      const key = `lock:${name}`;
+      const now = Date.now();
+      const existing = await this.state.storage.get<LockState>(key);
+      if (existing && existing.expiresAt > now) {
+        return { acquired: false, token: null };
+      }
+      const token = crypto.randomUUID();
+      await this.state.storage.put(key, { expiresAt: now + ttlMs, token });
+      return { acquired: true, token };
+    });
   }
 
-  async release(name: string): Promise<void> {
-    await this.state.storage.delete(`lock:${name}`);
+  async release(name: string, token: string): Promise<void> {
+    return this.state.blockConcurrencyWhile(async () => {
+      const key = `lock:${name}`;
+      const existing = await this.state.storage.get<LockState>(key);
+      if (existing && existing.token === token) {
+        await this.state.storage.delete(key);
+      }
+      // Mismatched token = our run exceeded its TTL and someone else now holds
+      // the lock. Silently no-op so we don't release the new owner's lock.
+    });
   }
 }

--- a/worker/src/cron-lock.ts
+++ b/worker/src/cron-lock.ts
@@ -1,0 +1,29 @@
+/**
+ * Atomic named locks via a single-instance Durable Object.
+ *
+ * KV-based locks have a TOCTOU window between get and put: two concurrent
+ * invocations can both observe an empty value and both write '1'. DO methods
+ * are serialized per-instance, so acquire/release runs without interleaving.
+ */
+export class CronLock {
+  private state: DurableObjectState;
+
+  constructor(state: DurableObjectState, _env: unknown) {
+    this.state = state;
+  }
+
+  async tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean }> {
+    const key = `lock:${name}`;
+    const now = Date.now();
+    const existing = await this.state.storage.get<number>(key);
+    if (existing && existing > now) {
+      return { acquired: false };
+    }
+    await this.state.storage.put(key, now + ttlMs);
+    return { acquired: true };
+  }
+
+  async release(name: string): Promise<void> {
+    await this.state.storage.delete(`lock:${name}`);
+  }
+}

--- a/worker/src/cron-lock.ts
+++ b/worker/src/cron-lock.ts
@@ -1,3 +1,5 @@
+import { DurableObject } from 'cloudflare:workers';
+
 /**
  * Atomic named locks via a single-instance Durable Object.
  *
@@ -9,39 +11,36 @@
  * Each successful acquire returns a fencing token. `release()` is a no-op
  * unless the caller's token matches the stored token, so a slow run that
  * exceeds its TTL cannot release the lock that the next acquirer holds.
+ *
+ * Must extend DurableObject from `cloudflare:workers` so its methods are
+ * callable via RPC on the stub returned by `env.CRON_LOCK.get(...)`.
  */
 interface LockState {
   expiresAt: number;
   token: string;
 }
 
-export class CronLock {
-  private state: DurableObjectState;
-
-  constructor(state: DurableObjectState, _env: unknown) {
-    this.state = state;
-  }
-
+export class CronLock extends DurableObject {
   async tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean; token: string | null }> {
-    return this.state.blockConcurrencyWhile(async () => {
+    return this.ctx.blockConcurrencyWhile(async () => {
       const key = `lock:${name}`;
       const now = Date.now();
-      const existing = await this.state.storage.get<unknown>(key);
+      const existing = await this.ctx.storage.get<unknown>(key);
       if (isLockState(existing) && existing.expiresAt > now) {
         return { acquired: false, token: null };
       }
       const token = crypto.randomUUID();
-      await this.state.storage.put(key, { expiresAt: now + ttlMs, token });
+      await this.ctx.storage.put(key, { expiresAt: now + ttlMs, token });
       return { acquired: true, token };
     });
   }
 
   async release(name: string, token: string): Promise<void> {
-    return this.state.blockConcurrencyWhile(async () => {
+    return this.ctx.blockConcurrencyWhile(async () => {
       const key = `lock:${name}`;
-      const existing = await this.state.storage.get<unknown>(key);
+      const existing = await this.ctx.storage.get<unknown>(key);
       if (isLockState(existing) && existing.token === token) {
-        await this.state.storage.delete(key);
+        await this.ctx.storage.delete(key);
       }
       // Mismatched / malformed entry = our run exceeded its TTL and someone
       // else (or no one) now holds the lock. Silently no-op so we don't

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -2,6 +2,9 @@ export interface Env {
   // KV
   SOCIAL: KVNamespace;
 
+  // Durable Objects
+  CRON_LOCK: DurableObjectNamespace;
+
   // Vars
   FACEBOOK_PAGE_ID: string;
   GRAPH_API_VERSION: string;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -57,6 +57,20 @@ app.post('/api/publish', async (c) => {
   const platform = validatePlatform(body.platform);
   if (!platform) return json({ error: `Unsupported platform: ${body.platform}` }, 400);
 
+  // Serialise the read-decide-publish sequence per idempotency key via the
+  // CronLock DO. Without this, two concurrent forceRetry calls for the same
+  // key can both observe the failed record, both delete it, and both publish.
+  const publishLockName = `publish:${body.idempotencyKey}`;
+  const publishLockStub = env.CRON_LOCK.get(env.CRON_LOCK.idFromName(publishLockName)) as DurableObjectStub & {
+    tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean; token: string | null }>;
+    release(name: string, token: string): Promise<void>;
+  };
+  const { acquired: publishAcquired, token: publishToken } = await publishLockStub.tryAcquire(publishLockName, 60_000);
+  if (!publishAcquired || !publishToken) {
+    return json({ error: 'A publish is already in progress for this idempotencyKey' }, 409);
+  }
+
+  try {
   // Check durable idempotency record. `published` records always block a retry
   // (prevents double-posting); `failed` records can be bypassed with forceRetry.
   const existingRaw = await env.SOCIAL.get(`idempotent:${body.idempotencyKey}`);
@@ -113,6 +127,9 @@ app.post('/api/publish', async (c) => {
 
   const status = result.isAuthError ? 503 : result.isTransient ? 502 : 422;
   return json({ published: false, error: result.error, isTransient: result.isTransient }, status);
+  } finally {
+    await publishLockStub.release(publishLockName, publishToken);
+  }
 });
 
 // ── POST /api/queue ───────────────────────────────────────────────────────────
@@ -302,11 +319,11 @@ app.post('/api/cron/publish', async (c) => {
 
   // Cron lock — atomic via Durable Object (prevents KV TOCTOU race)
   const lockStub = env.CRON_LOCK.get(env.CRON_LOCK.idFromName('publish')) as DurableObjectStub & {
-    tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean }>;
-    release(name: string): Promise<void>;
+    tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean; token: string | null }>;
+    release(name: string, token: string): Promise<void>;
   };
-  const { acquired } = await lockStub.tryAcquire('publish', 300_000);
-  if (!acquired) return json({ skipped: true, reason: 'locked' });
+  const { acquired, token: lockToken } = await lockStub.tryAcquire('publish', 300_000);
+  if (!acquired || !lockToken) return json({ skipped: true, reason: 'locked' });
 
   try {
     // Token health — check all configured platforms; skip unhealthy ones rather than halting all
@@ -422,7 +439,7 @@ app.post('/api/cron/publish', async (c) => {
 
     return json({ published, failed, remaining, tokenExpiresInDays: tokenExpiryByPlatform });
   } finally {
-    await lockStub.release('publish');
+    await lockStub.release('publish', lockToken);
   }
 });
 
@@ -434,11 +451,11 @@ app.post('/api/cron/comments', async (c) => {
   if (!authOk) return unauthorized();
 
   const commentsLockStub = env.CRON_LOCK.get(env.CRON_LOCK.idFromName('comments')) as DurableObjectStub & {
-    tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean }>;
-    release(name: string): Promise<void>;
+    tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean; token: string | null }>;
+    release(name: string, token: string): Promise<void>;
   };
-  const { acquired: commentsAcquired } = await commentsLockStub.tryAcquire('comments', 300_000);
-  if (!commentsAcquired) return json({ skipped: true, reason: 'locked' });
+  const { acquired: commentsAcquired, token: commentsToken } = await commentsLockStub.tryAcquire('comments', 300_000);
+  if (!commentsAcquired || !commentsToken) return json({ skipped: true, reason: 'locked' });
 
   try {
     // Process comments for each configured platform
@@ -462,7 +479,7 @@ app.post('/api/cron/comments', async (c) => {
     const fbResult = platformResults.facebook as Record<string, unknown> | undefined;
     return json({ ...fbResult, platforms: platformResults });
   } finally {
-    await commentsLockStub.release('comments');
+    await commentsLockStub.release('comments', commentsToken);
   }
 });
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -60,6 +60,10 @@ app.post('/api/publish', async (c) => {
   // Serialise the read-decide-publish sequence per idempotency key via the
   // CronLock DO. Without this, two concurrent forceRetry calls for the same
   // key can both observe the failed record, both delete it, and both publish.
+  //
+  // TTL: 60s. Cloudflare Workers cap subrequests at 30s and the whole request
+  // at the per-plan CPU/wall budget — a hung publishPost will be killed long
+  // before the lock expires. No renewal needed.
   const publishLockName = `publish:${body.idempotencyKey}`;
   const publishLockStub = env.CRON_LOCK.get(env.CRON_LOCK.idFromName(publishLockName)) as DurableObjectStub & {
     tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean; token: string | null }>;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4,6 +4,9 @@ import { verifyBearer } from './auth';
 import { createPlatform, getConfiguredPlatforms } from './platforms/factory';
 import type { SocialPost, IdempotencyRecord, Platform } from './platforms/types';
 import { processComments } from './cron/comments';
+import { CronLock } from './cron-lock';
+
+export { CronLock };
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -48,19 +51,26 @@ app.post('/api/publish', async (c) => {
     youtubeUrl?: string;
     backdatedTime?: string;
     idempotencyKey: string;
+    forceRetry?: boolean;
   }>();
 
   const platform = validatePlatform(body.platform);
   if (!platform) return json({ error: `Unsupported platform: ${body.platform}` }, 400);
 
-  // Check durable idempotency record
+  // Check durable idempotency record. `published` records always block a retry
+  // (prevents double-posting); `failed` records can be bypassed with forceRetry.
   const existingRaw = await env.SOCIAL.get(`idempotent:${body.idempotencyKey}`);
   if (existingRaw) {
     const existing: IdempotencyRecord = JSON.parse(existingRaw);
     if (existing.status === 'published') {
       return json({ alreadyPublished: true, platformPostId: existing.platformPostId });
     }
-    return json({ alreadyFailed: true, error: existing.error });
+    if (!body.forceRetry) {
+      return json({ alreadyFailed: true, error: existing.error });
+    }
+    // forceRetry: clear the failed record so the publish below can proceed and
+    // write a fresh idempotency entry on completion.
+    await env.SOCIAL.delete(`idempotent:${body.idempotencyKey}`);
   }
 
   const adapter = createPlatform(platform, env);
@@ -290,10 +300,13 @@ app.post('/api/cron/publish', async (c) => {
   const authOk = await verifyBearer(c.req.header('Authorization') ?? null, env.CRON_SECRET);
   if (!authOk) return unauthorized();
 
-  // Cron lock
-  const cronLock = await env.SOCIAL.get('cron-lock:publish');
-  if (cronLock) return json({ skipped: true, reason: 'locked' });
-  await env.SOCIAL.put('cron-lock:publish', '1', { expirationTtl: 300 });
+  // Cron lock — atomic via Durable Object (prevents KV TOCTOU race)
+  const lockStub = env.CRON_LOCK.get(env.CRON_LOCK.idFromName('publish')) as DurableObjectStub & {
+    tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean }>;
+    release(name: string): Promise<void>;
+  };
+  const { acquired } = await lockStub.tryAcquire('publish', 300_000);
+  if (!acquired) return json({ skipped: true, reason: 'locked' });
 
   try {
     // Token health — check all configured platforms; skip unhealthy ones rather than halting all
@@ -409,7 +422,7 @@ app.post('/api/cron/publish', async (c) => {
 
     return json({ published, failed, remaining, tokenExpiresInDays: tokenExpiryByPlatform });
   } finally {
-    await env.SOCIAL.delete('cron-lock:publish');
+    await lockStub.release('publish');
   }
 });
 
@@ -420,9 +433,12 @@ app.post('/api/cron/comments', async (c) => {
   const authOk = await verifyBearer(c.req.header('Authorization') ?? null, env.CRON_SECRET);
   if (!authOk) return unauthorized();
 
-  const cronLock = await env.SOCIAL.get('cron-lock:comments');
-  if (cronLock) return json({ skipped: true, reason: 'locked' });
-  await env.SOCIAL.put('cron-lock:comments', '1', { expirationTtl: 300 });
+  const commentsLockStub = env.CRON_LOCK.get(env.CRON_LOCK.idFromName('comments')) as DurableObjectStub & {
+    tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean }>;
+    release(name: string): Promise<void>;
+  };
+  const { acquired: commentsAcquired } = await commentsLockStub.tryAcquire('comments', 300_000);
+  if (!commentsAcquired) return json({ skipped: true, reason: 'locked' });
 
   try {
     // Process comments for each configured platform
@@ -446,7 +462,7 @@ app.post('/api/cron/comments', async (c) => {
     const fbResult = platformResults.facebook as Record<string, unknown> | undefined;
     return json({ ...fbResult, platforms: platformResults });
   } finally {
-    await env.SOCIAL.delete('cron-lock:comments');
+    await commentsLockStub.release('comments');
   }
 });
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -75,62 +75,63 @@ app.post('/api/publish', async (c) => {
   }
 
   try {
-  // Check durable idempotency record. `published` records always block a retry
-  // (prevents double-posting); `failed` records can be bypassed with forceRetry.
-  const existingRaw = await env.SOCIAL.get(`idempotent:${body.idempotencyKey}`);
-  if (existingRaw) {
-    const existing: IdempotencyRecord = JSON.parse(existingRaw);
-    if (existing.status === 'published') {
-      return json({ alreadyPublished: true, platformPostId: existing.platformPostId });
+    // Check durable idempotency record. `published` records always block a
+    // retry (prevents double-posting); `failed` records can be bypassed with
+    // forceRetry.
+    const existingRaw = await env.SOCIAL.get(`idempotent:${body.idempotencyKey}`);
+    if (existingRaw) {
+      const existing: IdempotencyRecord = JSON.parse(existingRaw);
+      if (existing.status === 'published') {
+        return json({ alreadyPublished: true, platformPostId: existing.platformPostId });
+      }
+      if (!body.forceRetry) {
+        return json({ alreadyFailed: true, error: existing.error });
+      }
+      // forceRetry: clear the failed record so the publish below can proceed
+      // and write a fresh idempotency entry on completion.
+      await env.SOCIAL.delete(`idempotent:${body.idempotencyKey}`);
     }
-    if (!body.forceRetry) {
-      return json({ alreadyFailed: true, error: existing.error });
+
+    const adapter = createPlatform(platform, env);
+
+    const post: SocialPost = {
+      id: body.idempotencyKey,
+      platform,
+      type: body.type as SocialPost['type'],
+      message: body.message,
+      link: body.link,
+      imageUrl: body.imageUrl,
+      videoUrl: body.videoUrl,
+      youtubeUrl: body.youtubeUrl,
+      backdatedTime: body.backdatedTime,
+      scheduledAt: new Date().toISOString(),
+      scheduledAtEpoch: Date.now(),
+      status: 'queued',
+      publishedId: null,
+      publishedAt: null,
+      error: null,
+    };
+
+    const result = await adapter.publishPost(post);
+
+    // Write durable idempotency record (30-day TTL)
+    const record: IdempotencyRecord = {
+      key: body.idempotencyKey,
+      status: result.success ? 'published' : 'failed',
+      platformPostId: result.platformPostId ?? null,
+      completedAt: new Date().toISOString(),
+      error: result.error ?? null,
+    };
+    await env.SOCIAL.put(`idempotent:${body.idempotencyKey}`, JSON.stringify(record), {
+      expirationTtl: 30 * 24 * 60 * 60,
+    });
+
+    if (result.success) {
+      return json({ published: true, platformPostId: result.platformPostId });
     }
-    // forceRetry: clear the failed record so the publish below can proceed and
-    // write a fresh idempotency entry on completion.
-    await env.SOCIAL.delete(`idempotent:${body.idempotencyKey}`);
-  }
 
-  const adapter = createPlatform(platform, env);
-
-  const post: SocialPost = {
-    id: body.idempotencyKey,
-    platform,
-    type: body.type as SocialPost['type'],
-    message: body.message,
-    link: body.link,
-    imageUrl: body.imageUrl,
-    videoUrl: body.videoUrl,
-    youtubeUrl: body.youtubeUrl,
-    backdatedTime: body.backdatedTime,
-    scheduledAt: new Date().toISOString(),
-    scheduledAtEpoch: Date.now(),
-    status: 'queued',
-    publishedId: null,
-    publishedAt: null,
-    error: null,
-  };
-
-  const result = await adapter.publishPost(post);
-
-  // Write durable idempotency record (30-day TTL)
-  const record: IdempotencyRecord = {
-    key: body.idempotencyKey,
-    status: result.success ? 'published' : 'failed',
-    platformPostId: result.platformPostId ?? null,
-    completedAt: new Date().toISOString(),
-    error: result.error ?? null,
-  };
-  await env.SOCIAL.put(`idempotent:${body.idempotencyKey}`, JSON.stringify(record), {
-    expirationTtl: 30 * 24 * 60 * 60,
-  });
-
-  if (result.success) {
-    return json({ published: true, platformPostId: result.platformPostId });
-  }
-
-  const status = result.isAuthError ? 503 : result.isTransient ? 502 : 422;
-  return json({ published: false, error: result.error, isTransient: result.isTransient }, status);
+    const status = result.isAuthError ? 503 : result.isTransient ? 502 : 422;
+    return json({ published: false, error: result.error, isTransient: result.isTransient }, status);
   } finally {
     await publishLockStub.release(publishLockName, publishToken);
   }

--- a/worker/test-shims/cloudflare-workers.ts
+++ b/worker/test-shims/cloudflare-workers.ts
@@ -1,0 +1,16 @@
+/**
+ * Test-only shim for the `cloudflare:workers` module. Vitest runs outside
+ * the Workers runtime, so the real module isn't resolvable.
+ *
+ * `DurableObject` is exposed as a plain base class with the same `ctx`/`env`
+ * fields the production runtime would inject. Production builds use Wrangler,
+ * which resolves the real import.
+ */
+export class DurableObject<Env = unknown> {
+  ctx: DurableObjectState;
+  env: Env;
+  constructor(ctx: DurableObjectState, env: Env) {
+    this.ctx = ctx;
+    this.env = env;
+  }
+}

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+// The `cloudflare:workers` module is provided by the Workers runtime in
+// production builds (Wrangler resolves it). Vitest runs in plain Node, so
+// alias it to a tiny shim that mirrors the API our code uses.
+export default defineConfig({
+  resolve: {
+    alias: {
+      'cloudflare:workers': fileURLToPath(
+        new URL('./test-shims/cloudflare-workers.ts', import.meta.url),
+      ),
+    },
+  },
+});

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -7,6 +7,14 @@ compatibility_flags = ["nodejs_compat"]
 binding = "SOCIAL"
 id = "b85557255f9c475abd4af15d4a9dd458"
 
+[[durable_objects.bindings]]
+name = "CRON_LOCK"
+class_name = "CronLock"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["CronLock"]
+
 [vars]
 FACEBOOK_PAGE_ID = "35753603727"
 GRAPH_API_VERSION = "v21.0"


### PR DESCRIPTION
## Summary

Bundle of five hardening fixes — three to the social worker, one to the CSP worker, one to the OG meta pipeline. JPEG parser also tightened after Gemini QA caught two spec-compliant edge cases.

### Worker (Cloudflare)
- **Cron lock → Durable Object.** The old \`KV.get(lock) -> KV.put(lock)\` pattern has a TOCTOU window where two concurrent cron invocations can both observe an empty value and both proceed. New \`CronLock\` DO serialises \`tryAcquire\`/\`release\` per-instance. Both \`/api/cron/publish\` and \`/api/cron/comments\` migrated. Wrangler binding + \`new_sqlite_classes\` migration added.
- **Force-retry idempotency.** New \`forceRetry: boolean\` flag on \`POST /api/publish\`. Bypasses a \`failed\` idempotency record (deletes it before re-running the publish), but **never** bypasses a \`published\` record — that guarantee is the whole point of the key.
- **Per-platform test registry.** The old factory mock returned a single shared mock regardless of which platform was requested, so multi-platform behaviour couldn't actually be tested. New registry pattern hands each platform its own \`publishPost\`/\`debugAuth\`. Two new tests prove the wiring: one publishes via bluesky without touching facebook; one shows cron processes the healthy platform and skips the expired one in the same run.

### worker-csp
- Pin transitive \`wrangler\` to \`^4.90.0\` via \`overrides\`. Resolves Dependabot #57 / GHSA-36p8-mvp6-cv38 / CVE-2026-0933 (\`wrangler pages deploy --commit-hash\` command injection). Transitive bumped 4.35.0 → 4.92.0; tests still pass.

### Site
- **OG image dimensions read from the file, not the filename.** The previous \`heroImage.includes('infographic') ? 1536x2752 : 1200x630\` heuristic guesses wrong any time a hero is portrait without \`infographic\` in the path, or landscape with \`infographic\` in the path. New \`src/lib/image-dimensions.ts\` parses PNG/JPEG/WebP/GIF headers (first 256 KB of the file) and caches results. Falls back to 1200x630 if the file is missing or unrecognised.
- **JPEG parser hardened (post Gemini QA).** Two spec-compliant JPEG constructs broke the original parser: (a) \`0xFF\` fill bytes valid per ITU-T T.81 §B.1.1.2 caused garbled segment-length reads; (b) standalone markers (RST0-7, TEM, SOI, EOI) have no length field and the parser tried to read one, desyncing. Fixed by skipping fill bytes and explicitly bypassing standalone markers.

## Test plan
- [x] \`cd worker && npm test\` — 101 tests pass (was 96 before; added 5 new tests for forceRetry + multi-platform)
- [x] \`cd worker-csp && npm test\` — 18 tests pass
- [x] \`npm run build\` — site builds cleanly
- [x] Spot-checked built HTML: \`og:image:width\`/\`og:image:height\` correctly reports 1536×2752 for infographic OG cards
- [x] \`npm ls wrangler\` in worker-csp confirms transitive bumped to 4.92.0
- [x] Codex QA: no blocking issues (KV eventual-consistency caveat acknowledged as pre-existing; DO lock mitigates main race)
- [x] Gemini QA: JPEG fill-byte + standalone-marker bugs caught and fixed
- [ ] CI green