### PR TITLE
fix(site): wire OG generator into build; stop overriding canonical URL in project JSON-LD

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build && pagefind --site dist",
+    "build": "node scripts/generate-og-images.mjs && astro build && pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro",
     "fetch-analytics": "node scripts/fetch-ga4-data.mjs",

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -94,7 +94,12 @@ const allBlogPosts = project.data.series
       keywords: project.data.tags,
       ...(project.data.repo || project.data.url ? { applicationCategory: 'DeveloperApplication' } : {}),
       ...(project.data.repo ? { offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' } } : {}),
-      ...(project.data.url ? { url: project.data.url } : {}),
+      // External project URL goes in `sameAs`, NOT `url`. Previously the spread
+      // here was `{ url: project.data.url }`, which silently overrode the
+      // canonical adrianwedd.com URL above. Google ingests `url` as the
+      // entity's canonical address — every project with `url` set was telling
+      // Google the entity lived at the external site, splitting page authority.
+      ...(project.data.url ? { sameAs: [project.data.url] } : {}),
       ...(project.data.repo
         ? {
             codeRepository: project.data.repo.startsWith('http')


### PR DESCRIPTION
## Summary

Closes 2 Critical findings from today's multi-engine QA. Both are SEO-impacting bugs that have been latent on `main` for a while.

| ID | Finding | Severity |
|----|---------|---------|
| **C6** | `scripts/generate-og-images.mjs` was never invoked by the build pipeline | 🔴 Critical |
| **C7** | `SoftwareApplication` JSON-LD `url` overridden by external project URL | 🔴 Critical |

## C6 — wire the OG generator into `build`

The `build` script was `astro build && pagefind --site dist`. No workflow step ran the generator either. The blog/project templates fall back to `/og/{type}/{slug}.png` when `heroImage` is unset, but that path 404'd for every such post because the generator only ran by hand. `public/og/` contained nothing but `services.png`.

Currently a latent bug — every non-draft post happens to have `heroImage` set — but the next heroImage-less post ships breaks social previews on FB / X / LinkedIn / iMessage. This is defensive infrastructure.

The generator depends on `sharp` (resolves transitively via `astro:assets`) and `gray-matter` (already in `devDependencies`). No new deps needed.

## C7 — `SoftwareApplication.url` shadow

The JSON-LD set `url:` to the canonical adrianwedd.com page, then spread `{ url: project.data.url }` on top — overriding the canonical with the external URL. Google ingests `url` as the entity's canonical address, so every project with `url` set told Google the entity lived at the external site, splitting page authority away from the dedicated adrianwedd.com page.

Renamed the spread key to `sameAs: [project.data.url]`, which is the schema.org-correct way to assert an alternative public URL for the same entity.

**Verified in built output** (`dist/projects/afterwords/index.html`):

Before (pre-fix): `url: "https://adrianwedd.github.io/afterwords/"` (external)

After: `url: "https://adrianwedd.com/projects/afterwords/"` (canonical) + `sameAs: ["https://adrianwedd.github.io/afterwords/"]` (external)

## Test plan

- [ ] CI green (build picks up generator step without error)
- [ ] After deploy, run a couple of project URLs through Google's Rich Results Test — `url` is canonical, `sameAs` is external
- [ ] Inspect the new prebuild step's output in CI logs to confirm it ran