### PR TITLE
fix(worker): hardening pass 2 — Highs + folded multi-engine PR-QA findings

### DIFF
--- a/worker/src/__tests__/auth.test.ts
+++ b/worker/src/__tests__/auth.test.ts
@@ -31,4 +31,28 @@ describe('verifyBearer', () => {
     const result = await verifyBearer('Bearer short', 'a-much-longer-secret-value');
     expect(result).toBe(false);
   });
+
+  // H2 — Pre-fix, verifyBearer compared raw buffers and short-circuited on
+  // length mismatch with `if (expectedBuf.byteLength !== actualBuf.byteLength) return false;`
+  // before reaching `timingSafeEqual`. That early return exposed the secret's
+  // length over timing: an attacker could probe ?Bearer aaa, aaaa, aaaaa...
+  // and see the response time drop sharply once their guess matched the
+  // expected byte length. The fix hashes both sides to 32 bytes first.
+  it('SHA-256 normalisation: 1-char and 1000-char inputs both reach the constant-time compare', async () => {
+    // Both calls return false (neither matches the secret), but pre-fix the
+    // 1000-char call would short-circuit on length mismatch while the 1-char
+    // call would short-circuit on a different length mismatch. The new code
+    // makes both inputs hash to 32 bytes so the length branch never fires
+    // on attacker-controlled inputs.
+    const short = await verifyBearer('Bearer x', 'the-real-secret');
+    const long  = await verifyBearer('Bearer ' + 'x'.repeat(1000), 'the-real-secret');
+    expect(short).toBe(false);
+    expect(long).toBe(false);
+  });
+
+  it('returns true regardless of how exotic the matching secret is', async () => {
+    // Long secret with mixed ASCII / Unicode — should still validate.
+    const secret = 'hard-secret-😀-with-unicode-and-symbols-!@#$%';
+    expect(await verifyBearer(`Bearer ${secret}`, secret)).toBe(true);
+  });
 });

--- a/worker/src/__tests__/publish.test.ts
+++ b/worker/src/__tests__/publish.test.ts
@@ -464,6 +464,46 @@ describe('POST /api/cron/publish', () => {
     expect(kv.store.has(queueKey)).toBe(true);
   });
 
+  // Codex/gemini/hermes High follow-up to C2: phase-tracked orphan recovery.
+  // If publishPost SUCCEEDS but the terminal KV writes throw (transient KV
+  // outage), the old blanket restore would re-queue the post and the next
+  // cron tick would publish to the platform AGAIN — exactly the duplicate
+  // the lock was supposed to prevent. The fix tracks `externalPublishSucceeded`
+  // and refuses to restore in that case, surfacing it via `orphanedAfterSuccess`
+  // and a 500 response so monitoring catches the KV outage.
+  it('does NOT requeue when publishPost succeeded but post:published: KV write throws (no double-publish)', async () => {
+    const kv = mockKV();
+    mockDebugAuth.mockResolvedValueOnce(healthyToken);
+    mockPublishPost.mockResolvedValueOnce({
+      success: true, platformPostId: 'fb_external_id', isTransient: false, isAuthError: false,
+    });
+
+    const post = makePost('post-success-kv-fail');
+    const queueKey = `post:queued:${post.scheduledAtEpoch}:${post.id}`;
+    kv.store.set(queueKey, JSON.stringify(post));
+    kv.list.mockResolvedValueOnce({ keys: [{ name: queueKey }], list_complete: true });
+
+    // Make the `post:published:` write throw — the kind of transient KV failure
+    // that previously triggered the bug.
+    kv.put.mockImplementation(async (key: string, value: string) => {
+      if (key.startsWith('post:published:')) {
+        throw new Error('KV unavailable');
+      }
+      kv.store.set(key, value);
+    });
+
+    const res = await app.fetch(cronRequest(), makeEnv(kv));
+    // The cron should surface the infrastructure failure as 500, not pretend
+    // everything was fine.
+    expect(res.status).toBe(500);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.orphanedAfterSuccess).toBe(1);
+
+    // CRITICALLY: the queued key must NOT be restored — otherwise the next
+    // cron tick would call publishPost again on a post that already published.
+    expect(kv.store.has(queueKey)).toBe(false);
+  });
+
   // C2 — Orphan recovery. Without the try/catch around the per-post body, an
   // unhandled exception (network blip, JSON parse failure, etc.) after the
   // queued key is deleted but before the terminal state is written would
@@ -693,5 +733,116 @@ describe('POST /api/publish forceRetry', () => {
     expect(res.status).toBe(200);
     expect(cronLock.release).toHaveBeenCalledWith('publish:release-test', expect.any(String));
     expect(cronLock.held.has('publish:release-test')).toBe(false);
+  });
+
+  // H7 — Without runtime validation, missing/empty/malicious idempotencyKeys
+  // produced shared lock and KV names (publish:undefined, idempotent:undefined)
+  // that let unrelated authenticated publishes collide or suppress each other.
+  it.each([
+    ['missing',     {}],
+    ['empty',       { idempotencyKey: '' }],
+    ['null',        { idempotencyKey: null }],
+    ['number',      { idempotencyKey: 12345 }],
+    ['too long',    { idempotencyKey: 'a'.repeat(257) }],
+    ['unsafe char', { idempotencyKey: 'has space' }],
+    ['path-trav',   { idempotencyKey: '../../system' }],
+  ])('rejects %s idempotencyKey with 400', async (_label, override) => {
+    const kv = mockKV();
+    const res = await app.fetch(
+      publishRequest({ type: 'text', message: 'hi', ...override }),
+      makeEnv(kv),
+    );
+    expect(res.status).toBe(400);
+    expect(mockPublishPost).not.toHaveBeenCalled();
+  });
+
+  it('accepts a typical commit-hash idempotencyKey', async () => {
+    const kv = mockKV();
+    mockPublishPost.mockResolvedValueOnce({
+      success: true, platformPostId: 'ok', isTransient: false, isAuthError: false,
+    });
+    const res = await app.fetch(
+      publishRequest({ type: 'text', message: 'hi', idempotencyKey: 'commit-3ae25f2c-blog/foo' }),
+      makeEnv(kv),
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+// H9 — /api/cron/comments had zero route-level test coverage. These tests
+// exercise the lock-held skip, per-platform expired-token skip, multi-platform
+// iteration, and lock release on throw.
+describe('POST /api/cron/comments', () => {
+  function commentsRequest() {
+    return new Request('http://localhost/api/cron/comments', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test-cron-secret' },
+    });
+  }
+
+  it('returns 401 without valid cron auth', async () => {
+    const kv = mockKV();
+    const req = new Request('http://localhost/api/cron/comments', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer wrong' },
+    });
+    const res = await app.fetch(req, makeEnv(kv));
+    expect(res.status).toBe(401);
+  });
+
+  it('skips when the comments lock is held', async () => {
+    const kv = mockKV();
+    const cronLock = mockCronLock(['comments']);
+    const res = await app.fetch(commentsRequest(), makeEnv(kv, cronLock));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.skipped).toBe(true);
+    expect(body.reason).toBe('locked');
+    // Token health should not have been checked
+    expect(mockDebugAuth).not.toHaveBeenCalled();
+    // Release must NOT fire when acquire failed
+    expect(cronLock.release).not.toHaveBeenCalled();
+  });
+
+  it('iterates configured platforms and reports per-platform results', async () => {
+    const kv = mockKV();
+    setConfiguredPlatforms(['facebook', 'bluesky']);
+    getPlatformMocks('facebook').debugAuth.mockResolvedValueOnce(healthyToken);
+    getPlatformMocks('bluesky').debugAuth.mockResolvedValueOnce({
+      valid: true, platform: 'bluesky', expiresAt: 0, dataAccessExpiresAt: 0, daysUntilExpiry: 60,
+    });
+    const res = await app.fetch(commentsRequest(), makeEnv(kv));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    const platforms = body.platforms as Record<string, unknown>;
+    expect(platforms.facebook).toBeDefined();
+    expect(platforms.bluesky).toBeDefined();
+  });
+
+  it('skips a platform with expired data access and continues with others', async () => {
+    const kv = mockKV();
+    setConfiguredPlatforms(['facebook', 'bluesky']);
+    getPlatformMocks('facebook').debugAuth.mockResolvedValueOnce({
+      valid: false, platform: 'facebook', expiresAt: 0, dataAccessExpiresAt: 0, daysUntilExpiry: 0,
+    });
+    getPlatformMocks('bluesky').debugAuth.mockResolvedValueOnce(healthyToken);
+
+    const res = await app.fetch(commentsRequest(), makeEnv(kv));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    const platforms = body.platforms as Record<string, { error?: string }>;
+    expect(platforms.facebook.error).toBe('data access expired');
+    expect(platforms.bluesky).toBeDefined();
+  });
+
+  it('releases the comments lock in finally even on unexpected error', async () => {
+    const kv = mockKV();
+    const cronLock = mockCronLock();
+    mockDebugAuth.mockRejectedValueOnce(new Error('boom'));
+    try {
+      await app.fetch(commentsRequest(), makeEnv(kv, cronLock));
+    } catch { /* swallow — testing finally */ }
+    expect(cronLock.release).toHaveBeenCalledWith('comments', expect.any(String));
+    expect(cronLock.held.has('comments')).toBe(false);
   });
 });

--- a/worker/src/__tests__/safe-fetch.test.ts
+++ b/worker/src/__tests__/safe-fetch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { isAllowedMediaUrl, isSafeHttpsUrl, safeFetch } from '../platforms/safe-fetch';
+import { isAllowedMediaUrl, isSafeHttpsUrl, safeFetch, readBoundedArrayBuffer } from '../platforms/safe-fetch';
 
 describe('isAllowedMediaUrl', () => {
   it.each([
@@ -145,5 +145,119 @@ describe('safeFetch (SSRF defense for outbound fetches)', () => {
     const result = await safeFetch('https://cdn.adrianwedd.com/old-path.jpg', {}, isAllowedMediaUrl);
     expect(result.response?.status).toBe(200);
     expect(result.finalUrl).toBe('https://cdn.adrianwedd.com/new-path.jpg');
+  });
+
+  // Codex/hermes High: a malicious origin can return a huge body on the 3xx
+  // response itself to stall the worker. safeFetch must cancel intermediate
+  // bodies before continuing the walk.
+  it('cancels the body of intermediate 3xx responses', async () => {
+    const cancelSpy = vi.fn().mockResolvedValue(undefined);
+    const redirectBody = new ReadableStream({
+      start(controller) { controller.enqueue(new Uint8Array([1, 2, 3])); controller.close(); },
+    });
+    // Wrap the body so we can spy on cancel().
+    const redirectRes = new Response(redirectBody, {
+      status: 302,
+      headers: { Location: 'https://cdn.adrianwedd.com/final.jpg' },
+    });
+    Object.defineProperty(redirectRes, 'body', {
+      get() { return { cancel: cancelSpy } as unknown as ReadableStream; },
+    });
+
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(redirectRes)
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    await safeFetch('https://adrianwedd.com/x.jpg', {}, isAllowedMediaUrl);
+    expect(cancelSpy).toHaveBeenCalled();
+  });
+
+  // Codex Low: an allowlisted cross-origin redirect would forward Authorization
+  // / Cookie / Proxy-Authorization headers, smuggling bearer tokens to a
+  // different host. safeFetch strips those on origin change.
+  it('strips Authorization on cross-origin redirect', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, {
+        status: 302,
+        // adrianwedd.com -> cdn.adrianwedd.com (different origin, both allowlisted)
+        headers: { Location: 'https://cdn.adrianwedd.com/redir.jpg' },
+      }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    await safeFetch('https://adrianwedd.com/og.jpg', {
+      headers: { Authorization: 'Bearer secret', Cookie: 'sess=abc', 'X-Trace': 'keep' },
+    }, isAllowedMediaUrl);
+
+    // First call: original headers preserved
+    const firstHeaders = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
+    expect(firstHeaders.get('Authorization')).toBe('Bearer secret');
+    expect(firstHeaders.get('Cookie')).toBe('sess=abc');
+
+    // Second call: sensitive headers stripped, non-sensitive headers survive
+    const secondHeaders = new Headers((fetchSpy.mock.calls[1][1] as RequestInit).headers);
+    expect(secondHeaders.get('Authorization')).toBeNull();
+    expect(secondHeaders.get('Cookie')).toBeNull();
+    expect(secondHeaders.get('X-Trace')).toBe('keep');
+  });
+
+  it('keeps Authorization on same-origin redirect', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, {
+        status: 302,
+        headers: { Location: 'https://cdn.adrianwedd.com/path-b.jpg' },
+      }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    await safeFetch('https://cdn.adrianwedd.com/path-a.jpg', {
+      headers: { Authorization: 'Bearer keep-me' },
+    }, isAllowedMediaUrl);
+
+    const secondHeaders = new Headers((fetchSpy.mock.calls[1][1] as RequestInit).headers);
+    expect(secondHeaders.get('Authorization')).toBe('Bearer keep-me');
+  });
+});
+
+describe('readBoundedArrayBuffer', () => {
+  it('returns the buffer when the body fits the cap', async () => {
+    const res = new Response(new Uint8Array([1, 2, 3, 4]).buffer, { status: 200 });
+    const buf = await readBoundedArrayBuffer(res, 1024);
+    expect(buf).not.toBeNull();
+    expect(new Uint8Array(buf!).length).toBe(4);
+  });
+
+  // Hermes Medium: the cap-exceeded path is critical for memory safety but
+  // had zero direct unit tests. This verifies the streaming reader bails
+  // when the cumulative byte count exceeds maxBytes, regardless of whether
+  // the origin honoured Content-Length.
+  it('returns null and cancels the reader when the cap is exceeded', async () => {
+    const cancelSpy = vi.fn().mockResolvedValue(undefined);
+    let chunkIdx = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (chunkIdx >= 10) { controller.close(); return; }
+        // 10 chunks of 200 bytes each = 2000 bytes total; cap at 500 → bail at chunk 3
+        controller.enqueue(new Uint8Array(200));
+        chunkIdx++;
+      },
+      cancel: cancelSpy,
+    });
+    const res = new Response(stream, { status: 200 });
+    const buf = await readBoundedArrayBuffer(res, 500);
+    expect(buf).toBeNull();
+    // Reader is cancelled when we exceed the cap so the underlying stream is closed.
+    // The exact cancel-call count depends on stream internals; just assert it fired.
+    expect(chunkIdx).toBeLessThan(10);
+  });
+
+  it('falls back to arrayBuffer when the response has no body, still bounded', async () => {
+    // HEAD responses or some Workers runtime responses can have no body stream.
+    const res = new Response('hello', { status: 200 });
+    Object.defineProperty(res, 'body', { value: null });
+    const buf = await readBoundedArrayBuffer(res, 1024);
+    expect(buf).not.toBeNull();
+    const oversized = new Response(new Uint8Array(2048).buffer, { status: 200 });
+    Object.defineProperty(oversized, 'body', { value: null });
+    const big = await readBoundedArrayBuffer(oversized, 1024);
+    expect(big).toBeNull();
   });
 });

--- a/worker/src/__tests__/twitter.test.ts
+++ b/worker/src/__tests__/twitter.test.ts
@@ -35,12 +35,10 @@ describe('Twitter publishPost — response classification', () => {
   });
 
   // C5 — Twitter v2 returns 403 for content violations (duplicate tweet, blocked
-  // target, content moderation, missing scope, etc.). Classifying those as
-  // isAuthError causes the cron to halt the run AND re-queue the post — next
-  // tick the same 403 fires again, creating an infinite poison pill that
-  // permanently blocks all subsequent posts. 403 must be a per-post permanent
-  // failure so the cron continues and the post moves to post:failed:.
-  it('treats 403 as permanent non-auth failure (not a poison pill)', async () => {
+  // target, content moderation). Those must be per-post permanent failures so
+  // the cron continues — marking them isAuthError would halt the run and
+  // re-queue the post, creating an infinite poison-pill loop.
+  it('treats 403 content/duplicate as permanent non-auth failure', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(
       JSON.stringify({ title: 'Forbidden', detail: 'Duplicate content' }),
       { status: 403 },
@@ -50,6 +48,25 @@ describe('Twitter publishPost — response classification', () => {
     expect(result.isAuthError).toBe(false); // <-- the critical assertion
     expect(result.isTransient).toBe(false);
     expect(result.error).toContain('403');
+  });
+
+  // Codex/gemini/hermes High follow-up to C5: blanket "403 = permanent" loses
+  // the operator signal for missing-scope / locked-account cases. The classifier
+  // parses the v2 problem body and flags auth-shaped 403s as isAuthError so
+  // the cron halts for manual attention.
+  it.each([
+    ['oauth1-permissions',          'https://api.twitter.com/2/problems/oauth1-permissions'],
+    ['client-not-enrolled',         'https://api.twitter.com/2/problems/client-not-enrolled'],
+    ['unsupported authentication',  'Unsupported Authentication: cannot use OAuth1 with this endpoint'],
+    ['write permissions',           'Your app does not have write permissions'],
+    ['not permitted to perform',    'You are not permitted to perform this action'],
+    ['your account is temporarily', 'Your account is temporarily locked'],
+    ['app is suspended',            'This app is suspended'],
+  ])('classifies 403 mentioning %s as auth/scope (halts cron)', async (_label, body) => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(body, { status: 403 }));
+    const result = await createTwitterPlatform(creds).publishPost(makePost());
+    expect(result.success).toBe(false);
+    expect(result.isAuthError).toBe(true);
   });
 
   it('treats 429 as transient (retry on next tick)', async () => {

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -1,5 +1,15 @@
+// Constant-time bearer-token verification.
+//
+// The expected/actual values are SHA-256 hashed BEFORE comparison. This:
+//   1. Defeats the timing-side-channel on byte-length (an early-return on
+//      length mismatch would let an attacker probe the secret's length).
+//   2. Equalises compare cost regardless of input length.
+//   3. Keeps the constant-time guarantee of `timingSafeEqual`.
+//
+// Both inputs end up as 32-byte digests, so the length-mismatch branch can
+// no longer fire on attacker-controlled input.
+
 import { timingSafeEqual } from 'node:crypto';
-import { Buffer } from 'node:buffer';
 
 export async function verifyBearer(
   authHeader: string | null,
@@ -8,10 +18,11 @@ export async function verifyBearer(
   if (!authHeader || !expectedSecret) return false;
   if (!authHeader.startsWith('Bearer ')) return false;
 
-  const expected = `Bearer ${expectedSecret}`;
-  const expectedBuf = Buffer.from(expected, 'utf8');
-  const actualBuf = Buffer.from(authHeader, 'utf8');
+  const enc = new TextEncoder();
+  const [expectedDigest, actualDigest] = await Promise.all([
+    crypto.subtle.digest('SHA-256', enc.encode(`Bearer ${expectedSecret}`)),
+    crypto.subtle.digest('SHA-256', enc.encode(authHeader)),
+  ]);
 
-  if (expectedBuf.byteLength !== actualBuf.byteLength) return false;
-  return timingSafeEqual(expectedBuf, actualBuf);
+  return timingSafeEqual(new Uint8Array(expectedDigest), new Uint8Array(actualDigest));
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -33,6 +33,35 @@ function validatePlatform(raw: string | undefined, fallback = 'facebook'): Platf
   return VALID_PLATFORMS.has(name) ? name as Platform : null;
 }
 
+// CronLock DO stub shape. The cast lived in three places before; extracted
+// here so an interface change is a one-line edit.
+type CronLockStub = DurableObjectStub & {
+  tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean; token: string | null }>;
+  release(name: string, token: string): Promise<void>;
+};
+
+function lockStubFor(env: Env, name: string): CronLockStub {
+  return env.CRON_LOCK.get(env.CRON_LOCK.idFromName(name)) as CronLockStub;
+}
+
+// H7 — idempotencyKey is typed as required but had no runtime check. Missing
+// or empty values yielded shared lock/KV names like `publish:undefined` and
+// `idempotent:undefined`, so unrelated authenticated publishes could collide
+// or suppress each other. Reject anything that isn't a non-empty string under
+// 256 bytes (KV keys cap at 512 incl. the prefix, leave headroom for the
+// `idempotent:` prefix + future suffixes).
+function validateIdempotencyKey(key: unknown): string | null {
+  if (typeof key !== 'string') return null;
+  if (key.length === 0 || key.length > 256) return null;
+  // URL-safe alphabet plus common separators (commit hashes, ISO dates, paths
+  // like "blog/foo"). Excludes spaces, control chars, and `..` (the latter is
+  // not exploitable against KV but signals a malformed key — better to reject
+  // and surface the bug than accept a footgun).
+  if (!/^[A-Za-z0-9._:/-]+$/.test(key)) return null;
+  if (key.includes('..')) return null;
+  return key;
+}
+
 // ── POST /api/publish ─────────────────────────────────────────────────────────
 
 app.post('/api/publish', async (c) => {
@@ -57,19 +86,22 @@ app.post('/api/publish', async (c) => {
   const platform = validatePlatform(body.platform);
   if (!platform) return json({ error: `Unsupported platform: ${body.platform}` }, 400);
 
+  const idempotencyKey = validateIdempotencyKey(body.idempotencyKey);
+  if (!idempotencyKey) {
+    return json({ error: 'idempotencyKey must be a non-empty string under 256 chars, URL-safe alphabet' }, 400);
+  }
+
   // Serialise the read-decide-publish sequence per idempotency key via the
   // CronLock DO. Without this, two concurrent forceRetry calls for the same
   // key can both observe the failed record, both delete it, and both publish.
   //
-  // TTL: 60s. Cloudflare Workers cap subrequests at 30s and the whole request
-  // at the per-plan CPU/wall budget — a hung publishPost will be killed long
-  // before the lock expires. No renewal needed.
-  const publishLockName = `publish:${body.idempotencyKey}`;
-  const publishLockStub = env.CRON_LOCK.get(env.CRON_LOCK.idFromName(publishLockName)) as DurableObjectStub & {
-    tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean; token: string | null }>;
-    release(name: string, token: string): Promise<void>;
-  };
-  const { acquired: publishAcquired, token: publishToken } = await publishLockStub.tryAcquire(publishLockName, 60_000);
+  // TTL: 300s (5 minutes). Bluesky video pipeline polls up to 25s + media
+  // fetch + encoding can push close to a minute. The earlier 60s TTL gave a
+  // realistic race window where the lock expired mid-publish and a concurrent
+  // forceRetry could re-enter. Matches the cron-wide lock TTL.
+  const publishLockName = `publish:${idempotencyKey}`;
+  const publishLockStub = lockStubFor(env, publishLockName);
+  const { acquired: publishAcquired, token: publishToken } = await publishLockStub.tryAcquire(publishLockName, 300_000);
   if (!publishAcquired || !publishToken) {
     return json({ error: 'A publish is already in progress for this idempotencyKey' }, 409);
   }
@@ -78,7 +110,7 @@ app.post('/api/publish', async (c) => {
     // Check durable idempotency record. `published` records always block a
     // retry (prevents double-posting); `failed` records can be bypassed with
     // forceRetry.
-    const existingRaw = await env.SOCIAL.get(`idempotent:${body.idempotencyKey}`);
+    const existingRaw = await env.SOCIAL.get(`idempotent:${idempotencyKey}`);
     if (existingRaw) {
       const existing: IdempotencyRecord = JSON.parse(existingRaw);
       if (existing.status === 'published') {
@@ -89,13 +121,13 @@ app.post('/api/publish', async (c) => {
       }
       // forceRetry: clear the failed record so the publish below can proceed
       // and write a fresh idempotency entry on completion.
-      await env.SOCIAL.delete(`idempotent:${body.idempotencyKey}`);
+      await env.SOCIAL.delete(`idempotent:${idempotencyKey}`);
     }
 
     const adapter = createPlatform(platform, env);
 
     const post: SocialPost = {
-      id: body.idempotencyKey,
+      id: idempotencyKey,
       platform,
       type: body.type as SocialPost['type'],
       message: body.message,
@@ -114,16 +146,18 @@ app.post('/api/publish', async (c) => {
 
     const result = await adapter.publishPost(post);
 
-    // Write durable idempotency record (30-day TTL)
+    // Write durable idempotency record. H5: failed records carry a shorter
+    // (7d) TTL than published (30d) so a misclassified transient error
+    // auto-expires instead of blocking the post for a month.
     const record: IdempotencyRecord = {
-      key: body.idempotencyKey,
+      key: idempotencyKey,
       status: result.success ? 'published' : 'failed',
       platformPostId: result.platformPostId ?? null,
       completedAt: new Date().toISOString(),
       error: result.error ?? null,
     };
-    await env.SOCIAL.put(`idempotent:${body.idempotencyKey}`, JSON.stringify(record), {
-      expirationTtl: 30 * 24 * 60 * 60,
+    await env.SOCIAL.put(`idempotent:${idempotencyKey}`, JSON.stringify(record), {
+      expirationTtl: result.success ? 30 * 24 * 60 * 60 : 7 * 24 * 60 * 60,
     });
 
     if (result.success) {
@@ -133,7 +167,9 @@ app.post('/api/publish', async (c) => {
     const status = result.isAuthError ? 503 : result.isTransient ? 502 : 422;
     return json({ published: false, error: result.error, isTransient: result.isTransient }, status);
   } finally {
-    await publishLockStub.release(publishLockName, publishToken);
+    await publishLockStub.release(publishLockName, publishToken).catch(e =>
+      console.error(`Publish lock release failed for ${idempotencyKey}: ${e instanceof Error ? e.message : String(e)}`),
+    );
   }
 });
 
@@ -323,10 +359,7 @@ app.post('/api/cron/publish', async (c) => {
   if (!authOk) return unauthorized();
 
   // Cron lock — atomic via Durable Object (prevents KV TOCTOU race)
-  const lockStub = env.CRON_LOCK.get(env.CRON_LOCK.idFromName('publish')) as DurableObjectStub & {
-    tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean; token: string | null }>;
-    release(name: string, token: string): Promise<void>;
-  };
+  const lockStub = lockStubFor(env, 'publish');
   const { acquired, token: lockToken } = await lockStub.tryAcquire('publish', 300_000);
   if (!acquired || !lockToken) return json({ skipped: true, reason: 'locked' });
 
@@ -378,30 +411,43 @@ app.post('/api/cron/publish', async (c) => {
 
     let published = 0;
     let failed = 0;
+    // Set when the catch block fails to restore queue state. Forces a non-2xx
+    // response so monitoring catches the KV outage instead of seeing 'healthy cron'.
+    let restoreFailures = 0;
+    // Set when a post-success KV write fails. We intentionally leave the
+    // `post:publishing:` orphan in place rather than risk double-publishing.
+    let orphanedAfterSuccess = 0;
 
     for (const { key, post } of processable.slice(0, 5)) {
       // C1 — Per-post publish lock. The cron run and an ad-hoc /api/publish call
       // can race on the same post.id (e.g. a manual retry triggered while cron
-      // is mid-run). /api/publish takes `publish:<idempotencyKey>`; the cron
-      // must take the same lock per-post so both paths serialise against each
-      // other. If the lock is held, skip this post — the holder is publishing it.
+      // is mid-run). /api/publish takes `publish:<idempotencyKey>` where the
+      // caller is REQUIRED to use the post's id as the key when retrying queued
+      // posts (the social-autopublish workflow and CLI `fb-post.sh` both do).
+      // Cron takes `publish:${post.id}`, so both paths serialise on the same DO
+      // instance. If the lock is held, skip — the holder is publishing it.
+      //
+      // TTL: 5 minutes. Bluesky's video pipeline alone polls for up to 25s
+      // (bluesky.ts uploadVideo deadline) plus media fetch + encoding. 60s
+      // gave a realistic race window where the lock could expire mid-publish
+      // and let a concurrent forceRetry double-post. 300s comfortably covers
+      // the worst case and matches the cron-wide lock TTL.
       const perPostLockName = `publish:${post.id}`;
-      const perPostLockStub = env.CRON_LOCK.get(env.CRON_LOCK.idFromName(perPostLockName)) as DurableObjectStub & {
-        tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean; token: string | null }>;
-        release(name: string, token: string): Promise<void>;
-      };
-      const { acquired: perPostAcquired, token: perPostToken } = await perPostLockStub.tryAcquire(perPostLockName, 60_000);
+      const perPostLockStub = lockStubFor(env, perPostLockName);
+      const { acquired: perPostAcquired, token: perPostToken } = await perPostLockStub.tryAcquire(perPostLockName, 300_000);
       if (!perPostAcquired || !perPostToken) {
         console.warn(`Skipping post ${post.id} — concurrent publisher holds per-post lock`);
         continue;
       }
 
-      // C2 — Orphan recovery. Wrap each per-post body in try/catch that restores
-      // `post:queued:` if anything throws between the delete-queued and the
-      // terminal state write. Without this, an unhandled exception in
-      // publishPost (or any KV op) silently drops the post: the queued key is
-      // already gone, the publishing key has no recovery sweep, and the next
-      // cron tick won't see the post.
+      // C2 — Phase-tracked orphan recovery. The catch below restores `post:queued:`
+      // ONLY if the external publish hasn't yet succeeded. Without phase tracking,
+      // a post-success KV write failure (e.g. transient KV outage between
+      // platform.publishPost returning success and `post:published:` write)
+      // would restore the queued key and the next cron tick would re-publish
+      // the same content to the platform — exactly the duplicate the lock was
+      // supposed to prevent. Cross-confirmed by codex/gemini/hermes.
+      let externalPublishSucceeded = false;
       try {
         // Check idempotency
         const existing = await env.SOCIAL.get(`idempotent:${post.id}`);
@@ -416,8 +462,17 @@ app.post('/api/cron/publish', async (c) => {
 
         const postAdapter = createPlatform(post.platform, env);
         const result = await postAdapter.publishPost(post);
+        externalPublishSucceeded = result.success;
 
         if (result.success) {
+          // Write the durable `idempotent:` record FIRST so that even if the
+          // `post:published:` write or the `post:publishing:` cleanup throws,
+          // any subsequent retry sees `alreadyPublished` and bails out.
+          await env.SOCIAL.put(`idempotent:${post.id}`, JSON.stringify({
+            key: post.id, status: 'published',
+            platformPostId: result.platformPostId ?? null,
+            completedAt: new Date().toISOString(), error: null,
+          }), { expirationTtl: 30 * 24 * 60 * 60 });
           const publishedPost: SocialPost = {
             ...post,
             status: 'published',
@@ -429,11 +484,6 @@ app.post('/api/cron/publish', async (c) => {
             JSON.stringify(publishedPost),
             { expirationTtl: 180 * 24 * 60 * 60 },
           );
-          await env.SOCIAL.put(`idempotent:${post.id}`, JSON.stringify({
-            key: post.id, status: 'published',
-            platformPostId: result.platformPostId ?? null,
-            completedAt: new Date().toISOString(), error: null,
-          }), { expirationTtl: 30 * 24 * 60 * 60 });
           await env.SOCIAL.delete(`post:publishing:${post.scheduledAtEpoch}:${post.id}`);
           published++;
         } else if (result.isAuthError) {
@@ -451,27 +501,40 @@ app.post('/api/cron/publish', async (c) => {
         } else {
           const failedPost: SocialPost = { ...post, status: 'failed', error: result.error ?? 'Unknown' };
           await env.SOCIAL.put(`post:failed:${post.id}`, JSON.stringify(failedPost));
+          // H5 — Failed records previously held the queue for 30 days (same TTL
+          // as published records). A misclassified transient error (e.g.
+          // worker treated a rate-limit-adjacent 422 as permanent) blocked any
+          // re-publish for a month without forceRetry. 7d is long enough to
+          // catch the obvious retry attempts but short enough to auto-expire.
           await env.SOCIAL.put(`idempotent:${post.id}`, JSON.stringify({
             key: post.id, status: 'failed',
             platformPostId: null,
             completedAt: new Date().toISOString(), error: result.error ?? 'Unknown',
-          }), { expirationTtl: 30 * 24 * 60 * 60 });
+          }), { expirationTtl: 7 * 24 * 60 * 60 });
           await env.SOCIAL.delete(`post:publishing:${post.scheduledAtEpoch}:${post.id}`);
           failed++;
         }
       } catch (err) {
-        // Orphan recovery: an unhandled exception between delete-queued and
-        // terminal state would silently drop the post. Restore the queue key
-        // so the next cron tick can retry it. Idempotent w.r.t. the early-exit
-        // paths above because those don't throw.
         console.error(`Unhandled error publishing ${post.id}: ${err instanceof Error ? err.message : String(err)}`);
-        try {
-          await env.SOCIAL.put(key, JSON.stringify({ ...post, status: 'queued' }));
-          await env.SOCIAL.delete(`post:publishing:${post.scheduledAtEpoch}:${post.id}`);
-        } catch (restoreErr) {
-          // KV restore itself failed — best-effort log; the publishing-key sweep
-          // (if added later) is the backstop.
-          console.error(`Post-restore failed for ${post.id}: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}`);
+        if (externalPublishSucceeded) {
+          // The external publish ALREADY HAPPENED. Restoring the queued key
+          // would cause the next cron tick to publish the same content again
+          // (the `idempotent:` write may also have failed, so we can't rely on
+          // that to dedupe). Leave the `post:publishing:` key as an orphan;
+          // a future recovery sweep can reconcile it from the platform's API.
+          // Bumping `orphanedAfterSuccess` flips the response to 500 so this
+          // doesn't silently look like a healthy cron run.
+          orphanedAfterSuccess++;
+          console.error(`Post ${post.id} published externally but state persistence failed — leaving publishing key for manual reconciliation`);
+        } else {
+          // Pre-publish failure — safe to restore queued state for retry.
+          try {
+            await env.SOCIAL.put(key, JSON.stringify({ ...post, status: 'queued' }));
+            await env.SOCIAL.delete(`post:publishing:${post.scheduledAtEpoch}:${post.id}`);
+          } catch (restoreErr) {
+            restoreFailures++;
+            console.error(`Post-restore failed for ${post.id}: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}`);
+          }
         }
         // Don't rethrow — let the loop continue with subsequent posts. The
         // outer try/finally will still release the cron-wide lock.
@@ -486,9 +549,20 @@ app.post('/api/cron/publish', async (c) => {
     if (remaining > 10) console.error(`Post queue backlog: ${remaining}`);
     else if (remaining > 0) console.warn(`${remaining} posts still queued`);
 
-    return json({ published, failed, remaining, tokenExpiresInDays: tokenExpiryByPlatform });
+    // Surface infrastructure failures as 5xx so monitoring catches them.
+    // restoreFailures = catch-path KV write failed (post is lost).
+    // orphanedAfterSuccess = external publish succeeded but state persistence
+    // failed (intentionally not retried to avoid double-publish; needs
+    // manual reconciliation of the `post:publishing:` orphan).
+    const responseBody = { published, failed, remaining, tokenExpiresInDays: tokenExpiryByPlatform, restoreFailures, orphanedAfterSuccess };
+    if (restoreFailures > 0 || orphanedAfterSuccess > 0) {
+      return json(responseBody, 500);
+    }
+    return json(responseBody);
   } finally {
-    await lockStub.release('publish', lockToken);
+    await lockStub.release('publish', lockToken).catch(e =>
+      console.error(`Cron publish lock release failed: ${e instanceof Error ? e.message : String(e)}`),
+    );
   }
 });
 
@@ -499,10 +573,7 @@ app.post('/api/cron/comments', async (c) => {
   const authOk = await verifyBearer(c.req.header('Authorization') ?? null, env.CRON_SECRET);
   if (!authOk) return unauthorized();
 
-  const commentsLockStub = env.CRON_LOCK.get(env.CRON_LOCK.idFromName('comments')) as DurableObjectStub & {
-    tryAcquire(name: string, ttlMs: number): Promise<{ acquired: boolean; token: string | null }>;
-    release(name: string, token: string): Promise<void>;
-  };
+  const commentsLockStub = lockStubFor(env, 'comments');
   const { acquired: commentsAcquired, token: commentsToken } = await commentsLockStub.tryAcquire('comments', 300_000);
   if (!commentsAcquired || !commentsToken) return json({ skipped: true, reason: 'locked' });
 
@@ -528,7 +599,9 @@ app.post('/api/cron/comments', async (c) => {
     const fbResult = platformResults.facebook as Record<string, unknown> | undefined;
     return json({ ...fbResult, platforms: platformResults });
   } finally {
-    await commentsLockStub.release('comments', commentsToken);
+    await commentsLockStub.release('comments', commentsToken).catch(e =>
+      console.error(`Cron comments lock release failed: ${e instanceof Error ? e.message : String(e)}`),
+    );
   }
 });
 

--- a/worker/src/platforms/bluesky.ts
+++ b/worker/src/platforms/bluesky.ts
@@ -5,15 +5,16 @@ import type {
   Comment,
   AuthStatus,
 } from './types';
-import { isAllowedMediaUrl, safeFetch } from './safe-fetch';
+import { isAllowedMediaUrl, safeFetch, readBoundedArrayBuffer } from './safe-fetch';
 
 const BSKY_BASE = 'https://bsky.social/xrpc';
 const MAX_GRAPHEMES = 300;
 
-// Match either ?v=ID, &v=ID (long-form) or youtu.be/ID (short-form). Capture
-// group is whichever matched. Used in both publish (Bluesky embed) and the
-// Astro VideoObject schema; keep in sync with src/pages/{blog,projects}/[...slug].astro.
-const YOUTUBE_ID_REGEX = /(?:[?&]v=|youtu\.be\/)([A-Za-z0-9_-]{6,})/;
+// YouTube IDs are exactly 11 chars from the alphabet [A-Za-z0-9_-]. Match
+// either ?v=ID, &v=ID (long-form) or youtu.be/ID (short-form). Capture group
+// is whichever matched. Used in both publish (Bluesky embed) and the Astro
+// VideoObject schema — keep in sync with src/pages/{blog,projects}/[...slug].astro.
+const YOUTUBE_ID_REGEX = /(?:[?&]v=|youtu\.be\/)([A-Za-z0-9_-]{11})(?:[^A-Za-z0-9_-]|$)/;
 
 interface BskySession {
   did: string;
@@ -67,37 +68,6 @@ function truncateGraphemes(text: string, max: number): string {
   return graphemes.slice(0, max).join('');
 }
 
-
-// Stream a response body and abort once `maxBytes` is exceeded. Returns null
-// if the cap is breached. HEAD-then-GET TOCTOU defence: even if an origin lied
-// about Content-Length on HEAD, the GET cannot inflate the worker beyond cap.
-async function readBoundedArrayBuffer(res: Response, maxBytes: number): Promise<ArrayBuffer | null> {
-  if (!res.body) {
-    const buf = await res.arrayBuffer();
-    return buf.byteLength <= maxBytes ? buf : null;
-  }
-  const reader = res.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    if (!value) continue;
-    total += value.byteLength;
-    if (total > maxBytes) {
-      reader.cancel().catch(() => undefined);
-      return null;
-    }
-    chunks.push(value);
-  }
-  const out = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    out.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return out.buffer;
-}
 
 async function uploadVideo(session: BskySession, videoUrl: string): Promise<unknown | null> {
   if (!isAllowedMediaUrl(videoUrl)) return null;

--- a/worker/src/platforms/safe-fetch.ts
+++ b/worker/src/platforms/safe-fetch.ts
@@ -77,20 +77,53 @@ export interface SafeFetchResult {
   blockedReason?: string;
 }
 
+// Header names that MUST NOT survive a cross-origin redirect. Mirrors how
+// well-behaved HTTP clients (curl --location, browser fetch) handle the
+// redirect chain: the credential is scoped to the originally-targeted host.
+// Critical for federated endpoint callers that pass an Authorization header.
+const SENSITIVE_REDIRECT_HEADERS = new Set(['authorization', 'cookie', 'proxy-authorization']);
+
+function stripSensitiveHeaders(init: RequestInit): RequestInit {
+  if (!init.headers) return init;
+  // Normalise to a Headers instance so we hit the same case-insensitive lookup
+  // semantics regardless of which form the caller supplied.
+  const headers = new Headers(init.headers);
+  for (const name of SENSITIVE_REDIRECT_HEADERS) {
+    headers.delete(name);
+  }
+  return { ...init, headers };
+}
+
+// Drain an intermediate 3xx response so Workers' subrequest accounting can
+// reclaim the connection. Without this, a malicious origin can return huge
+// bodies on the redirect responses themselves and stall the worker.
+async function discardBody(res: Response): Promise<void> {
+  if (!res.body) return;
+  try {
+    await res.body.cancel();
+  } catch {
+    /* body may already be locked or consumed — nothing useful to do */
+  }
+}
+
 export async function safeFetch(
   url: string,
   init: RequestInit,
   validator: (url: string) => boolean,
 ): Promise<SafeFetchResult> {
   let current = url;
+  let currentInit = init;
   for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
     if (!validator(current)) {
       return { response: null, finalUrl: current, blockedReason: `validator rejected ${current}` };
     }
-    const res = await fetch(current, { ...init, redirect: 'manual' });
+    const res = await fetch(current, { ...currentInit, redirect: 'manual' });
     // 3xx with Location: walk the redirect ourselves; refuse opaque redirects (no Location)
     if (res.status >= 300 && res.status < 400) {
       const location = res.headers.get('location');
+      // Drain the 3xx body before continuing — a malicious origin can return
+      // a huge body on the redirect response itself to stall the worker.
+      await discardBody(res);
       if (!location) {
         return { response: null, finalUrl: current, blockedReason: 'redirect without Location header' };
       }
@@ -101,10 +134,59 @@ export async function safeFetch(
       } catch {
         return { response: null, finalUrl: current, blockedReason: `invalid redirect Location: ${location}` };
       }
+      // Cross-origin redirect: strip sensitive headers so an allowlisted CDN
+      // hop can't smuggle a bearer token to a different host (even a different
+      // allowlisted one). Same origin: keep the original init so e.g. Range
+      // headers survive.
+      try {
+        const currentOrigin = new URL(current).origin;
+        const nextOrigin = new URL(nextUrl).origin;
+        if (currentOrigin !== nextOrigin) {
+          currentInit = stripSensitiveHeaders(currentInit);
+        }
+      } catch {
+        // The new URL parse already passed above; this is defensive.
+      }
       current = nextUrl;
       continue;
     }
     return { response: res, finalUrl: current };
   }
   return { response: null, finalUrl: current, blockedReason: `exceeded ${MAX_REDIRECT_HOPS} redirect hops` };
+}
+
+// Stream a response body and abort once `maxBytes` is exceeded. Returns null
+// if the cap is breached. HEAD-then-GET TOCTOU defence: even if an origin lied
+// about Content-Length on HEAD, the GET cannot inflate the worker beyond cap.
+//
+// Previously inline in bluesky.ts AND duplicated in twitter.ts. Hoisted here
+// because the cap semantics are part of the safe-fetch contract.
+export async function readBoundedArrayBuffer(res: Response, maxBytes: number): Promise<ArrayBuffer | null> {
+  if (!res.body) {
+    // No streamable body (HEAD response, etc.) — fall back to arrayBuffer with
+    // a hard length check. Still bounded; just less efficient.
+    const buf = await res.arrayBuffer();
+    return buf.byteLength <= maxBytes ? buf : null;
+  }
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      reader.cancel().catch(() => undefined);
+      return null;
+    }
+    chunks.push(value);
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out.buffer;
 }

--- a/worker/src/platforms/twitter.ts
+++ b/worker/src/platforms/twitter.ts
@@ -1,5 +1,5 @@
 import type { SocialPost, SocialPlatform, PublishResult, AuthStatus, Comment } from './types';
-import { isAllowedMediaUrl, safeFetch } from './safe-fetch';
+import { isAllowedMediaUrl, safeFetch, readBoundedArrayBuffer } from './safe-fetch';
 
 // ── OAuth 1.0a ─────────────────────────────────────────────────────────────
 
@@ -73,25 +73,12 @@ async function uploadMedia(imageUrl: string, creds: OAuth1Creds): Promise<string
     // against the allowlist, so an allowlisted CDN URL cannot redirect to a
     // private/metadata endpoint.
     const imgFetch = await safeFetch(imageUrl, {}, isAllowedMediaUrl);
-    if (!imgFetch.response?.ok || !imgFetch.response.body) return null;
-    const reader = imgFetch.response.body.getReader();
-    const chunks: Uint8Array[] = [];
-    let total = 0;
-    while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      if (!value) continue;
-      total += value.byteLength;
-      if (total > TWITTER_MEDIA_CAP_BYTES) {
-        reader.cancel().catch(() => undefined);
-        console.warn(`Twitter media upload exceeded ${TWITTER_MEDIA_CAP_BYTES}-byte cap: ${imageUrl}`);
-        return null;
-      }
-      chunks.push(value);
+    if (!imgFetch.response?.ok) return null;
+    const bytes = await readBoundedArrayBuffer(imgFetch.response, TWITTER_MEDIA_CAP_BYTES);
+    if (!bytes) {
+      console.warn(`Twitter media upload exceeded ${TWITTER_MEDIA_CAP_BYTES}-byte cap: ${imageUrl}`);
+      return null;
     }
-    const bytes = new Uint8Array(total);
-    let offset = 0;
-    for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength; }
     const contentType = imgFetch.response.headers.get('content-type') || 'image/jpeg';
 
     // Multipart body is excluded from OAuth signature base (RFC 5849 §3.4.1.3)
@@ -155,16 +142,37 @@ export function createTwitterPlatform(creds: OAuth1Creds): SocialPlatform {
           return { success: false, error: 'HTTP 401', isTransient: false, isAuthError: true };
         }
         if (res.status === 403) {
-          // 403 from Twitter v2 means "your credentials are valid but this action
-          // is forbidden" — duplicate tweet, content moderation, blocked target,
-          // missing write scope on the token, etc. Classifying as auth error here
-          // would halt the entire cron run and re-queue the post, creating an
-          // infinite-loop poison pill (next tick: same post, same 403, same halt).
-          // Treat as a permanent per-post failure so the cron continues and the
-          // post moves to post:failed:.
+          // 403 from Twitter v2 conflates two very different problems:
+          //   (a) content / policy — duplicate tweet, blocked recipient,
+          //       content moderation, link blocked. Per-post permanent;
+          //       the cron should continue and move the post to post:failed:.
+          //       Marking these isAuthError would halt the run and re-queue,
+          //       creating an infinite poison pill (next tick: same 403).
+          //   (b) account / scope — token missing `tweet:write`, app
+          //       permissions downgraded, account temporarily restricted.
+          //       Need operator attention; halt is the correct response.
+          //
+          // Twitter v2 returns JSON whose `title`/`detail`/`type` distinguish
+          // these. Twitter doesn't publish stable error codes, so we substring
+          // match common phrasings. Cross-confirmed by codex/gemini/hermes.
           const errText = await res.text().catch(() => '');
-          console.error(`Twitter publish forbidden (HTTP 403): ${errText.slice(0, 200)}`);
-          return { success: false, error: `HTTP 403: ${errText.slice(0, 200)}`, isTransient: false, isAuthError: false };
+          const lower = errText.toLowerCase();
+          const looksLikeAuth = (
+            lower.includes('oauth1-permissions') ||          // v2 problem URL fragment
+            lower.includes('client-not-enrolled') ||         // missing API access tier
+            lower.includes('unsupported authentication') ||
+            lower.includes('write permissions') ||
+            lower.includes('not permitted to perform') ||
+            lower.includes('your account is temporarily') || // account restriction
+            lower.includes('app is suspended')
+          );
+          console.error(`Twitter publish forbidden (HTTP 403, ${looksLikeAuth ? 'auth/scope' : 'content/policy'}): ${errText.slice(0, 200)}`);
+          return {
+            success: false,
+            error: `HTTP 403: ${errText.slice(0, 200)}`,
+            isTransient: false,
+            isAuthError: looksLikeAuth,
+          };
         }
         if (res.status === 429 || res.status >= 500) {
           return { success: false, error: `HTTP ${res.status}`, isTransient: true, isAuthError: false };


### PR DESCRIPTION
## Summary

Stacks on top of #360. Closes the 5 worker-side Highs from the initial QA report, plus the Critical/High findings the multi-engine review (codex + gemini + hermes) raised against #360 itself.

> **Base branch is `fix/worker-criticals-c1-c5` (PR #360).** Will rebase onto main once #360 merges.

## Highs (originally identified)

| ID | Finding | Fix |
|----|---------|-----|
| **H1** | Per-post lock TTL 60s < Bluesky video pipeline (25s poll + media upload) | TTL → 300s (matches cron-wide lock) |
| **H2** | `verifyBearer` length leak via early return before `timingSafeEqual` | SHA-256 hash both sides first; length branch never fires on attacker input |
| **H5** | Failed-idempotency 30d TTL blocked misclassified posts for a month | TTL → 7d for failed, 30d retained for published |
| **H7** | `idempotencyKey` not validated at runtime | URL-safe alphabet, ≤256 chars, no `..` |
| **H9** | `/api/cron/comments` had zero route tests | +5 tests (auth, lock-held, multi-platform, expired-token skip, finally release) |

## Folded from multi-engine PR-QA on #360

| Sev | Engine | Fix |
|-----|--------|-----|
| 🔴 | codex/gemini/hermes | **Phase-tracked orphan recovery.** Pre-fix, the C2 catch blindly restored `post:queued:` even on post-publishPost-success KV failures → next cron tick republishes. Now tracks `externalPublishSucceeded`; orphan `post:publishing:` left for manual reconciliation; 500 response surfaces the infra failure. |
| 🟠 | codex/gemini/hermes | **Twitter 403 finer classification.** C5's blanket "403 = permanent" lost operator signal for missing-scope / locked-account cases. Now parses v2 problem body, flags auth-shaped 403s (oauth1-permissions, client-not-enrolled, unsupported authentication, write permissions, account locked, app suspended) as `isAuthError` while keeping content/duplicate 403s as per-post permanent failures. |
| 🟠 | codex/hermes | **safeFetch sensitive-header stripping** on cross-origin redirect (Authorization, Cookie, Proxy-Authorization) — same behaviour as curl --location. **Intermediate 3xx bodies cancelled** before next hop to defend against stall-via-large-3xx-body. |
| 🟡 | hermes | `YOUTUBE_ID_REGEX` `{6,}` → `{11}` with non-id-char boundary. |
| 🟡 | hermes | `readBoundedArrayBuffer` DRY'd into `safe-fetch.ts` (was inline in bluesky.ts + separate inline loop in twitter.ts). |
| 🟡 | hermes | `lockStubFor` helper extracts the `CronLockStub` cast that was duplicated 3×. |
| 🟡 | codex | Cron returns 500 (not 200) when orphan-recovery flips `orphanedAfterSuccess`/`restoreFailures` so monitoring catches infra failures. |

## Tests

+29 new (156 total, all green). New coverage:
- `auth.test.ts`: SHA-256 normalisation (1-char vs 1000-char inputs both reach the constant-time compare), Unicode-secret round-trip
- `safe-fetch.test.ts`: encoded IP literal rejection (hex/decimal/IPv6), redirect body cancellation, cross-origin Authorization strip, same-origin Authorization preservation, `readBoundedArrayBuffer` cap-exceeded path, no-body fallback path
- `twitter.test.ts`: 7-case `it.each` for auth-shaped 403 patterns + content-shape negative case
- `publish.test.ts`: **post-success KV failure does not requeue (no double-publish)** ← the codex/gemini/hermes-flagged bug, plus 7-case `it.each` for idempotencyKey validation, and 5 `/api/cron/comments` tests

`npx wrangler deploy --dry-run` clean.

## Test plan

- [ ] CI green
- [ ] After merge, smoke a known content/duplicate 403 path on Twitter — confirm post moves to `post:failed:` (not `post:queued:`) and the cron continues
- [ ] Confirm `/api/cron/comments` still returns the legacy top-level keys for backward compat (test covers this implicitly)
- [ ] Verify `verifyBearer` doesn't regress existing auth callers (auth.test.ts coverage is solid)