### PR TITLE
content(video): add cinematic videoUrl for 9 AI safety posts

### DIFF
--- a/src/content/blog/alignment-regression-post.md
+++ b/src/content/blog/alignment-regression-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'alignment', 'reasoning', 'jailbreaking', 'llm', 'autonomous
 draft: false
 heroImage: '/notebook-assets/alignment-regression/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/alignment-regression/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/alignment-regression/video.mp4'
 audioDuration: '21:36'
 ---
 

--- a/src/content/blog/compute-is-not-governance-post.md
+++ b/src/content/blog/compute-is-not-governance-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'policy', 'anthropic', 'governance', 'research', 'geopolitic
 draft: false
 heroImage: '/notebook-assets/compute-is-not-governance/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/compute-is-not-governance/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/compute-is-not-governance/video.mp4'
 audioDuration: '21:29'
 faq:
   - q: "What is Anthropic's 2028 document?"

--- a/src/content/blog/eight-layers-of-visual-jailbreaks-post.md
+++ b/src/content/blog/eight-layers-of-visual-jailbreaks-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'research', 'jailbreaking', 'llm', 'multimodal', 'vulnerabil
 draft: false
 heroImage: '/notebook-assets/eight-layers-of-visual-jailbreaks/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-layers-of-visual-jailbreaks/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-layers-of-visual-jailbreaks/video.mp4'
 audioDuration: '14:04'
 ---
 

--- a/src/content/blog/glasswing-buried-number-post.md
+++ b/src/content/blog/glasswing-buried-number-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'security', 'anthropic', 'research', 'vulnerability', 'gover
 draft: false
 heroImage: '/notebook-assets/glasswing-buried-number/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/glasswing-buried-number/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/glasswing-buried-number/video.mp4'
 audioDuration: '21:03'
 faq:
   - q: 'What is Project Glasswing?'

--- a/src/content/blog/moral-formation-isnt-enough-post.md
+++ b/src/content/blog/moral-formation-isnt-enough-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'alignment', 'research', 'opinion', 'anthropic', 'llm']
 draft: false
 heroImage: '/notebook-assets/moral-formation-isnt-enough/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/moral-formation-isnt-enough/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/moral-formation-isnt-enough/video.mp4'
 audioDuration: '20:13'
 ---
 

--- a/src/content/blog/reasoning-models-think-themselves-into-trouble-post.md
+++ b/src/content/blog/reasoning-models-think-themselves-into-trouble-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'research', 'reasoning', 'llm', 'vulnerability', 'benchmarki
 draft: false
 heroImage: '/notebook-assets/reasoning-models-think-themselves-into-trouble/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/reasoning-models-think-themselves-into-trouble/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/reasoning-models-think-themselves-into-trouble/video.mp4'
 audioDuration: '21:10'
 ---
 

--- a/src/content/blog/robot-dogs-security-nightmare-post.md
+++ b/src/content/blog/robot-dogs-security-nightmare-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'robotics', 'embodied-ai', 'security', 'cve', 'research']
 draft: false
 heroImage: '/notebook-assets/robot-dogs-security-nightmare/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/robot-dogs-security-nightmare/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/robot-dogs-security-nightmare/video.mp4'
 audioDuration: '22:30'
 ---
 

--- a/src/content/blog/the-67-percent-wall-post.md
+++ b/src/content/blog/the-67-percent-wall-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'research', 'jailbreaking', 'llm', 'benchmarking', 'vulnerab
 draft: false
 heroImage: '/notebook-assets/the-67-percent-wall/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-67-percent-wall/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-67-percent-wall/video.mp4'
 audioDuration: '19:18'
 ---
 

--- a/src/content/blog/the-thinking-chain-leak-post.md
+++ b/src/content/blog/the-thinking-chain-leak-post.md
@@ -6,6 +6,7 @@ tags: ['ai-safety', 'research', 'llm', 'reasoning', 'jailbreaking', 'vulnerabili
 draft: false
 heroImage: '/notebook-assets/the-thinking-chain-leak/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-thinking-chain-leak/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-thinking-chain-leak/video.mp4'
 audioDuration: '19:15'
 ---
 


### PR DESCRIPTION
## Summary

- Adds `videoUrl` frontmatter to 9 AI safety blog posts pointing to cinematic NotebookLM videos on R2
- Videos use the dark botanical aesthetic (dark plum backgrounds, dusty copper accents)
- All videos uploaded to `cdn.adrianwedd.com/notebook-assets/{slug}/video.mp4`

## Posts

- alignment-regression (94MB)
- eight-layers-of-visual-jailbreaks (87MB)
- the-67-percent-wall (50MB)
- moral-formation-isnt-enough (45MB)
- robot-dogs-security-nightmare (53MB)
- compute-is-not-governance (58MB)
- glasswing-buried-number (53MB)
- reasoning-models-think-themselves-into-trouble (50MB)
- the-thinking-chain-leak (60MB)