### PR TITLE
fix(content): remove dead YouTube embed + fix cygnet 404 link

### DIFF
--- a/src/content/audio/cygnet-overview.md
+++ b/src/content/audio/cygnet-overview.md
@@ -5,7 +5,6 @@ date: 2025-04-01
 tags: ['notebooklm', 'ai', 'housing', 'agents']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/cygnet/audio.mp3'
 duration: '16:03'
-relatedProject: 'cygnet'
 ---
 
 Housing in Australia is broken in a way that building slightly cheaper versions of the same thing will never fix. The timelines are wrong. The waste is staggering. The economics serve the people who need homes least. Cygnet starts from that premise and asks what happens when you route around the entire construction industry's incentive structure.
@@ -13,5 +12,3 @@ Housing in Australia is broken in a way that building slightly cheaper versions 
 The answer involves 170 acres in Cygnet, Tasmania, twenty-eight specialised AI agents, and 3D-printed homes. This episode explores how those agents coordinate land acquisition, building operations, and print logistics across what is designed to become an eco village. They don't replace human decisions — they accelerate the parts that are slow for bad reasons: permit choreography, material logistics, scheduling dependencies, cost modelling across dozens of simultaneous variables.
 
 The engineering constraints are ambitious: sixty percent cost reduction, eighty percent waste reduction, carbon footprint halved. Not as aspiration, but as hard targets. When you rethink what building means from first principles, those numbers stop sounding impossible and start sounding like engineering.
-
-[View the full project →](/projects/cygnet/)

--- a/src/content/blog/the-robot-that-refuses-to-give-orders-post.md
+++ b/src/content/blog/the-robot-that-refuses-to-give-orders-post.md
@@ -8,7 +8,6 @@ audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-robot-that-refuses-to-
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-robot-that-refuses-to-give-orders/video.mp4'
 series: 'PiCar-X'
 seriesOrder: 1
-youtubeUrl: 'https://www.youtube.com/watch?v=nzZ83pc_E9Y'
 ---
 
 ## The missing manual for the human mind


### PR DESCRIPTION
## Summary
Two genuine content bugs found in `main` during Sprint 35 branch-pile triage.

### 1. Dead YouTube embed
`the-robot-that-refuses-to-give-orders` carried `youtubeUrl: …nzZ83pc_E9Y`, but the video is **removed** (oEmbed returns 404). This rendered a broken embed and an invalid `VideoObject` schema. The post still has its R2 `videoUrl`, so video coverage is unaffected.

### 2. Cygnet dangling 404 link
`cygnet-overview` (audio) linked to `/projects/cygnet/` via both `relatedProject` and an in-body link, but that project page was curated out in #374. Both now 404. Lychee skips own-domain so CI never flagged it. Removed the dangling references; the standalone audio overview is preserved.

## Verification
- `node scripts/validate-content.js` → 0 errors, 0 warnings
- `npm run build` → 483 pages, clean
- `git grep nzZ83pc_E9Y` / `/projects/cygnet/` → no remaining references

## Context
Found while triaging 21 stale local branches (all confirmed content-already-in-main via squash-merge). These were the only two pieces of genuinely outstanding work in the codebase. Closes the loop with #189 (Facebook renewal) as the only remaining open issue.