### PR TITLE
fix(lejepa): trim description to ≤160 chars

### DIFF
--- a/src/content/blog/lejepa-self-supervised-learning-gets-a-theoretical-foundation.md
+++ b/src/content/blog/lejepa-self-supervised-learning-gets-a-theoretical-foundation.md
@@ -1,6 +1,6 @@
 ---
 title: "LeJEPA: Self-Supervised Learning Gets a Theoretical Foundation"
-description: "Balestriero and LeCun prove that isotropic Gaussian embeddings are optimal for downstream tasks, then build a 50-line self-supervised method that eliminates stop-gradients, EMA teachers, and hyperparameter schedules."
+description: "Balestriero and LeCun prove isotropic Gaussian embeddings are optimal, then build a 50-line self-supervised method eliminating stop-gradients and EMA teachers."
 date: 2026-02-13
 tags: ["ai", "machine-learning", "research", "self-supervised-learning"]
 draft: false


### PR DESCRIPTION
Validation gate was failing: description was 216 chars. Trimmed to 159.