### PR TITLE
fix(validate): detect duplicate frontmatter YAML keys

### DIFF
--- a/scripts/validate-content.js
+++ b/scripts/validate-content.js
@@ -59,6 +59,20 @@ for (const [collection, rules] of Object.entries(COLLECTIONS)) {
     const { data: fm } = matter(content);
     const label = filePath.replace(CONTENT_DIR + '/', '');
 
+    // Duplicate YAML keys — gray-matter silently deduplicates, so check raw text
+    const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    if (fmMatch) {
+      const keys = [...fmMatch[1].matchAll(/^([a-zA-Z_][a-zA-Z0-9_]*):/gm)].map((m) => m[1]);
+      const seen = new Set();
+      for (const key of keys) {
+        if (seen.has(key)) {
+          console.error(`ERROR [${label}]: duplicate frontmatter key '${key}'`);
+          errors++;
+        }
+        seen.add(key);
+      }
+    }
+
     // Required fields
     for (const field of rules.required) {
       const val = fm[field];


### PR DESCRIPTION
`gray-matter` silently deduplicates YAML keys (last-one-wins), so the existing validator didn't catch the recurring `youtubeUrl` duplicate in `adhdo.md` — which has now been introduced and fixed three separate times.

This adds a raw-text regex check over the frontmatter block before parsing, flagging any key that appears more than once as a hard error. CI now catches the issue at `Validate content` rather than letting it through to the YAML parser at `Astro type check`.

Tested locally: fires on a manufactured duplicate, clean on current content tree.