### PR TITLE
chore: NLM configs + LeJEPA paper post

### DIFF
--- a/scripts/notebooklm/configs/squishmallowdex-infographic.json
+++ b/scripts/notebooklm/configs/squishmallowdex-infographic.json
@@ -1,0 +1,9 @@
+{
+  "title": "Squishmallowdex - Infographic",
+  "sources": [
+    "textfile:/Users/adrian/repos/adrianwedd.com/src/content/projects/squishmallowdex.md"
+  ],
+  "studio": [
+    {"type": "infographic"}
+  ]
+}

--- a/scripts/notebooklm/configs/the-robot-that-refuses-to-give-orders.json
+++ b/scripts/notebooklm/configs/the-robot-that-refuses-to-give-orders.json
@@ -1,0 +1,10 @@
+{
+  "title": "The Robot That Refuses to Give Orders - Audio & Video Overview",
+  "sources": [
+    "textfile:/Users/adrian/repos/adrianwedd.com/src/content/blog/the-robot-that-refuses-to-give-orders-post.md"
+  ],
+  "studio": [
+    {"type": "audio"},
+    {"type": "video"}
+  ]
+}

--- a/src/content/blog/lejepa-self-supervised-learning-gets-a-theoretical-foundation.md
+++ b/src/content/blog/lejepa-self-supervised-learning-gets-a-theoretical-foundation.md
@@ -1,0 +1,67 @@
+---
+title: "LeJEPA: Self-Supervised Learning Gets a Theoretical Foundation"
+description: "Balestriero and LeCun prove that isotropic Gaussian embeddings are optimal for downstream tasks, then build a 50-line self-supervised method that eliminates stop-gradients, EMA teachers, and hyperparameter schedules."
+date: 2026-02-13
+tags: ["ai", "machine-learning", "research", "self-supervised-learning"]
+draft: false
+---
+
+**Balestriero & LeCun (2025)** — [arXiv:2511.08544](https://arxiv.org/abs/2511.08544)
+
+Self-supervised learning has powered much of the recent progress in computer vision, but the methods that work best — DINO, I-JEPA, data2vec — rely on a stack of heuristics: stop-gradients, exponential moving average teachers, asymmetric augmentation pipelines, and carefully scheduled hyperparameters. Remove any one piece and training collapses. Nobody has a satisfying explanation for *why* this particular combination works. Balestriero and LeCun's new paper, LeJEPA, offers one — and the answer is surprisingly clean.
+
+## The core insight
+
+The paper asks a fundamental question: what should the *distribution* of learned embeddings look like to minimise error on arbitrary downstream tasks? Their answer, backed by formal proofs covering both linear and nonlinear probing: an **isotropic Gaussian**.
+
+This isn't just an empirical observation. Theorem 1 proves that among all distributions with fixed variance, the isotropic Gaussian uniquely minimises integrated squared bias for k-NN and kernel-based methods. Two supporting lemmas show that anisotropic embeddings amplify both bias and variance in linear probes, regardless of downstream task structure. The implication is direct: if you can push your encoder's output distribution toward an isotropic Gaussian, you're provably minimising the worst-case downstream risk.
+
+## SIGReg: making it work in practice
+
+Knowing the target distribution is one thing; getting there during training is another. Naively enforcing Gaussianity in high-dimensional spaces runs into the curse of dimensionality. The paper introduces **SIGReg** (Sketched Isotropic Gaussian Regularisation), which sidesteps this by projecting embeddings onto random 1D directions and matching the characteristic function of a standard Gaussian on each projection.
+
+The specific test used is the Epps-Pulley statistic, chosen after a systematic comparison of three families:
+
+- **Moment-based tests** (matching mean, variance, skewness, kurtosis) — suffer from gradient explosion with higher moments
+- **CDF-based tests** (Kolmogorov-Smirnov, Anderson-Darling) — require sorting, which is non-differentiable
+- **Characteristic function tests** (Epps-Pulley) — bounded gradients, fully differentiable, compatible with distributed training
+
+The theoretical guarantees are strong. The gradient magnitudes stay bounded at O(sigma^2/N) regardless of input distribution (Theorem 4). Only O(K) random directions are needed to characterise a K-dimensional space for smooth distributions (Theorem 5). Minibatch bias vanishes at O(1/N) (Theorem 6).
+
+## What LeJEPA looks like
+
+The full method is the JEPA prediction loss plus SIGReg regularisation, weighted by a single hyperparameter lambda. That's it. No stop-gradient. No teacher-student network. No EMA schedule. No asymmetric augmentation. The implementation is roughly 50 lines of PyTorch.
+
+The training loop:
+1. Encode two views of an image
+2. Predict one embedding from the other
+3. Compute JEPA prediction loss
+4. Compute SIGReg regularisation on the embeddings
+5. Backpropagate the weighted sum
+
+## Results
+
+**Architecture universality.** LeJEPA trained 50+ architectures from 8 different families (ResNets, ViTs, ConvNets, and others) with the *same hyperparameters*, achieving 91.5–95% accuracy on ImageNet-10 with a frozen backbone. No per-architecture tuning required.
+
+**ImageNet-1K scale.** With ViT-H/14, LeJEPA reaches 79% linear probe accuracy. Performance is stable across batch sizes (128–1024), view counts (4–10), and lambda values (0.01–0.1).
+
+**Domain-specific pretraining.** On Galaxy10 and Food101, LeJEPA trained on in-domain data consistently outperformed zero-shot transfer from DINOv2 and DINOv3. This is a striking result — it suggests that principled SSL can make domain-specific pretraining practical even with relatively small datasets, challenging the assumption that foundation model transfer is always the right move.
+
+**Model selection without labels.** Training loss correlates strongly with downstream performance, meaning you can select checkpoints without running supervised probes. This is a significant practical benefit that most SSL methods lack.
+
+**Scaling.** Stable training on 1.8B parameter ViT-g models with no heuristic tuning, maintaining linear time and memory complexity.
+
+## Why this matters
+
+The standard playbook for self-supervised learning is empirical: try combinations of tricks, ablate until something works, then justify it post-hoc. LeJEPA inverts this. Start from a theoretical result about optimal embedding geometry, derive a tractable regulariser, and show that the resulting method is simpler *and* more robust than the heuristic approaches.
+
+The practical implications are worth spelling out:
+
+1. **Lower barrier to entry.** One hyperparameter instead of a constellation of scheduling and architecture decisions.
+2. **Architecture freedom.** No assumption about the encoder family — use whatever makes sense for your domain.
+3. **Domain pretraining unlocked.** The in-domain results suggest that practitioners with specialised datasets (medical imaging, remote sensing, materials science) can train competitive representations without relying on ImageNet-pretrained checkpoints.
+4. **Theoretical grounding.** When something goes wrong, there's a principled framework for diagnosing it, rather than ablating through heuristic combinations.
+
+The 50-line implementation claim is not just marketing. The method's simplicity follows directly from the theory — once you know the target distribution is Gaussian and you have a differentiable way to match it, the rest is just standard gradient descent.
+
+Whether LeJEPA's 79% on ImageNet-1K catches up to the state-of-the-art heuristic methods remains to be seen as the approach matures. But the argument that we should prefer provably correct simplicity over fragile empirical complexity is compelling. This feels like the kind of paper that reframes how a subfield thinks about its own foundations.


### PR DESCRIPTION
## Summary

- Adds NotebookLM configs for squishmallowdex infographic and robot-that-refuses-to-give-orders
- Adds daily paper blog post for LeJEPA (arXiv:2511.08544) — self-supervised learning theoretical foundation

## Changes

- `scripts/notebooklm/configs/squishmallowdex-infographic.json` — NLM config cherry-picked from `chore/gemini-md-nlm-configs`
- `scripts/notebooklm/configs/the-robot-that-refuses-to-give-orders.json` — NLM config cherry-picked from same
- `src/content/blog/lejepa-self-supervised-learning-gets-a-theoretical-foundation.md` — paper blog post cherry-picked from `content/daily-paper-batch3`