### PR TITLE
fix(content): remove old-style videoUrl from SPARK project

### DIFF
--- a/src/content/projects/spark.md
+++ b/src/content/projects/spark.md
@@ -11,7 +11,6 @@ series: 'PiCar-X'
 seriesOrder: 1
 heroImage: '/notebook-assets/spark/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/spark/audio.mp3'
-videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/spark/video.mp4'
 ---
 
 SPARK (Support Partner for Awareness, Regulation & Kindness) is a Raspberry Pi 4-based robotics platform powered by Claude Haiku, designed as a non-coercive companion for children with AuDHD (ADHD + ASD comorbid) profiles.


### PR DESCRIPTION
## Summary
- Remove old-style videoUrl field from SPARK project frontmatter (superseded by cinematic video)