### PR TITLE
fix(adhdo): remove duplicate youtubeUrl key

### DIFF
--- a/src/content/projects/adhdo.md
+++ b/src/content/projects/adhdo.md
@@ -10,7 +10,6 @@ audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adhdo/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/adhdo/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=it_8g1ApwEk'
 heroImage: '/notebook-assets/adhdo/infographic.webp'
-youtubeUrl: 'https://www.youtube.com/watch?v=v1qvpX_OJK0'
 ---
 
 Most productivity tools are built for brains that can hold a queue. If you can't — if the queue collapses the moment something shiny crosses your peripheral vision — those tools don't fail gracefully. They fail judgmentally. Missed reminders become evidence. Incomplete lists become character flaws.


### PR DESCRIPTION
The `feat(youtube): add youtubeUrl for batch 2026-05-04` commit (15672c6) re-introduced a duplicate `youtubeUrl` key in adhdo.md frontmatter. This is the third time this same duplicate has been introduced and fixed (previously fixed in #322 and a5a2b9b). Removing `v1qvpX_OJK0` and keeping the original cinematic video URL `it_8g1ApwEk` per prior fixes.

Fixes CI: `duplicated mapping key` YAML parse error at adhdo.md:12.