### PR TITLE
feat(content): add cinematic videoUrl to SPARK project

### DIFF
--- a/src/content/projects/spark.md
+++ b/src/content/projects/spark.md
@@ -11,6 +11,7 @@ series: 'PiCar-X'
 seriesOrder: 1
 heroImage: '/notebook-assets/spark/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/spark/audio.mp3'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/spark/video.mp4'
 ---
 
 SPARK (Support Partner for Awareness, Regulation & Kindness) is a Raspberry Pi 4-based robotics platform powered by Claude Haiku, designed as a non-coercive companion for children with AuDHD (ADHD + ASD comorbid) profiles.


### PR DESCRIPTION
## Summary
- Add cinematic videoUrl to SPARK project (dark botanical aesthetic)
- Depends on #387 (remove old-style videoUrl)