### PR TITLE
fix(site): wire OG generator into build; fix canonical URL in project JSON-LD

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build && pagefind --site dist",
+    "build": "node scripts/generate-og-images.mjs && astro build && pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro",
     "fetch-analytics": "node scripts/fetch-ga4-data.mjs",

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -94,7 +94,12 @@ const allBlogPosts = project.data.series
       keywords: project.data.tags,
       ...(project.data.repo || project.data.url ? { applicationCategory: 'DeveloperApplication' } : {}),
       ...(project.data.repo ? { offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' } } : {}),
-      ...(project.data.url ? { url: project.data.url } : {}),
+      // External project URL goes in `sameAs`, NOT `url`. Previously the spread
+      // here was `{ url: project.data.url }`, which silently overrode the
+      // canonical adrianwedd.com URL above. Google ingests `url` as the
+      // entity's canonical address — every project with `url` set was telling
+      // Google the entity lived at the external site, splitting page authority.
+      ...(project.data.url ? { sameAs: [project.data.url] } : {}),
       ...(project.data.repo
         ? {
             codeRepository: project.data.repo.startsWith('http')


### PR DESCRIPTION
## Summary
- Wire OG image generator into build pipeline
- Stop overriding canonical URL in project JSON-LD schema