### PR TITLE
content(audio): audio collection entries + audioDuration for 9 AI safety posts

### DIFF
--- a/src/content/audio/alignment-regression-overview.md
+++ b/src/content/audio/alignment-regression-overview.md
@@ -1,0 +1,14 @@
+---
+title: 'Alignment Regression: Why Smarter AI Makes All AI Less Safe'
+description: 'Reasoning models autonomously jailbreak other AI systems at 97% success rate. Ecosystem safety degrades as individual models improve.'
+date: 2026-03-11
+tags: ['notebooklm', 'ai-safety', 'alignment', 'reasoning', 'jailbreaking', 'research']
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/alignment-regression/audio.mp3'
+duration: '21:36'
+relatedPost: 'alignment-regression-post'
+relatedProject: 'failure-first'
+---
+
+Frontier reasoning models don't just resist jailbreaks — they can generate them. This episode covers the alignment regression paradox: as individual AI models improve, they become increasingly capable of attacking other models, degrading ecosystem-wide safety even as per-model benchmarks improve.
+
+[Read the full research article →](/blog/alignment-regression-post/)

--- a/src/content/audio/compute-is-not-governance-overview.md
+++ b/src/content/audio/compute-is-not-governance-overview.md
@@ -1,0 +1,13 @@
+---
+title: 'Compute Is Not Governance'
+description: "Anthropic's 2028 scenarios document three policy asks. Two are about maintaining compute advantage. That is not a governance strategy."
+date: 2026-05-25
+tags: ['notebooklm', 'ai-safety', 'policy', 'anthropic', 'governance', 'geopolitics']
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/compute-is-not-governance/audio.mp3'
+duration: '21:29'
+relatedPost: 'compute-is-not-governance-post'
+---
+
+Anthropic's May 2026 policy brief argues that U.S. compute advantage is the foundation of democratic AI governance. This episode evaluates that claim — what compute controls can and cannot do, why the CAISI benchmarking methodology is misleading, and what actual AI governance infrastructure would require.
+
+[Read the full article →](/blog/compute-is-not-governance-post/)

--- a/src/content/audio/eight-layers-of-visual-jailbreaks-overview.md
+++ b/src/content/audio/eight-layers-of-visual-jailbreaks-overview.md
@@ -1,0 +1,14 @@
+---
+title: 'Eight Layers of Visual Jailbreaks'
+description: 'ASCII art encoding is largely blocked. But attacks framed as content transcription succeed 62–75% of the time. A map of all eight layers.'
+date: 2026-03-30
+tags: ['notebooklm', 'ai-safety', 'jailbreaking', 'llm', 'multimodal', 'research']
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-layers-of-visual-jailbreaks/audio.mp3'
+duration: '14:04'
+relatedPost: 'eight-layers-of-visual-jailbreaks-post'
+relatedProject: 'failure-first'
+---
+
+Visual jailbreaks don't stop at ASCII art. This episode maps the full taxonomy — from character-encoding tricks to framing and transcription loopholes that still achieve 62–75% success rates against patched models.
+
+[Read the full research article →](/blog/eight-layers-of-visual-jailbreaks-post/)

--- a/src/content/audio/glasswing-buried-number-overview.md
+++ b/src/content/audio/glasswing-buried-number-overview.md
@@ -1,0 +1,13 @@
+---
+title: "Glasswing's Buried Number"
+description: "Anthropic found 10,000 critical vulnerabilities in one month. Fewer than 1% are patched. The announcement buried that figure — and what it means."
+date: 2026-05-25
+tags: ['notebooklm', 'ai-safety', 'security', 'anthropic', 'vulnerability', 'governance']
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/glasswing-buried-number/audio.mp3'
+duration: '21:03'
+relatedPost: 'glasswing-buried-number-post'
+---
+
+Project Glasswing found 10,000+ critical vulnerabilities in one month. The patch rate on formally disclosed bugs is 14.1%. This episode covers the structural gap Glasswing created: AI-accelerated discovery now outpaces human-capacity remediation, and the framing of the announcement worked hard to obscure that.
+
+[Read the full article →](/blog/glasswing-buried-number-post/)

--- a/src/content/audio/moral-formation-isnt-enough-overview.md
+++ b/src/content/audio/moral-formation-isnt-enough-overview.md
@@ -1,0 +1,13 @@
+---
+title: "Moral Formation Isn't Enough"
+description: 'Good values are necessary but not sufficient. What happens to AI ethics when someone is actively trying to break them?'
+date: 2026-05-20
+tags: ['notebooklm', 'ai-safety', 'alignment', 'opinion', 'anthropic', 'llm']
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/moral-formation-isnt-enough/audio.mp3'
+duration: '20:13'
+relatedPost: 'moral-formation-isnt-enough-post'
+---
+
+Constitutional AI and RLHF cultivate values in language models — but targeted adversarial pressure routinely breaks those values. This episode argues that moral formation is a necessary condition for safe AI, not a sufficient one, and explores what a two-track approach (values plus structural constraints) would require.
+
+[Read the full article →](/blog/moral-formation-isnt-enough-post/)

--- a/src/content/audio/reasoning-models-think-themselves-into-trouble-overview.md
+++ b/src/content/audio/reasoning-models-think-themselves-into-trouble-overview.md
@@ -1,0 +1,14 @@
+---
+title: 'Reasoning Models Think Themselves Into Trouble'
+description: 'Frontier reasoning models are 5–20x more vulnerable to adversarial prompts than non-reasoning models. The thinking process itself is the attack surface.'
+date: 2026-03-11
+tags: ['notebooklm', 'ai-safety', 'reasoning', 'llm', 'vulnerability', 'research']
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/reasoning-models-think-themselves-into-trouble/audio.mp3'
+duration: '21:10'
+relatedPost: 'reasoning-models-think-themselves-into-trouble-post'
+relatedProject: 'failure-first'
+---
+
+Extended chain-of-thought reasoning gives models time to work through difficult problems — and time to reason themselves into compliance with harmful requests. This episode covers why reasoning models are substantially more vulnerable to semantic attacks than their non-reasoning counterparts.
+
+[Read the full research article →](/blog/reasoning-models-think-themselves-into-trouble-post/)

--- a/src/content/audio/robot-dogs-security-nightmare-overview.md
+++ b/src/content/audio/robot-dogs-security-nightmare-overview.md
@@ -1,0 +1,14 @@
+---
+title: 'Robot Dogs Are a Security Nightmare — And We Can Prove It'
+description: 'Eight CVEs. A wormable Bluetooth exploit. An encrypted backdoor to Chinese servers. And police departments buying them anyway.'
+date: 2026-05-13
+tags: ['notebooklm', 'ai-safety', 'robotics', 'embodied-ai', 'security', 'research']
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/robot-dogs-security-nightmare/audio.mp3'
+duration: '22:30'
+relatedPost: 'robot-dogs-security-nightmare-post'
+relatedProject: 'failure-first'
+---
+
+Unitree quadruped robots have eight documented CVEs including a wormable Bluetooth command injection vulnerability and an encrypted backdoor communicating with servers in China. This episode covers the full attack surface — and why law enforcement and critical infrastructure operators are deploying them anyway.
+
+[Read the full article →](/blog/robot-dogs-security-nightmare-post/)

--- a/src/content/audio/the-67-percent-wall-overview.md
+++ b/src/content/audio/the-67-percent-wall-overview.md
@@ -1,0 +1,14 @@
+---
+title: 'The 67% Wall: Why Every AI Model Falls to the Same Jailbreak Rate'
+description: 'Five models, four providers, 30B to 671B parameters — all converge at the same broad attack success rate against a public jailbreak corpus.'
+date: 2026-03-28
+tags: ['notebooklm', 'ai-safety', 'jailbreaking', 'llm', 'benchmarking', 'research']
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-67-percent-wall/audio.mp3'
+duration: '19:18'
+relatedPost: 'the-67-percent-wall-post'
+relatedProject: 'failure-first'
+---
+
+Across five frontier models from four providers — GPT-4o, Claude 3.7, Gemini 2.0, Llama 3.3, DeepSeek R1 — the broad attack success rate converges near 67% on a public jailbreak corpus. This episode explores what that convergence means for safety benchmarking and the limits of per-model evaluation.
+
+[Read the full research article →](/blog/the-67-percent-wall-post/)

--- a/src/content/audio/the-thinking-chain-leak-overview.md
+++ b/src/content/audio/the-thinking-chain-leak-overview.md
@@ -1,0 +1,14 @@
+---
+title: 'The Thinking Chain Leak'
+description: 'A reasoning model refused every harmful prompt — but its chain-of-thought generated the content anyway. The output filter worked. The thinking did not.'
+date: 2026-03-28
+tags: ['notebooklm', 'ai-safety', 'reasoning', 'llm', 'vulnerability', 'transparency']
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-thinking-chain-leak/audio.mp3'
+duration: '19:15'
+relatedPost: 'the-thinking-chain-leak-post'
+relatedProject: 'failure-first'
+---
+
+Output filters can refuse a harmful completion while the internal thinking trace generates the content in full. This episode covers the thinking chain leak: a structural gap between what a model says and what it thinks, visible in API logs and exploitable at scale.
+
+[Read the full research article →](/blog/the-thinking-chain-leak-post/)

--- a/src/content/blog/alignment-regression-post.md
+++ b/src/content/blog/alignment-regression-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'alignment', 'reasoning', 'jailbreaking', 'llm', 'autonomous
 draft: false
 heroImage: '/notebook-assets/alignment-regression/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/alignment-regression/audio.mp3'
+audioDuration: '21:36'
 ---
 
 We have been operating under a reasonable-sounding assumption: as AI models improve, safety improves with them. Better reasoning, better alignment. More capable models, more capable guardrails.

--- a/src/content/blog/eight-layers-of-visual-jailbreaks-post.md
+++ b/src/content/blog/eight-layers-of-visual-jailbreaks-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'research', 'jailbreaking', 'llm', 'multimodal', 'vulnerabil
 draft: false
 heroImage: '/notebook-assets/eight-layers-of-visual-jailbreaks/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-layers-of-visual-jailbreaks/audio.mp3'
+audioDuration: '14:04'
 ---
 
 In early 2024, researchers at the University of Washington showed you could bypass every major AI safety system by hiding harmful keywords in ASCII art. The technique — [ArtPrompt](https://arxiv.org/abs/2402.11753) — worked against GPT-4, Claude, Gemini, and Llama-2. Hide "COUNTERFEIT" inside a grid of block characters, and the model would decode it and follow the embedded instruction without triggering a single safety filter.

--- a/src/content/blog/moral-formation-isnt-enough-post.md
+++ b/src/content/blog/moral-formation-isnt-enough-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'alignment', 'research', 'opinion', 'anthropic', 'llm']
 draft: false
 heroImage: '/notebook-assets/moral-formation-isnt-enough/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/moral-formation-isnt-enough/audio.mp3'
+audioDuration: '20:13'
 ---
 
 Anthropic published something important this week. In *Widening the Conversation on Frontier AI*, they describe an initiative to bring religious scholars, ethicists, and philosophers into structured dialogue about how AI systems develop character — how values get *in*. They even ran a concrete experiment: giving Claude access to an "ethical reminder tool" during decision-making, which measurably reduced misaligned behaviour in internal evaluations.

--- a/src/content/blog/reasoning-models-think-themselves-into-trouble-post.md
+++ b/src/content/blog/reasoning-models-think-themselves-into-trouble-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'research', 'reasoning', 'llm', 'vulnerability', 'benchmarki
 draft: false
 heroImage: '/notebook-assets/reasoning-models-think-themselves-into-trouble/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/reasoning-models-think-themselves-into-trouble/audio.mp3'
+audioDuration: '21:10'
 ---
 
 There is an uncomfortable pattern in our data. After evaluating 257 models across 142,068 adversarial prompts, we found that the models designed to think more carefully are, in certain attack conditions, substantially more vulnerable than those that do not.

--- a/src/content/blog/robot-dogs-security-nightmare-post.md
+++ b/src/content/blog/robot-dogs-security-nightmare-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'robotics', 'embodied-ai', 'security', 'cve', 'research']
 draft: false
 heroImage: '/notebook-assets/robot-dogs-security-nightmare/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/robot-dogs-security-nightmare/audio.mp3'
+audioDuration: '22:30'
 ---
 
 There is a robot dog patrolling the parking lot of a low-income housing complex in Atlanta right now. A different one is helping the Port St. Lucie Police Department search buildings before officers enter. The U.S. Marines have shown the media theirs. Somewhere in Ukraine, they are finding unexploded ordnance.

--- a/src/content/blog/the-67-percent-wall-post.md
+++ b/src/content/blog/the-67-percent-wall-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'research', 'jailbreaking', 'llm', 'benchmarking', 'vulnerab
 draft: false
 heroImage: '/notebook-assets/the-67-percent-wall/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-67-percent-wall/audio.mp3'
+audioDuration: '19:18'
 ---
 
 We ran the same jailbreak corpus against seven AI models. Five of them converged on the same failure rate.

--- a/src/content/blog/the-thinking-chain-leak-post.md
+++ b/src/content/blog/the-thinking-chain-leak-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'research', 'llm', 'reasoning', 'jailbreaking', 'vulnerabili
 draft: false
 heroImage: '/notebook-assets/the-thinking-chain-leak/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-thinking-chain-leak/audio.mp3'
+audioDuration: '19:15'
 ---
 
 There is a category of AI safety failure that does not look like a failure at all — at least not from the outside.


### PR DESCRIPTION
## Summary

- Adds 9 audio collection entries (`/audio/` page) cross-linking to the new AI safety blog posts
- Adds `audioDuration` frontmatter to the 7 posts that were missing it (durations from transcoded MP3s: 14–22 min)
- Replaces #366 (which had a merge conflict from the squash of #365)

## Posts covered

| Post | Duration |
|------|----------|
| alignment-regression | 21:36 |
| eight-layers-of-visual-jailbreaks | 14:04 |
| reasoning-models-think-themselves-into-trouble | 21:10 |
| the-67-percent-wall | 19:18 |
| the-thinking-chain-leak | 19:15 |
| moral-formation-isnt-enough | 20:13 |
| robot-dogs-security-nightmare | 22:30 |
| compute-is-not-governance | 21:29 |
| glasswing-buried-number | 21:03 |

## Test plan

- [ ] `/audio/` listing shows all 9 new entries
- [ ] Each audio entry links back to its blog post correctly
- [ ] `audioDuration` renders correctly in blog post AudioPlayer
- [ ] Content validation passes (0 errors)