### PR TITLE
content(positioning): align services, contact, homepage, and about with ops docs

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -158,6 +158,11 @@ const recentPosts = (await getCollection('blog'))
       </p>
 
       <p>
+        On the practical side: digital infrastructure for businesses that need it built properly and maintained by the
+        person who built it — no agency handoff, no disappearing act.
+      </p>
+
+      <p>
         Also: music tools, interactive installations, writing, and whatever else demands enough attention to be worth
         the hyperfocus.
       </p>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -42,7 +42,10 @@ import HeroCanvas from '../components/HeroCanvas.astro';
     {/* Enquiry form */}
     <div class="mt-12">
       <h2 class="text-xl font-semibold text-text">Start a project</h2>
-      <p class="mt-1 text-sm text-text-muted">Tell us what you need. We'll respond within minutes.</p>
+      <p class="mt-1 text-sm text-text-muted">
+        Tell me what you need. All work begins with a written scope and quote — nothing starts until we've agreed on
+        both, and a deposit is required before work proceeds.
+      </p>
       <form id="enquiry-form" class="mt-6 space-y-4" novalidate>
         <div>
           <label for="enquiry-name" class="block text-xs text-text-muted">Name</label>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,7 +15,7 @@ const recentPosts = allPosts
 
 <BaseLayout
   title="Adrian Wedd"
-  description="Systems builder. AI safety, systems architecture, adversarial thinking. Based in Tasmania."
+  description="Digital systems builder for practical business infrastructure, AI safety, systems architecture, and security-aware delivery. Based in Tasmania."
 >
   <script
     is:inline
@@ -25,7 +25,7 @@ const recentPosts = allPosts
       '@type': 'WebSite',
       name: 'Adrian Wedd',
       url: 'https://adrianwedd.com',
-      description: 'Systems builder. AI safety, systems architecture, adversarial thinking. Based in Tasmania.',
+      description: 'Digital systems builder for practical business infrastructure, AI safety, systems architecture, and security-aware delivery. Based in Tasmania.',
       potentialAction: {
         '@type': 'SearchAction',
         target: {

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -13,11 +13,11 @@ const totalWords = blogPosts.reduce((sum, p) => sum + (p.body ? p.body.split(/\s
 const totalImages = galleries.reduce((sum, g) => sum + g.data.images.length, 0);
 ---
 
-<BaseLayout title="Now" description="What I'm focused on right now. Updated April 2026.">
+<BaseLayout title="Now" description="What I'm focused on right now. Updated May 2026.">
   <section class="relative flex min-h-[50dvh] items-center px-4 sm:px-6 lg:px-8">
     <div class="relative z-10 mx-auto max-w-3xl">
       <h1 class="text-text">Now</h1>
-      <p class="mt-2 text-text-muted">What I'm focused on right now. Updated April 2026.</p>
+      <p class="mt-2 text-text-muted">What I'm focused on right now. Updated May 2026.</p>
     </div>
     <HeroCanvas animation="orbit" />
   </section>
@@ -40,19 +40,25 @@ const totalImages = galleries.reduce((sum, g) => sum + g.data.images.length, 0);
         <h2 class="text-text">Focus</h2>
         <p>
           Multi-agent AI safety and adversarial evaluation. The <a href="/projects/failure-first/">Failure First</a> research
-          — 231+ models, 141K+ adversarial prompts as of April 2026 — keeps expanding. Recent writing covers
-          <a href="/blog/the-failure-first-team/">the fifteen-agent research team</a> that runs it,
-          <a href="/blog/when-ai-systems-talk-safety-breaks/">what breaks when AI systems talk to each other</a>,
-          <a href="/blog/the-cognitive-cage/">embodied AI risk</a>, and
-          <a href="/blog/why-demonstrated-risk-is-ignored/">why organisations ignore demonstrated risk</a>.
+          — 257 models, 142k prompts, 346 attack techniques as of May 2026 — keeps expanding. Recent writing covers
+          <a href="/blog/compute-is-not-governance/">why compute scaling isn't a governance substitute</a>,
+          <a href="/blog/moral-formation-isnt-enough/">why moral formation alone can't align AI</a>,
+          <a href="/blog/robot-dogs-security-nightmare/">robot dogs as a live security vulnerability</a>, and
+          <a href="/blog/glasswing-buried-number/">what safety benchmarks are actually measuring</a>.
         </p>
       </section>
 
       <section>
         <h2 class="text-text">Building</h2>
         <ul class="mt-2 space-y-2">
-          <li>Client projects — AI integration, automation, and infrastructure for small businesses</li>
-          <li>This site — weekly sprints, shipping in public, now with automated social publishing to Facebook</li>
+          <li>
+            Client projects — practical digital infrastructure for businesses that need it built properly and maintained
+            by the person who built it
+          </li>
+          <li>
+            This site — weekly sprints, shipping in public, with automated social publishing across Facebook, Instagram,
+            Bluesky, and Twitter
+          </li>
           <li>
             <a href="/projects/spark/">SPARK</a> — a non-coercive AI companion for neurodivergent children, now with <a
               href="/blog/giving-a-robot-three-voices/">three distinct voices</a
@@ -76,13 +82,13 @@ const totalImages = galleries.reduce((sum, g) => sum + g.data.images.length, 0);
       <section>
         <h2 class="text-text">Writing</h2>
         <p>
-          Publishing steadily — recent pieces cover <a href="/blog/the-failure-first-team/">the AI research team</a>,
-          <a href="/blog/giving-a-robot-three-voices/">giving a robot three voices</a>,
-          <a href="/blog/voice-cloning-qwen3-tts-mlx/">voice cloning on Apple Silicon</a>,
-          <a href="/blog/the-resonant-fringe/">Perth's electronic music underground</a>,
-          <a href="/blog/getting-google-nest-cameras-into-frigate-nvr/">homelab engineering</a>,
-          <a href="/blog/safety-first-therapeutic-ai/">therapeutic AI safety</a>, and
-          <a href="/blog/the-legal-ai-trust-deficit/">legal AI trust</a>. Also running a <a
+          Publishing steadily — recent pieces cover
+          <a href="/blog/compute-is-not-governance/">compute and governance</a>,
+          <a href="/blog/glasswing-buried-number/">safety benchmark transparency</a>,
+          <a href="/blog/moral-formation-isnt-enough/">AI alignment limits</a>,
+          <a href="/blog/the-bottom-pub-co-op/">community ownership models</a>,
+          <a href="/blog/robot-dogs-security-nightmare/">robot dogs as security risk</a>, and
+          <a href="/blog/the-resonant-fringe/">Perth's electronic music underground</a>. Also running a <a
             href="/projects/notebooklm-automation/">NotebookLM pipeline</a
           > that generates audio overviews and infographics for every post and project. See <a href="/new/"
             >what's new</a
@@ -93,10 +99,10 @@ const totalImages = galleries.reduce((sum, g) => sum + g.data.images.length, 0);
       <section>
         <h2 class="text-text">Available for</h2>
         <p>
-          Client work, research collaboration, and technical advisory. I'm particularly useful when the problem sits at
-          the intersection of AI, infrastructure, and something that matters — healthcare, legal access, community
-          systems, governance. The problem is either worth solving properly or it isn't. Open to <a href="/services/"
-            >consulting engagements</a
+          Two kinds of work: practical implementation for businesses that need reliable digital infrastructure without
+          agency overhead; and specialist advisory for organisations navigating AI risk, governance, or security
+          evaluation. Both start the same way — written scope, agreed price, deposit before work proceeds. Open to <a
+            href="/services/">consulting engagements</a
           > and conversations that start with a real problem, not a brief.
         </p>
       </section>

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -131,13 +131,13 @@ const pricing = [
     title: 'Retainer',
     cadence: 'Monthly',
     typical: 'From $1,250/month',
-    desc: 'For ongoing build work after the initial project. Retainers are paid monthly in advance and reduce the effective hourly rate in exchange for reserved capacity. Work is still scoped before it starts. Unused time does not roll over. Specialist advisory, AI governance, security evaluation, and incident-sensitive work are quoted separately.',
+    desc: 'For ongoing build work after the initial project. Retainers are paid monthly in advance and reduce the effective hourly rate in exchange for reserved capacity. Work is still scoped before it starts. Unused time does not roll over. Capacity scales — growth packages from $2,000/month. Specialist advisory, AI governance, security evaluation, and incident-sensitive work are quoted separately.',
   },
   {
     title: 'Consult',
     cadence: 'Day rate',
     typical: 'From $200/hour',
-    desc: 'Strategy, architecture, evaluation, policy, security review, AI systems, or a second opinion before you commit to a build. Half-day and full-day workshops available.',
+    desc: 'Strategy, architecture, evaluation, policy, security review, AI systems, or a second opinion before you commit to a build. Half-day workshops from $800; full-day from $1,600.',
   },
 ];
 ---
@@ -411,8 +411,10 @@ const pricing = [
       }
     </div>
     <p class="mt-6 text-sm text-text-muted">
-      Rates depend on scope and engagement type.{' '}
-      <a href="/contact/" class="text-accent transition-colors hover:opacity-90"> Let's talk. </a>
+      Implementation work (build, automation, web) is billed at the project or retainer rate. Specialist advisory — AI
+      governance, security evaluation, red-teaming, incident-sensitive work — is always quoted and agreed separately,
+      even within an active retainer.{' '}
+      <a href="/contact/" class="text-accent transition-colors hover:opacity-90">Rates depend on scope. Let's talk.</a>
     </p>
   </section>
 

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -41,7 +41,7 @@ const capabilities = [
       'GenAI governance frameworks for procurement and executives',
     ],
     examples: [
-      { label: 'Failure First — 231+ models, 141K+ adversarial prompts (April 2026)', href: '/blog/120-models-18k-prompts/' },
+      { label: 'Failure First — 257 models, 142k prompts, 346 attack techniques (May 2026)', href: '/blog/120-models-18k-prompts/' },
     ],
   },
 ];

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -131,7 +131,7 @@ const pricing = [
     title: 'Retainer',
     cadence: 'Monthly',
     typical: 'From $1,250/month',
-    desc: 'For ongoing build work after the initial project. Retainers are paid monthly in advance and reduce the effective hourly rate in exchange for reserved capacity. Work is still scoped before it starts. Unused time does not roll over. Capacity scales — growth packages from $2,000/month. Specialist advisory, AI governance, security evaluation, and incident-sensitive work are quoted separately.',
+    desc: 'For ongoing build work after the initial project. Retainers are paid monthly in advance for reserved implementation capacity. Work is still scoped before it starts. Unused time does not roll over. Capacity scales — growth packages from $2,000/month. Specialist advisory, AI governance, security evaluation, and incident-sensitive work are quoted separately.',
   },
   {
     title: 'Consult',


### PR DESCRIPTION
## Summary

- **Services / Consult**: workshop prices now explicit — half-day from \$800, full-day from \$1,600 (previously said "available" with no anchor; old copy had wrong \$1,400 full-day figure)
- **Services / Retainer**: signals growth tier — "capacity scales — growth packages from \$2,000/month"
- **Services / Pricing footer**: explicit implementation vs. specialist advisory split — "specialist advisory, AI governance, security evaluation... is always quoted and agreed separately, even within an active retainer"
- **Contact**: scope + deposit expectation set above the enquiry form — "nothing starts until we've agreed on both, and a deposit is required before work proceeds"
- **Homepage**: meta description now covers both implementation and specialist tracks — "Digital systems builder for practical business infrastructure, AI safety, systems architecture, and security-aware delivery"
- **About / What I'm working on**: one sentence on practical infrastructure work alongside the AI-forward copy

## Rationale

Follows Codex review of the gaps between site copy and \`adrianwedd-ops\` docs (rate-card, engagement-standards). Top priority items: workshop self-qualification pricing, implementation/advisory split visibility, and contact-page expectation setting.

## Test plan

- [ ] `/services/` pricing cards render — all three visible with updated copy
- [ ] Pricing footer note displays below the cards
- [ ] `/contact/` enquiry form intro shows scope/deposit language
- [ ] `/` meta description updated (check source)
- [ ] `/about/` "What I'm working on" shows new sentence