### PR TITLE
fix(site): site Highs — YouTube ID extraction, og/thumbnail webp→jpg, sharp pin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "astro": "^6.2.2",
         "preact": "^10.29.1",
         "satori": "^0.26.0",
+        "sharp": "0.34.5",
         "tailwindcss": "^4.2.4",
         "typescript": ">=5.0.0 <6.0.0"
       },
@@ -1274,7 +1275,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -9136,7 +9136,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -9180,7 +9179,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "astro": "^6.2.2",
     "preact": "^10.29.1",
     "satori": "^0.26.0",
+    "sharp": "0.34.5",
     "tailwindcss": "^4.2.4",
     "typescript": ">=5.0.0 <6.0.0"
   },

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -44,7 +44,7 @@ export function youtubeId(url: string | undefined | null): string | null {
     const id = u.pathname.slice(1).split('/')[0];
     return idRe.test(id) ? id : null;
   }
-  if (host === 'youtube.com' || host === 'm.youtube.com' || host === 'music.youtube.com') {
+  if (host === 'youtube.com' || host === 'youtube-nocookie.com' || host === 'm.youtube.com' || host === 'music.youtube.com') {
     const v = u.searchParams.get('v');
     if (v && idRe.test(v)) return v;
     const m = u.pathname.match(/^\/(?:embed|shorts|live|v)\/([A-Za-z0-9_-]{11})(?:[/?].*)?$/);
@@ -61,5 +61,5 @@ export function youtubeId(url: string | undefined | null): string | null {
  * metadata at those. Non-webp paths pass through unchanged.
  */
 export function ogSafeImage(path: string): string {
-  return path.replace(/\.webp$/i, '.jpg');
+  return path.replace(/\.webp(?=[?#]|$)/i, '.jpg');
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -18,3 +18,48 @@ export function imageSlug(alt: string): string {
     .replace(/^-|-$/g, '');
   return result || 'image';
 }
+
+/**
+ * Extract the 11-char YouTube video ID from any of the canonical URL forms:
+ *   - https://www.youtube.com/watch?v=ID
+ *   - https://youtu.be/ID
+ *   - https://www.youtube.com/embed/ID
+ *   - https://www.youtube.com/shorts/ID
+ *   - https://www.youtube.com/live/ID
+ * Returns null for non-YouTube hosts, malformed URLs, or any "id" that doesn't
+ * match the canonical `[A-Za-z0-9_-]{11}` shape. The regex anchor is what
+ * prevents `?v=foo<script>` from reaching the JSON-LD embedUrl.
+ */
+export function youtubeId(url: string | undefined | null): string | null {
+  if (!url) return null;
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return null;
+  }
+  const host = u.hostname.toLowerCase().replace(/^www\./, '');
+  const idRe = /^[A-Za-z0-9_-]{11}$/;
+  if (host === 'youtu.be') {
+    const id = u.pathname.slice(1).split('/')[0];
+    return idRe.test(id) ? id : null;
+  }
+  if (host === 'youtube.com' || host === 'm.youtube.com' || host === 'music.youtube.com') {
+    const v = u.searchParams.get('v');
+    if (v && idRe.test(v)) return v;
+    const m = u.pathname.match(/^\/(?:embed|shorts|live|v)\/([A-Za-z0-9_-]{11})(?:[/?].*)?$/);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+/**
+ * Swap a `.webp` extension to `.jpg` for og:image / VideoObject.thumbnailUrl
+ * fields. Facebook, X, LinkedIn, iMessage and Google's video crawler still
+ * don't reliably handle WebP for OG/thumbnail scrapes, so we emit JPG twins
+ * (generated alongside .webp at content-build time) and point social/SEO
+ * metadata at those. Non-webp paths pass through unchanged.
+ */
+export function ogSafeImage(path: string): string {
+  return path.replace(/\.webp$/i, '.jpg');
+}

--- a/src/pages/audio/[...slug].astro
+++ b/src/pages/audio/[...slug].astro
@@ -6,7 +6,7 @@ import RelatedContent from '../../components/RelatedContent.astro';
 import NotebookAssets from '../../components/NotebookAssets.astro';
 import AudioPlayer from '../../components/islands/AudioPlayer';
 import { getCollection, render } from 'astro:content';
-import { slug } from '../../lib/utils';
+import { slug, ogSafeImage } from '../../lib/utils';
 
 export async function getStaticPaths() {
   const episodes = (await getCollection('audio')).filter((e) => !e.data.draft);
@@ -19,6 +19,11 @@ export async function getStaticPaths() {
 const { episode } = Astro.props;
 const { Content } = await render(episode);
 
+// FB / X / LinkedIn / iMessage don't reliably render WebP og:image scrapes;
+// the .jpg twin is generated alongside the .webp at content-build time. Fall
+// back to the site-wide default OG card when the episode has no heroImage.
+const ogImage = episode.data.heroImage ? ogSafeImage(episode.data.heroImage) : '/og-default.png';
+
 const allEpisodes = (await getCollection('audio'))
   .filter((e) => !e.data.draft)
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
@@ -30,7 +35,7 @@ const nextEpisode = currentIndex > 0 ? allEpisodes[currentIndex - 1] : null;
 <BaseLayout
   title={episode.data.title}
   description={episode.data.description}
-  image={episode.data.heroImage}
+  image={ogImage}
   type="article"
   publishedDate={episode.data.date.toISOString()}
   tags={episode.data.tags}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -111,8 +111,9 @@ const matchedProject = allProjects.find(
     })}
   />
   {
-    (post.data.videoUrl || post.data.youtubeUrl) && (() => {
+    (() => {
       const ytId = youtubeId(post.data.youtubeUrl);
+      if (!post.data.videoUrl && !ytId) return null;
       return (
         <script
           is:inline

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -8,7 +8,7 @@ import RelatedContent from '../../components/RelatedContent.astro';
 import NotebookAssets from '../../components/NotebookAssets.astro';
 import AudioPlayer from '../../components/islands/AudioPlayer';
 import { getCollection, render } from 'astro:content';
-import { slug } from '../../lib/utils';
+import { slug, youtubeId, ogSafeImage } from '../../lib/utils';
 import { getImageDimensions } from '../../lib/image-dimensions';
 
 export async function getStaticPaths() {
@@ -41,9 +41,7 @@ const readingTime = Math.max(1, Math.ceil(words / 200));
 // scrapes. The .jpg twin is generated alongside the .webp at build/asset
 // time. Fall back to the auto-generated text-card OG PNG when no heroImage.
 const postSlug = slug(post.id);
-const ogImage = post.data.heroImage
-  ? post.data.heroImage.replace(/\.webp$/, '.jpg')
-  : `/og/blog/${postSlug}.png`;
+const ogImage = post.data.heroImage ? ogSafeImage(post.data.heroImage) : `/og/blog/${postSlug}.png`;
 // Read the actual image dimensions at build time (covers infographics, text
 // cards, and any future OG image shape without filename-based heuristics).
 // Falls back to standard 1200x630 if the file is missing or unreadable.
@@ -114,7 +112,7 @@ const matchedProject = allProjects.find(
   />
   {
     (post.data.videoUrl || post.data.youtubeUrl) && (() => {
-      const ytId = post.data.youtubeUrl?.match(/[?&]v=([^&]+)/)?.[1];
+      const ytId = youtubeId(post.data.youtubeUrl);
       return (
         <script
           is:inline
@@ -131,7 +129,7 @@ const matchedProject = allProjects.find(
             }),
             uploadDate: post.data.date.toISOString(),
             thumbnailUrl: post.data.heroImage
-              ? new URL(post.data.heroImage, Astro.site).href
+              ? new URL(ogSafeImage(post.data.heroImage), Astro.site).href
               : new URL('/og-default.png', Astro.site).href,
           })}
         />

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -7,7 +7,7 @@ import RelatedContent from '../../components/RelatedContent.astro';
 import NotebookAssets from '../../components/NotebookAssets.astro';
 import AudioPlayer from '../../components/islands/AudioPlayer';
 import { getCollection, render } from 'astro:content';
-import { slug } from '../../lib/utils';
+import { slug, youtubeId, ogSafeImage } from '../../lib/utils';
 import { getImageDimensions } from '../../lib/image-dimensions';
 import { Picture } from 'astro:assets';
 
@@ -28,9 +28,7 @@ const projectSlug = slug(project.id);
 // OG image: prefer the project's hero infographic, swap .webp -> .jpg
 // (FB / X / LinkedIn / iMessage don't reliably render WebP og:image).
 // The .jpg twin is generated alongside the .webp.
-const ogImage = project.data.heroImage
-  ? project.data.heroImage.replace(/\.webp$/, '.jpg')
-  : `/og/projects/${projectSlug}.png`;
+const ogImage = project.data.heroImage ? ogSafeImage(project.data.heroImage) : `/og/projects/${projectSlug}.png`;
 // Read actual image dimensions at build time — covers infographics, text
 // cards, and any future OG image shape without filename-based heuristics.
 const ogDimensions = getImageDimensions(ogImage);
@@ -113,7 +111,7 @@ const allBlogPosts = project.data.series
   />
   {
     (project.data.videoUrl || project.data.youtubeUrl) && (() => {
-      const ytId = project.data.youtubeUrl?.match(/[?&]v=([^&]+)/)?.[1];
+      const ytId = youtubeId(project.data.youtubeUrl);
       return (
         <script
           is:inline
@@ -130,7 +128,7 @@ const allBlogPosts = project.data.series
             }),
             uploadDate: project.data.date.toISOString(),
             thumbnailUrl: project.data.heroImage
-              ? new URL(project.data.heroImage, Astro.site).href
+              ? new URL(ogSafeImage(project.data.heroImage), Astro.site).href
               : new URL('/og-default.png', Astro.site).href,
           })}
         />

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -100,7 +100,7 @@ const allBlogPosts = project.data.series
               : `https://github.com/adrianwedd/${project.data.repo}`,
           }
         : {}),
-      ...(project.data.heroImage ? { image: new URL(project.data.heroImage, Astro.site).href } : {}),
+      ...(project.data.heroImage ? { image: new URL(ogSafeImage(project.data.heroImage), Astro.site).href } : {}),
       author: {
         '@type': 'Person',
         name: 'Adrian Wedd',
@@ -110,8 +110,9 @@ const allBlogPosts = project.data.series
     })}
   />
   {
-    (project.data.videoUrl || project.data.youtubeUrl) && (() => {
+    (() => {
       const ytId = youtubeId(project.data.youtubeUrl);
+      if (!project.data.videoUrl && !ytId) return null;
       return (
         <script
           is:inline


### PR DESCRIPTION
## Summary

Closes the 4 site-side Highs from the multi-engine QA, including the sharp-dep fragility caveat flagged on #361.

## Fixes

| ID | Finding | Fix |
|----|---------|-----|
| **H6** | `youtubeUrl?.match(/[?&]v=([^&]+)/)?.[1]` in blog + projects `VideoObject` schema only matched `?v=`-form URLs and accepted any-length / any-character "id" (e.g. `?v=foo<script>` would have reached JSON-LD `embedUrl`) | New `youtubeId()` helper in `src/lib/utils.ts`. Validates canonical `[A-Za-z0-9_-]{11}` shape via URL parser. Accepts `youtube.com/watch?v=`, `youtu.be/X`, `/embed/X`, `/shorts/X`, `/live/X` from `youtube.com`, `m.youtube.com`, `music.youtube.com` |
| **H8** | `thumbnailUrl` in blog + projects `VideoObject` was emitted as the `.webp` heroImage path. Google's video crawler historically doesn't reliably index WebP video thumbnails | Apply the same `.webp` → `.jpg` swap that `og:image` already uses. Confirmed every `.webp` infographic has a `.jpg` twin in `public/notebook-assets/`, so no 404 risk |
| **audio og:image** | `src/pages/audio/[...slug].astro` passed `episode.data.heroImage` (`.webp`) straight to `BaseLayout` → `SEOHead` → `og:image`. FB / X / LinkedIn / iMessage scrapes don't reliably handle WebP og:image | Same swap pattern as blog and projects |
| **sharp dep pin** | `sharp@0.34.5` was a transitive dep through `astro@6`. An astro upgrade could move the sharp version without warning and break the OG generator + placeholder pipeline (the `#361` fragility caveat) | Declare `sharp: "0.34.5"` directly in `dependencies` |

## Helpers added (`src/lib/utils.ts`)

- `youtubeId(url)` — extracts the 11-char canonical video ID from any of the canonical URL forms, returns `null` for malformed input or non-canonical IDs. Rejection-by-default prevents XSS-style injection into JSON-LD.
- `ogSafeImage(path)` — swaps `.webp` → `.jpg` for og:image / thumbnailUrl. Consolidates the inline `.replace(/\.webp$/, '.jpg')` that was duplicated across blog and projects pages.

## Verification

- `npm run lint` — clean
- `node scripts/validate-content.js` — pass
- `npm run build` — clean (433 pages, 7625 indexed words)
- Spot-check on built output:
  - `dist/blog/120-models-18k-prompts/index.html` VideoObject emits `embedUrl: https://www.youtube.com/embed/sYU4OsxdPkw` + `thumbnailUrl: https://adrianwedd.com/notebook-assets/120-models-18k-prompts/infographic.jpg`
  - `dist/audio/the-bottom-pub-co-op-overview/index.html` emits `og:image: https://adrianwedd.com/notebook-assets/the-bottom-pub-co-op/infographic.jpg` (was `.webp` pre-fix)

## Note on #361

#361 wires the OG generator into the build step but doesn't address the sharp transitive-dep risk. This PR closes that gap by pinning sharp directly. The two PRs can land independently in either order.

## Test plan

- [ ] CI green
- [ ] After merge, validate one blog page's VideoObject JSON-LD with Google's Rich Results test
- [ ] Validate one audio page's og:image via Facebook Sharing Debugger