### PR TITLE
fix(new): remove dangling episodes reference from stats bar

### DIFF
--- a/src/pages/new/index.astro
+++ b/src/pages/new/index.astro
@@ -91,8 +91,6 @@ function formatDate(d: Date) {
       <span class="opacity-30">/</span>
       <span>{galleries.length} galleries</span>
       <span class="opacity-30">/</span>
-      <span>{episodes.length} audio</span>
-      <span class="opacity-30">/</span>
       <span>{all.length} total</span>
     </div>
 


### PR DESCRIPTION
## Summary
- Remove dangling episodes reference from stats bar on /new page