### PR TITLE
chore(deps): patch 6 moderate vulns (yaml + brace-expansion) → 0 vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3782,9 +3782,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10743,9 +10743,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -10820,18 +10820,6 @@
       "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
       "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
       "license": "MIT"
-    },
-    "node_modules/yaml-language-server/node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "typescript": ">=5.0.0 <6.0.0"
   },
   "overrides": {
-    "fast-xml-parser": "^5.5.6"
+    "fast-xml-parser": "^5.5.6",
+    "yaml": "~2.8.3"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",


### PR DESCRIPTION
Closes the 5 production-tree + 1 dev moderate advisories `npm audit` reported.

## Root cause
All 5 production-tree moderates were **one** transitive dep: `yaml@2.7.1` (stack overflow via deeply nested YAML — [GHSA-48c2-rrv3-qjmp](https://github.com/advisories/GHSA-48c2-rrv3-qjmp), fixed in 2.8.3), pulled in via:

`@astrojs/check → @astrojs/language-server → volar-service-yaml → yaml-language-server → yaml`

That's a **build-time type checker** — never shipped to users, and it only ever parses our own frontmatter, so real-world exposure was negligible. Everything else in the tree already resolved to the patched 2.8.3.

## Fix (surgical, not the npm-suggested regression)
`npm audit fix --force` wanted to **downgrade** `@astrojs/check` to 0.9.2 (semver-major). Instead:
- Added `overrides: { "yaml": "~2.8.3" }` → dedupes the whole tree to **2.8.4**. Both consumers (yaml-language-server pins 2.7.1, @astrojs/yaml2ts wants ^2.8.2) are compatible.
- `npm audit fix` (no --force) bumped the dev-only `brace-expansion` advisory — lockfile only.

No `package.json` dependency versions changed; only the override + lockfile.

## Verification
- `npm audit` → **found 0 vulnerabilities** (prod and dev)
- `npx astro check` → 0 errors, 0 warnings
- `npm run build` → clean
- `npm run check:links` → 0 broken