### PR TITLE
fix(worker): close 5 critical hardening gaps from multi-engine QA

### DIFF
--- a/worker/src/__tests__/publish.test.ts
+++ b/worker/src/__tests__/publish.test.ts
@@ -438,6 +438,99 @@ describe('POST /api/cron/publish', () => {
     expect(cronLock.held.has('publish')).toBe(false);
   });
 
+  // C1 — Per-post publish lock in the cron. /api/publish takes
+  // `publish:<idempotencyKey>`, and the cron must take the same lock per post
+  // so an ad-hoc retry mid-cron-run cannot race the cron and double-publish.
+  it('skips a post whose per-post publish lock is held by /api/publish', async () => {
+    const kv = mockKV();
+    mockDebugAuth.mockResolvedValueOnce(healthyToken);
+
+    const post = makePost('contested-post');
+    const queueKey = `post:queued:${post.scheduledAtEpoch}:${post.id}`;
+    kv.store.set(queueKey, JSON.stringify(post));
+    kv.list.mockResolvedValueOnce({ keys: [{ name: queueKey }], list_complete: true });
+
+    // Pre-hold the per-post lock AND the cron lock — both share the same DO mock.
+    const cronLock = mockCronLock([`publish:${post.id}`]);
+
+    const res = await app.fetch(cronRequest(), makeEnv(kv, cronLock));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    // Cron didn't publish (the other holder is publishing it)
+    expect(body.published).toBe(0);
+    expect(mockPublishPost).not.toHaveBeenCalled();
+    // Crucially, the queue key was NOT consumed — the other publisher will write
+    // the terminal state and the next cron tick will clean up the stale queued key.
+    expect(kv.store.has(queueKey)).toBe(true);
+  });
+
+  // C2 — Orphan recovery. Without the try/catch around the per-post body, an
+  // unhandled exception (network blip, JSON parse failure, etc.) after the
+  // queued key is deleted but before the terminal state is written would
+  // silently drop the post: queued key gone, publishing key with no recovery
+  // sweep, post invisible to future cron runs.
+  it('restores queued key when publishPost throws unexpectedly', async () => {
+    const kv = mockKV();
+    mockDebugAuth.mockResolvedValueOnce(healthyToken);
+    mockPublishPost.mockRejectedValueOnce(new Error('JSON.parse failed on truncated response'));
+
+    const post = makePost('crash-post');
+    const queueKey = `post:queued:${post.scheduledAtEpoch}:${post.id}`;
+    kv.store.set(queueKey, JSON.stringify(post));
+    kv.list.mockResolvedValueOnce({ keys: [{ name: queueKey }], list_complete: true });
+
+    const res = await app.fetch(cronRequest(), makeEnv(kv));
+    expect(res.status).toBe(200);
+
+    // The queued key must be restored so the next cron tick can retry the post.
+    const restoredRaw = kv.store.get(queueKey);
+    expect(restoredRaw).toBeTruthy();
+    const restored = JSON.parse(restoredRaw!) as SocialPost;
+    expect(restored.status).toBe('queued');
+    expect(restored.id).toBe(post.id);
+
+    // The transient publishing key must be cleaned up so a later sweep doesn't
+    // see it as a duplicate.
+    expect(kv.store.has(`post:publishing:${post.scheduledAtEpoch}:${post.id}`)).toBe(false);
+  });
+
+  it('releases the per-post lock after a successful cron publish', async () => {
+    const kv = mockKV();
+    const cronLock = mockCronLock();
+    mockDebugAuth.mockResolvedValueOnce(healthyToken);
+    mockPublishPost.mockResolvedValueOnce({
+      success: true, platformPostId: 'fb_ok', isTransient: false, isAuthError: false,
+    });
+
+    const post = makePost('lock-release-test');
+    const queueKey = `post:queued:${post.scheduledAtEpoch}:${post.id}`;
+    kv.store.set(queueKey, JSON.stringify(post));
+    kv.list.mockResolvedValueOnce({ keys: [{ name: queueKey }], list_complete: true });
+
+    const res = await app.fetch(cronRequest(), makeEnv(kv, cronLock));
+    expect(res.status).toBe(200);
+    // Both the cron-wide lock AND the per-post lock must be released.
+    expect(cronLock.release).toHaveBeenCalledWith('publish', expect.any(String));
+    expect(cronLock.release).toHaveBeenCalledWith(`publish:${post.id}`, expect.any(String));
+    expect(cronLock.held.has(`publish:${post.id}`)).toBe(false);
+  });
+
+  it('releases the per-post lock even when publishPost throws (orphan recovery)', async () => {
+    const kv = mockKV();
+    const cronLock = mockCronLock();
+    mockDebugAuth.mockResolvedValueOnce(healthyToken);
+    mockPublishPost.mockRejectedValueOnce(new Error('boom'));
+
+    const post = makePost('lock-finally-test');
+    const queueKey = `post:queued:${post.scheduledAtEpoch}:${post.id}`;
+    kv.store.set(queueKey, JSON.stringify(post));
+    kv.list.mockResolvedValueOnce({ keys: [{ name: queueKey }], list_complete: true });
+
+    await app.fetch(cronRequest(), makeEnv(kv, cronLock));
+    expect(cronLock.release).toHaveBeenCalledWith(`publish:${post.id}`, expect.any(String));
+    expect(cronLock.held.has(`publish:${post.id}`)).toBe(false);
+  });
+
   it('skips posts only for the platform with expired auth, publishes the healthy platform', async () => {
     const kv = mockKV();
     setConfiguredPlatforms(['facebook', 'bluesky']);

--- a/worker/src/__tests__/safe-fetch.test.ts
+++ b/worker/src/__tests__/safe-fetch.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { isAllowedMediaUrl, isSafeHttpsUrl } from '../platforms/safe-fetch';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { isAllowedMediaUrl, isSafeHttpsUrl, safeFetch } from '../platforms/safe-fetch';
 
 describe('isAllowedMediaUrl', () => {
   it.each([
@@ -36,5 +36,114 @@ describe('isSafeHttpsUrl', () => {
     expect(isSafeHttpsUrl('https://169.254.169.254')).toBe(false);
     expect(isSafeHttpsUrl('http://pds.example.com')).toBe(false);
     expect(isSafeHttpsUrl('ftp://pds.example.com')).toBe(false);
+  });
+
+  // Hex-encoded and decimal-encoded IPv4 literals are a known SSRF bypass:
+  // `https://0x7f000001` and `https://2130706433` both resolve to 127.0.0.1
+  // in the WHATWG URL parser, but a naive dotted-quad regex would miss them.
+  it.each([
+    'https://0x7f000001/x',     // hex-encoded 127.0.0.1
+    'https://2130706433/x',     // decimal-encoded 127.0.0.1
+    'https://0x7f.0.0.1/x',     // mixed hex/dotted
+    'https://[::1]/x',           // bracketed IPv6 literal
+    'https://[fe80::1]/x',       // bracketed IPv6 link-local
+  ])('rejects encoded IP literal %s', (url) => {
+    expect(isSafeHttpsUrl(url)).toBe(false);
+  });
+});
+
+describe('safeFetch (SSRF defense for outbound fetches)', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('rejects the initial URL if the validator fails', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('should not be called'));
+    const result = await safeFetch('https://attacker.example/x', {}, isAllowedMediaUrl);
+    expect(result.response).toBeNull();
+    expect(result.blockedReason).toContain('attacker.example');
+    // Most importantly, no actual network call was made.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('follows a redirect to an allowlisted host', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, {
+        status: 302,
+        headers: { Location: 'https://cdn.adrianwedd.com/redirected.jpg' },
+      }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    const result = await safeFetch('https://adrianwedd.com/og/x.jpg', {}, isAllowedMediaUrl);
+
+    expect(result.response?.status).toBe(200);
+    expect(result.finalUrl).toBe('https://cdn.adrianwedd.com/redirected.jpg');
+    // Both calls must use `redirect: 'manual'` — the whole point is that we
+    // walk redirects ourselves rather than letting fetch follow blindly.
+    for (const call of fetchSpy.mock.calls) {
+      expect((call[1] as RequestInit | undefined)?.redirect).toBe('manual');
+    }
+  });
+
+  it('refuses a redirect that targets a non-allowlisted host (SSRF pivot)', async () => {
+    // Simulates the canonical SSRF redirect pivot: an allowlisted source URL
+    // returns 302 Location: <private/metadata IP>. Without redirect:manual the
+    // default fetch would happily follow this and turn the allowlist into a
+    // false sense of security.
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(null, {
+      status: 302,
+      headers: { Location: 'https://169.254.169.254/latest/meta-data/' },
+    }));
+
+    const result = await safeFetch('https://cdn.adrianwedd.com/x.jpg', {}, isAllowedMediaUrl);
+
+    expect(result.response).toBeNull();
+    expect(result.blockedReason).toContain('169.254.169.254');
+  });
+
+  it('refuses a redirect that targets a non-allowlisted external host', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(null, {
+      status: 301,
+      headers: { Location: 'https://attacker.example/payload' },
+    }));
+
+    const result = await safeFetch('https://cdn.adrianwedd.com/x.jpg', {}, isAllowedMediaUrl);
+
+    expect(result.response).toBeNull();
+    expect(result.blockedReason).toContain('attacker.example');
+  });
+
+  it('caps redirect chains to prevent infinite loops', async () => {
+    // Bounce between two allowlisted hosts forever — should bail at the hop cap.
+    let calls = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      calls++;
+      const target = calls % 2 === 0
+        ? 'https://cdn.adrianwedd.com/a.jpg'
+        : 'https://adrianwedd.com/b.jpg';
+      return new Response(null, { status: 302, headers: { Location: target } });
+    });
+
+    const result = await safeFetch('https://cdn.adrianwedd.com/start.jpg', {}, isAllowedMediaUrl);
+    expect(result.response).toBeNull();
+    expect(result.blockedReason).toMatch(/redirect hops/);
+  });
+
+  it('refuses a 3xx response without a Location header', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(null, { status: 302 }));
+    const result = await safeFetch('https://cdn.adrianwedd.com/x.jpg', {}, isAllowedMediaUrl);
+    expect(result.response).toBeNull();
+    expect(result.blockedReason).toContain('Location');
+  });
+
+  it('resolves relative-path redirect Locations against the current URL', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, {
+        status: 302,
+        headers: { Location: '/new-path.jpg' },
+      }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    const result = await safeFetch('https://cdn.adrianwedd.com/old-path.jpg', {}, isAllowedMediaUrl);
+    expect(result.response?.status).toBe(200);
+    expect(result.finalUrl).toBe('https://cdn.adrianwedd.com/new-path.jpg');
   });
 });

--- a/worker/src/__tests__/twitter.test.ts
+++ b/worker/src/__tests__/twitter.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTwitterPlatform } from '../platforms/twitter';
+import type { SocialPost } from '../platforms/types';
+
+const creds = {
+  apiKey: 'k', apiKeySecret: 'ks',
+  accessToken: 'at', accessTokenSecret: 'ats',
+};
+
+function makePost(): SocialPost {
+  return {
+    id: 'tw-test',
+    platform: 'twitter',
+    type: 'text',
+    message: 'Hello world',
+    scheduledAt: new Date().toISOString(),
+    scheduledAtEpoch: Date.now(),
+    status: 'queued',
+    publishedId: null,
+    publishedAt: null,
+    error: null,
+  };
+}
+
+beforeEach(() => vi.restoreAllMocks());
+afterEach(() => vi.restoreAllMocks());
+
+describe('Twitter publishPost — response classification', () => {
+  it('treats 401 as an auth error (cron halts and re-queues)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }));
+    const result = await createTwitterPlatform(creds).publishPost(makePost());
+    expect(result.success).toBe(false);
+    expect(result.isAuthError).toBe(true);
+    expect(result.isTransient).toBe(false);
+  });
+
+  // C5 — Twitter v2 returns 403 for content violations (duplicate tweet, blocked
+  // target, content moderation, missing scope, etc.). Classifying those as
+  // isAuthError causes the cron to halt the run AND re-queue the post — next
+  // tick the same 403 fires again, creating an infinite poison pill that
+  // permanently blocks all subsequent posts. 403 must be a per-post permanent
+  // failure so the cron continues and the post moves to post:failed:.
+  it('treats 403 as permanent non-auth failure (not a poison pill)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(
+      JSON.stringify({ title: 'Forbidden', detail: 'Duplicate content' }),
+      { status: 403 },
+    ));
+    const result = await createTwitterPlatform(creds).publishPost(makePost());
+    expect(result.success).toBe(false);
+    expect(result.isAuthError).toBe(false); // <-- the critical assertion
+    expect(result.isTransient).toBe(false);
+    expect(result.error).toContain('403');
+  });
+
+  it('treats 429 as transient (retry on next tick)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response('Rate limited', { status: 429 }));
+    const result = await createTwitterPlatform(creds).publishPost(makePost());
+    expect(result.success).toBe(false);
+    expect(result.isTransient).toBe(true);
+    expect(result.isAuthError).toBe(false);
+  });
+
+  it('treats 5xx as transient', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response('Server error', { status: 503 }));
+    const result = await createTwitterPlatform(creds).publishPost(makePost());
+    expect(result.success).toBe(false);
+    expect(result.isTransient).toBe(true);
+    expect(result.isAuthError).toBe(false);
+  });
+
+  it('returns success on 201 with the tweet id', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(
+      JSON.stringify({ data: { id: '1234567890' } }),
+      { status: 201, headers: { 'content-type': 'application/json' } },
+    ));
+    const result = await createTwitterPlatform(creds).publishPost(makePost());
+    expect(result.success).toBe(true);
+    expect(result.platformPostId).toBe('1234567890');
+  });
+});
+
+describe('Twitter debugAuth', () => {
+  it('reports valid when /users/me returns 200', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(
+      JSON.stringify({ data: { id: 'u1' } }), { status: 200 },
+    ));
+    const status = await createTwitterPlatform(creds).debugAuth();
+    expect(status.valid).toBe(true);
+  });
+
+  it('reports invalid on non-2xx', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response('nope', { status: 401 }));
+    const status = await createTwitterPlatform(creds).debugAuth();
+    expect(status.valid).toBe(false);
+  });
+});

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -380,61 +380,105 @@ app.post('/api/cron/publish', async (c) => {
     let failed = 0;
 
     for (const { key, post } of processable.slice(0, 5)) {
-      // Check idempotency
-      const existing = await env.SOCIAL.get(`idempotent:${post.id}`);
-      if (existing) {
-        await env.SOCIAL.delete(key); // Clean up stale queued key
+      // C1 — Per-post publish lock. The cron run and an ad-hoc /api/publish call
+      // can race on the same post.id (e.g. a manual retry triggered while cron
+      // is mid-run). /api/publish takes `publish:<idempotencyKey>`; the cron
+      // must take the same lock per-post so both paths serialise against each
+      // other. If the lock is held, skip this post — the holder is publishing it.
+      const perPostLockName = `publish:${post.id}`;
+      const perPostLockStub = env.CRON_LOCK.get(env.CRON_LOCK.idFromName(perPostLockName)) as DurableObjectStub & {
+        tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean; token: string | null }>;
+        release(name: string, token: string): Promise<void>;
+      };
+      const { acquired: perPostAcquired, token: perPostToken } = await perPostLockStub.tryAcquire(perPostLockName, 60_000);
+      if (!perPostAcquired || !perPostToken) {
+        console.warn(`Skipping post ${post.id} — concurrent publisher holds per-post lock`);
         continue;
       }
 
-      // Move to publishing state (optimistic lock)
-      await env.SOCIAL.put(`post:publishing:${post.scheduledAtEpoch}:${post.id}`, JSON.stringify({ ...post, status: 'publishing' }));
-      await env.SOCIAL.delete(key);
+      // C2 — Orphan recovery. Wrap each per-post body in try/catch that restores
+      // `post:queued:` if anything throws between the delete-queued and the
+      // terminal state write. Without this, an unhandled exception in
+      // publishPost (or any KV op) silently drops the post: the queued key is
+      // already gone, the publishing key has no recovery sweep, and the next
+      // cron tick won't see the post.
+      try {
+        // Check idempotency
+        const existing = await env.SOCIAL.get(`idempotent:${post.id}`);
+        if (existing) {
+          await env.SOCIAL.delete(key); // Clean up stale queued key
+          continue;
+        }
 
-      const postAdapter = createPlatform(post.platform, env);
-      const result = await postAdapter.publishPost(post);
+        // Move to publishing state (optimistic lock)
+        await env.SOCIAL.put(`post:publishing:${post.scheduledAtEpoch}:${post.id}`, JSON.stringify({ ...post, status: 'publishing' }));
+        await env.SOCIAL.delete(key);
 
-      if (result.success) {
-        const publishedPost: SocialPost = {
-          ...post,
-          status: 'published',
-          publishedId: result.platformPostId ?? null,
-          publishedAt: new Date().toISOString(),
-        };
-        await env.SOCIAL.put(
-          `post:published:${post.scheduledAtEpoch}:${post.id}`,
-          JSON.stringify(publishedPost),
-          { expirationTtl: 180 * 24 * 60 * 60 },
+        const postAdapter = createPlatform(post.platform, env);
+        const result = await postAdapter.publishPost(post);
+
+        if (result.success) {
+          const publishedPost: SocialPost = {
+            ...post,
+            status: 'published',
+            publishedId: result.platformPostId ?? null,
+            publishedAt: new Date().toISOString(),
+          };
+          await env.SOCIAL.put(
+            `post:published:${post.scheduledAtEpoch}:${post.id}`,
+            JSON.stringify(publishedPost),
+            { expirationTtl: 180 * 24 * 60 * 60 },
+          );
+          await env.SOCIAL.put(`idempotent:${post.id}`, JSON.stringify({
+            key: post.id, status: 'published',
+            platformPostId: result.platformPostId ?? null,
+            completedAt: new Date().toISOString(), error: null,
+          }), { expirationTtl: 30 * 24 * 60 * 60 });
+          await env.SOCIAL.delete(`post:publishing:${post.scheduledAtEpoch}:${post.id}`);
+          published++;
+        } else if (result.isAuthError) {
+          // Revert to queued
+          await env.SOCIAL.put(key, JSON.stringify({ ...post, status: 'queued' }));
+          await env.SOCIAL.delete(`post:publishing:${post.scheduledAtEpoch}:${post.id}`);
+          console.error(`${post.platform} token invalid — halting run`);
+          return json({ error: 'Token invalid', published, failed, tokenExpiresInDays: tokenExpiryByPlatform }, 503);
+        } else if (result.isTransient) {
+          // Revert to queued
+          await env.SOCIAL.put(key, JSON.stringify({ ...post, status: 'queued' }));
+          await env.SOCIAL.delete(`post:publishing:${post.scheduledAtEpoch}:${post.id}`);
+          console.warn(`Transient error for ${post.id}: ${result.error} — skipping remaining`);
+          break; // Spec: skip remaining posts on transient error
+        } else {
+          const failedPost: SocialPost = { ...post, status: 'failed', error: result.error ?? 'Unknown' };
+          await env.SOCIAL.put(`post:failed:${post.id}`, JSON.stringify(failedPost));
+          await env.SOCIAL.put(`idempotent:${post.id}`, JSON.stringify({
+            key: post.id, status: 'failed',
+            platformPostId: null,
+            completedAt: new Date().toISOString(), error: result.error ?? 'Unknown',
+          }), { expirationTtl: 30 * 24 * 60 * 60 });
+          await env.SOCIAL.delete(`post:publishing:${post.scheduledAtEpoch}:${post.id}`);
+          failed++;
+        }
+      } catch (err) {
+        // Orphan recovery: an unhandled exception between delete-queued and
+        // terminal state would silently drop the post. Restore the queue key
+        // so the next cron tick can retry it. Idempotent w.r.t. the early-exit
+        // paths above because those don't throw.
+        console.error(`Unhandled error publishing ${post.id}: ${err instanceof Error ? err.message : String(err)}`);
+        try {
+          await env.SOCIAL.put(key, JSON.stringify({ ...post, status: 'queued' }));
+          await env.SOCIAL.delete(`post:publishing:${post.scheduledAtEpoch}:${post.id}`);
+        } catch (restoreErr) {
+          // KV restore itself failed — best-effort log; the publishing-key sweep
+          // (if added later) is the backstop.
+          console.error(`Post-restore failed for ${post.id}: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}`);
+        }
+        // Don't rethrow — let the loop continue with subsequent posts. The
+        // outer try/finally will still release the cron-wide lock.
+      } finally {
+        await perPostLockStub.release(perPostLockName, perPostToken).catch(e =>
+          console.error(`Per-post lock release failed for ${post.id}: ${e instanceof Error ? e.message : String(e)}`),
         );
-        await env.SOCIAL.put(`idempotent:${post.id}`, JSON.stringify({
-          key: post.id, status: 'published',
-          platformPostId: result.platformPostId ?? null,
-          completedAt: new Date().toISOString(), error: null,
-        }), { expirationTtl: 30 * 24 * 60 * 60 });
-        await env.SOCIAL.delete(`post:publishing:${post.scheduledAtEpoch}:${post.id}`);
-        published++;
-      } else if (result.isAuthError) {
-        // Revert to queued
-        await env.SOCIAL.put(key, JSON.stringify({ ...post, status: 'queued' }));
-        await env.SOCIAL.delete(`post:publishing:${post.scheduledAtEpoch}:${post.id}`);
-        console.error(`${post.platform} token invalid — halting run`);
-        return json({ error: 'Token invalid', published, failed, tokenExpiresInDays: tokenExpiryByPlatform }, 503);
-      } else if (result.isTransient) {
-        // Revert to queued
-        await env.SOCIAL.put(key, JSON.stringify({ ...post, status: 'queued' }));
-        await env.SOCIAL.delete(`post:publishing:${post.scheduledAtEpoch}:${post.id}`);
-        console.warn(`Transient error for ${post.id}: ${result.error} — skipping remaining`);
-        break; // Spec: skip remaining posts on transient error
-      } else {
-        const failedPost: SocialPost = { ...post, status: 'failed', error: result.error ?? 'Unknown' };
-        await env.SOCIAL.put(`post:failed:${post.id}`, JSON.stringify(failedPost));
-        await env.SOCIAL.put(`idempotent:${post.id}`, JSON.stringify({
-          key: post.id, status: 'failed',
-          platformPostId: null,
-          completedAt: new Date().toISOString(), error: result.error ?? 'Unknown',
-        }), { expirationTtl: 30 * 24 * 60 * 60 });
-        await env.SOCIAL.delete(`post:publishing:${post.scheduledAtEpoch}:${post.id}`);
-        failed++;
       }
     }
 

--- a/worker/src/platforms/bluesky.ts
+++ b/worker/src/platforms/bluesky.ts
@@ -5,10 +5,15 @@ import type {
   Comment,
   AuthStatus,
 } from './types';
-import { isAllowedMediaUrl, isSafeHttpsUrl } from './safe-fetch';
+import { isAllowedMediaUrl, safeFetch } from './safe-fetch';
 
 const BSKY_BASE = 'https://bsky.social/xrpc';
 const MAX_GRAPHEMES = 300;
+
+// Match either ?v=ID, &v=ID (long-form) or youtu.be/ID (short-form). Capture
+// group is whichever matched. Used in both publish (Bluesky embed) and the
+// Astro VideoObject schema; keep in sync with src/pages/{blog,projects}/[...slug].astro.
+const YOUTUBE_ID_REGEX = /(?:[?&]v=|youtu\.be\/)([A-Za-z0-9_-]{6,})/;
 
 interface BskySession {
   did: string;
@@ -63,13 +68,47 @@ function truncateGraphemes(text: string, max: number): string {
 }
 
 
+// Stream a response body and abort once `maxBytes` is exceeded. Returns null
+// if the cap is breached. HEAD-then-GET TOCTOU defence: even if an origin lied
+// about Content-Length on HEAD, the GET cannot inflate the worker beyond cap.
+async function readBoundedArrayBuffer(res: Response, maxBytes: number): Promise<ArrayBuffer | null> {
+  if (!res.body) {
+    const buf = await res.arrayBuffer();
+    return buf.byteLength <= maxBytes ? buf : null;
+  }
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      reader.cancel().catch(() => undefined);
+      return null;
+    }
+    chunks.push(value);
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out.buffer;
+}
+
 async function uploadVideo(session: BskySession, videoUrl: string): Promise<unknown | null> {
   if (!isAllowedMediaUrl(videoUrl)) return null;
   try {
     // Skip if video is too large for CF Worker outgoing request (~20MB practical limit).
     // Require a Content-Length header; without it we cannot bound memory usage safely.
-    const headRes = await fetch(videoUrl, { method: 'HEAD' });
-    const rawContentLength = headRes.headers.get('content-length');
+    // safeFetch enforces `redirect: 'manual'` and re-validates each Location hop,
+    // so a 302 from cdn.adrianwedd.com cannot pivot to a private/metadata IP.
+    const headRes = await safeFetch(videoUrl, { method: 'HEAD' }, isAllowedMediaUrl);
+    if (!headRes.response) return null;
+    const rawContentLength = headRes.response.headers.get('content-length');
     if (rawContentLength === null) return null;
     const contentLength = parseInt(rawContentLength, 10);
     if (!Number.isFinite(contentLength) || contentLength <= 0 || contentLength > 20 * 1024 * 1024) return null;
@@ -81,9 +120,12 @@ async function uploadVideo(session: BskySession, videoUrl: string): Promise<unkn
     if (!serviceAuthRes.ok) return null;
     const { token } = await serviceAuthRes.json() as { token: string };
 
-    const videoRes = await fetch(videoUrl);
-    if (!videoRes.ok) return null;
-    const videoBytes = await videoRes.arrayBuffer();
+    const videoFetch = await safeFetch(videoUrl, {}, isAllowedMediaUrl);
+    if (!videoFetch.response || !videoFetch.response.ok) return null;
+    // HEAD reported a size we accept; cap the actual read at the same bound to
+    // defend against an origin that returns a small HEAD and a huge GET (TOCTOU).
+    const videoBytes = await readBoundedArrayBuffer(videoFetch.response, 20 * 1024 * 1024);
+    if (!videoBytes) return null;
 
     const uploadRes = await fetch(`https://video.bsky.app/xrpc/app.bsky.video.uploadVideo?did=${session.did}`, {
       method: 'POST',
@@ -130,26 +172,17 @@ export function createBlueskyPlatform(
       throw err;
     }
 
-    const data = await res.json() as {
-      did: string;
-      accessJwt: string;
-      didDoc?: { service?: Array<{ id: string; serviceEndpoint: string }> };
-    };
-    // Extract PDS endpoint from didDoc if present, otherwise resolve via PLC directory.
-    // The endpoint becomes the base URL for authenticated calls bearing our accessJwt,
-    // so reject anything that isn't a well-formed HTTPS URL (no IP literals).
-    let pdsEndpoint = BSKY_BASE;
-    const candidate = data.didDoc?.service?.find(s => s.id === '#atproto_pds')?.serviceEndpoint
-      ?? await (async () => {
-        const didRes = await fetch(`https://plc.directory/${encodeURIComponent(data.did)}`).catch(() => null);
-        if (!didRes?.ok) return undefined;
-        const didDoc = await didRes.json() as { service?: Array<{ id: string; serviceEndpoint: string }> };
-        return didDoc.service?.find(s => s.id === '#atproto_pds')?.serviceEndpoint;
-      })();
-    if (candidate && isSafeHttpsUrl(candidate)) {
-      pdsEndpoint = `${candidate.replace(/\/$/, '')}/xrpc`;
-    }
-    return { did: data.did, accessJwt: data.accessJwt, pdsEndpoint };
+    const data = await res.json() as { did: string; accessJwt: string };
+    // PDS endpoint is HARD-PINNED to bsky.social. The previous implementation
+    // honoured `didDoc.service[].serviceEndpoint` (or fell back to plc.directory),
+    // but PLC is open — anyone can register a DID with a service endpoint pointing
+    // at attacker-controlled hostname, which can resolve to 169.254.169.254 etc.
+    // The resulting accessJwt would then be sent to the attacker on every
+    // subsequent authenticated call. Hostname-only allowlisting cannot defend
+    // against DNS-rebinding here. If federation is ever needed, restrict PDS
+    // endpoints to a curated allowlist (e.g. *.host.bsky.network) and pin to
+    // resolved IPs across the connect.
+    return { did: data.did, accessJwt: data.accessJwt, pdsEndpoint: BSKY_BASE };
   }
 
   async function publishPost(post: SocialPost): Promise<PublishResult> {
@@ -190,21 +223,25 @@ export function createBlueskyPlatform(
       }
 
       if (!record.embed && post.youtubeUrl) {
-        const videoId = post.youtubeUrl.match(/[?&]v=([^&]+)/)?.[1];
+        const videoId = post.youtubeUrl.match(YOUTUBE_ID_REGEX)?.[1];
         if (videoId) {
           // img.youtube.com is in the allowlist; videoId is captured from a tight regex
           const thumbUrl = `https://img.youtube.com/vi/${encodeURIComponent(videoId)}/maxresdefault.jpg`;
-          const thumbRes = await fetch(thumbUrl);
+          const thumbFetch = await safeFetch(thumbUrl, {}, isAllowedMediaUrl);
           let thumbBlob: unknown = undefined;
-          if (thumbRes.ok) {
-            const thumbBytes = await thumbRes.arrayBuffer();
-            const blobRes = await fetch(`${session.pdsEndpoint}/com.atproto.repo.uploadBlob`, {
-              method: 'POST',
-              headers: { 'Authorization': `Bearer ${session.accessJwt}`, 'Content-Type': 'image/jpeg' },
-              body: thumbBytes,
-            });
-            if (blobRes.ok) {
-              thumbBlob = (await blobRes.json() as { blob: unknown }).blob;
+          if (thumbFetch.response?.ok) {
+            const thumbBytes = await readBoundedArrayBuffer(thumbFetch.response, 5 * 1024 * 1024);
+            if (thumbBytes) {
+              const blobRes = await fetch(`${session.pdsEndpoint}/com.atproto.repo.uploadBlob`, {
+                method: 'POST',
+                headers: { 'Authorization': `Bearer ${session.accessJwt}`, 'Content-Type': 'image/jpeg' },
+                body: thumbBytes,
+              });
+              if (blobRes.ok) {
+                thumbBlob = (await blobRes.json() as { blob: unknown }).blob;
+              }
+            } else {
+              console.warn(`YouTube thumbnail exceeded 5MB cap: ${thumbUrl}`);
             }
           }
           record.embed = {
@@ -221,18 +258,22 @@ export function createBlueskyPlatform(
 
       if (!record.embed && post.imageUrl && isAllowedMediaUrl(post.imageUrl)) {
         // Fall back to static image embed
-        const imgRes = await fetch(post.imageUrl);
-        if (imgRes.ok) {
-          const imgBytes = await imgRes.arrayBuffer();
-          const mimeType = imgRes.headers.get('content-type') ?? 'image/jpeg';
-          const blobRes = await fetch(`${session.pdsEndpoint}/com.atproto.repo.uploadBlob`, {
-            method: 'POST',
-            headers: { 'Authorization': `Bearer ${session.accessJwt}`, 'Content-Type': mimeType },
-            body: imgBytes,
-          });
-          if (blobRes.ok) {
-            const blobData = await blobRes.json() as { blob: unknown };
-            record.embed = { $type: 'app.bsky.embed.images', images: [{ image: blobData.blob, alt: '' }] };
+        const imgFetch = await safeFetch(post.imageUrl, {}, isAllowedMediaUrl);
+        if (imgFetch.response?.ok) {
+          const imgBytes = await readBoundedArrayBuffer(imgFetch.response, 5 * 1024 * 1024);
+          if (imgBytes) {
+            const mimeType = imgFetch.response.headers.get('content-type') ?? 'image/jpeg';
+            const blobRes = await fetch(`${session.pdsEndpoint}/com.atproto.repo.uploadBlob`, {
+              method: 'POST',
+              headers: { 'Authorization': `Bearer ${session.accessJwt}`, 'Content-Type': mimeType },
+              body: imgBytes,
+            });
+            if (blobRes.ok) {
+              const blobData = await blobRes.json() as { blob: unknown };
+              record.embed = { $type: 'app.bsky.embed.images', images: [{ image: blobData.blob, alt: '' }] };
+            }
+          } else {
+            console.warn(`Image embed exceeded 5MB cap: ${post.imageUrl}`);
           }
         }
       }

--- a/worker/src/platforms/safe-fetch.ts
+++ b/worker/src/platforms/safe-fetch.ts
@@ -12,6 +12,18 @@ const MEDIA_HOST_ALLOWLIST: ReadonlySet<string> = new Set([
 ]);
 
 const IPV4_LITERAL = /^\d{1,3}(\.\d{1,3}){3}$/;
+// Hex-encoded IPv4 (0x7f.0.0.1) and decimal-encoded IPv4 (2130706433) bypasses.
+const IPV4_HEX_OR_OCTAL = /^0[xX]?[0-9a-fA-F]+(\.0[xX]?[0-9a-fA-F]+){0,3}$/;
+const IPV4_PURE_DECIMAL = /^\d{8,10}$/;
+
+function hasIpLikeHostname(hostname: string): boolean {
+  if (IPV4_LITERAL.test(hostname)) return true;
+  if (hostname.includes(':')) return true; // IPv6 (incl. bracketed)
+  if (hostname.startsWith('[') && hostname.endsWith(']')) return true;
+  if (IPV4_HEX_OR_OCTAL.test(hostname)) return true;
+  if (IPV4_PURE_DECIMAL.test(hostname)) return true;
+  return false;
+}
 
 export function isAllowedMediaUrl(url: string): boolean {
   let parsed: URL;
@@ -21,12 +33,17 @@ export function isAllowedMediaUrl(url: string): boolean {
     return false;
   }
   if (parsed.protocol !== 'https:') return false;
-  if (IPV4_LITERAL.test(parsed.hostname) || parsed.hostname.includes(':')) return false;
+  if (hasIpLikeHostname(parsed.hostname)) return false;
   return MEDIA_HOST_ALLOWLIST.has(parsed.hostname);
 }
 
 // Looser check for federated endpoints (e.g. AT Protocol PDS) where we cannot
 // allowlist the host but still want to refuse IP literals and non-HTTPS.
+//
+// NOTE: hostname-only validation does NOT prevent DNS-rebinding to private IPs.
+// Callers that pass attacker-controlled hostnames here must additionally pin
+// the destination or use a maintained allowlist — see bluesky.ts where the
+// federated PDS endpoint is intentionally pinned to bsky.social.
 export function isSafeHttpsUrl(url: string): boolean {
   let parsed: URL;
   try {
@@ -35,6 +52,59 @@ export function isSafeHttpsUrl(url: string): boolean {
     return false;
   }
   if (parsed.protocol !== 'https:') return false;
-  if (IPV4_LITERAL.test(parsed.hostname) || parsed.hostname.includes(':')) return false;
+  if (hasIpLikeHostname(parsed.hostname)) return false;
   return true;
+}
+
+// ── Redirect-aware fetch ────────────────────────────────────────────────────
+//
+// Default `fetch()` follows redirects transparently, so an attacker-controlled
+// origin (or a poisoned CDN response) returning `302 Location: https://169.254.169.254/...`
+// turns an allowlisted source URL into an SSRF primitive. `safeFetch` does the
+// redirect walk itself and re-runs `validator` on each hop, capping at MAX_HOPS.
+//
+// `validator` should be `isAllowedMediaUrl` for media bytes and `isSafeHttpsUrl`
+// for federated endpoints. The initial URL is also validated by the caller
+// before invoking this function.
+
+const MAX_REDIRECT_HOPS = 3;
+
+export interface SafeFetchResult {
+  response: Response | null;
+  finalUrl: string;
+  // Non-null when the fetch was aborted because a redirect target failed validation
+  // or the hop limit was exceeded. Used by callers to surface debugging info.
+  blockedReason?: string;
+}
+
+export async function safeFetch(
+  url: string,
+  init: RequestInit,
+  validator: (url: string) => boolean,
+): Promise<SafeFetchResult> {
+  let current = url;
+  for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+    if (!validator(current)) {
+      return { response: null, finalUrl: current, blockedReason: `validator rejected ${current}` };
+    }
+    const res = await fetch(current, { ...init, redirect: 'manual' });
+    // 3xx with Location: walk the redirect ourselves; refuse opaque redirects (no Location)
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get('location');
+      if (!location) {
+        return { response: null, finalUrl: current, blockedReason: 'redirect without Location header' };
+      }
+      // Resolve relative redirects against the current URL.
+      let nextUrl: string;
+      try {
+        nextUrl = new URL(location, current).href;
+      } catch {
+        return { response: null, finalUrl: current, blockedReason: `invalid redirect Location: ${location}` };
+      }
+      current = nextUrl;
+      continue;
+    }
+    return { response: res, finalUrl: current };
+  }
+  return { response: null, finalUrl: current, blockedReason: `exceeded ${MAX_REDIRECT_HOPS} redirect hops` };
 }

--- a/worker/src/platforms/twitter.ts
+++ b/worker/src/platforms/twitter.ts
@@ -1,5 +1,5 @@
 import type { SocialPost, SocialPlatform, PublishResult, AuthStatus, Comment } from './types';
-import { isAllowedMediaUrl } from './safe-fetch';
+import { isAllowedMediaUrl, safeFetch } from './safe-fetch';
 
 // ── OAuth 1.0a ─────────────────────────────────────────────────────────────
 
@@ -61,13 +61,38 @@ const MEDIA_UPLOAD_URL = 'https://upload.twitter.com/1.1/media/upload.json';
 const TWEET_URL = 'https://api.twitter.com/2/tweets';
 const VERIFY_URL = 'https://api.twitter.com/2/users/me';
 
+// Twitter v1.1 media upload accepts up to 5MB for images. We enforce the same
+// cap during streaming to defend against an origin that lies about Content-Length
+// or omits it entirely (HEAD-vs-GET TOCTOU).
+const TWITTER_MEDIA_CAP_BYTES = 5 * 1024 * 1024;
+
 async function uploadMedia(imageUrl: string, creds: OAuth1Creds): Promise<string | null> {
   if (!isAllowedMediaUrl(imageUrl)) return null;
   try {
-    const imgRes = await fetch(imageUrl);
-    if (!imgRes.ok) return null;
-    const bytes = await imgRes.arrayBuffer();
-    const contentType = imgRes.headers.get('content-type') || 'image/jpeg';
+    // safeFetch enforces `redirect: 'manual'` and re-validates each Location hop
+    // against the allowlist, so an allowlisted CDN URL cannot redirect to a
+    // private/metadata endpoint.
+    const imgFetch = await safeFetch(imageUrl, {}, isAllowedMediaUrl);
+    if (!imgFetch.response?.ok || !imgFetch.response.body) return null;
+    const reader = imgFetch.response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > TWITTER_MEDIA_CAP_BYTES) {
+        reader.cancel().catch(() => undefined);
+        console.warn(`Twitter media upload exceeded ${TWITTER_MEDIA_CAP_BYTES}-byte cap: ${imageUrl}`);
+        return null;
+      }
+      chunks.push(value);
+    }
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength; }
+    const contentType = imgFetch.response.headers.get('content-type') || 'image/jpeg';
 
     // Multipart body is excluded from OAuth signature base (RFC 5849 §3.4.1.3)
     const auth = await oauthHeader('POST', MEDIA_UPLOAD_URL, {}, creds);
@@ -121,12 +146,25 @@ export function createTwitterPlatform(creds: OAuth1Creds): SocialPlatform {
           body: JSON.stringify(body),
         });
 
-        if (res.status === 401 || res.status === 403) {
-          // Drain body to keep the socket clean but don't include it in the error —
-          // OAuth response bodies can leak signature data into KV idempotency records.
+        if (res.status === 401) {
+          // 401 unambiguously means "your credentials are invalid". Drain the body
+          // (OAuth response bodies can leak signature data into KV idempotency
+          // records, so don't include it in the surfaced error).
           await res.text().catch(() => '');
-          console.error(`Twitter publish auth failure: HTTP ${res.status}`);
-          return { success: false, error: `HTTP ${res.status}`, isTransient: false, isAuthError: true };
+          console.error(`Twitter publish auth failure: HTTP 401`);
+          return { success: false, error: 'HTTP 401', isTransient: false, isAuthError: true };
+        }
+        if (res.status === 403) {
+          // 403 from Twitter v2 means "your credentials are valid but this action
+          // is forbidden" — duplicate tweet, content moderation, blocked target,
+          // missing write scope on the token, etc. Classifying as auth error here
+          // would halt the entire cron run and re-queue the post, creating an
+          // infinite-loop poison pill (next tick: same post, same 403, same halt).
+          // Treat as a permanent per-post failure so the cron continues and the
+          // post moves to post:failed:.
+          const errText = await res.text().catch(() => '');
+          console.error(`Twitter publish forbidden (HTTP 403): ${errText.slice(0, 200)}`);
+          return { success: false, error: `HTTP 403: ${errText.slice(0, 200)}`, isTransient: false, isAuthError: false };
         }
         if (res.status === 429 || res.status >= 500) {
           return { success: false, error: `HTTP ${res.status}`, isTransient: true, isAuthError: false };


### PR DESCRIPTION
## Summary

Closes 5 Critical findings from today's multi-engine QA (codex + gemini + hermes + 2 Claude reviewers). Cross-validated: each finding was flagged by at least one engine, most by 2+.

| ID | Finding | Severity vote |
|----|---------|--------------|
| **C1** | Cron-vs-publish double-post race (no shared lock between `/api/publish` and `/api/cron/publish`) | 🔴 Claude-worker |
| **C2** | Orphaned `post:publishing:` keys → lost posts on unhandled throw | 🔴 Claude-worker + gemini |
| **C3** | SSRF via federated PDS endpoint (attacker-influenceable DID → accessJwt exfil) | 🔴 codex + hermes + Claude-worker |
| **C4** | SSRF via redirect bypass (default fetch follows redirects past allowlist) | 🔴 codex |
| **C5** | Twitter 403 misclassified as auth error → infinite poison-pill queue block | 🔴 gemini |

## What changed

**C1 — per-post publish lock in cron.** Cron now acquires `publish:<post.id>` per post and skips if held. `/api/publish` already uses the same name keyed by `idempotencyKey`. A manual retry mid-cron-run can no longer race and double-post.

**C2 — orphan recovery.** Per-post body wrapped in `try/catch` that restores the queued key on unexpected throw. Idempotent w.r.t. the existing early-exit paths (auth/transient/permanent), which never throw.

**C3 — Bluesky PDS pinned to `bsky.social`.** Removed federated PDS resolution (`didDoc.service` / `plc.directory` fallback). PLC is open — anyone can register a DID whose service endpoint resolves to a private IP, and the worker would have sent `accessJwt` there on every authenticated call. Hostname-only allowlisting cannot defend against DNS rebinding; only IP pinning or a curated PDS hostname allowlist would, and we don't need either since `adrianwedd.com` lives on `bsky.social`.

**C4 — `safeFetch` wrapper.** Walks redirects with `redirect: 'manual'`, re-validates every `Location` through the supplied validator, caps at 3 hops, refuses opaque 3xx. Applied to all media fetches (video, YouTube thumbnail, image embed, Twitter media upload). Also adds streaming size cap (5MB / 20MB) to defend against an origin that returns small HEAD + huge GET.

**C5 — Twitter 403 → permanent non-auth failure.** Only 401 is `isAuthError` now. 403 (duplicate tweet, content moderation, blocked target, missing scope) becomes a per-post permanent failure so the cron continues and the post moves to `post:failed:`. Previously the 403 made the cron halt and re-queue, so the next tick replayed the same 403 forever.

**Bonus hardening** picked up along the way:
- `hasIpLikeHostname()` now rejects hex (`0x7f000001`), decimal (`2130706433`), and bracketed-IPv6 (`[::1]`) encoded literals — additional SSRF bypasses flagged by hermes.
- YouTube short URL regex (`youtu.be/ID`) — embeds were silently missing on Bluesky for the short-link form (flagged by gemini).
- Removed leftover \`isSafeHttpsUrl\` import in \`bluesky.ts\` (the PDS pinning made it unused there).

## Tests

- `worker/src/__tests__/safe-fetch.test.ts` — +12 tests: hex/decimal/IPv6 IP rejection, redirect walker (initial validator, allowlisted redirect, SSRF-pivot rejection, external-redirect rejection, hop cap, opaque 3xx, relative-path resolution)
- `worker/src/__tests__/twitter.test.ts` — new file, 7 tests covering the 401/403/429/5xx/201 classification matrix and `debugAuth`
- `worker/src/__tests__/publish.test.ts` — +4 tests: per-post lock skip, orphan recovery on throw, per-post lock release on success and on throw

127 tests pass (was 104). `npx wrangler deploy --dry-run` clean.

## Test plan

- [ ] CI green
- [ ] Manual smoke: `/api/health` returns 200 with multi-platform stats
- [ ] Smoke a Twitter 403 path (e.g. duplicate tweet retry) — confirm post moves to `post:failed:` and the cron continues processing subsequent posts
- [ ] Confirm Bluesky publish still works post-PDS-pin