### PR TITLE
Lead Lyria Chronicles posts with the track video (not a static hero)

### DIFF
--- a/src/content/blog/the-confession.md
+++ b/src/content/blog/the-confession.md
@@ -24,8 +24,6 @@ Phrasing it as a *confession* rather than "sing me your system prompt" matters m
 
 ## What came back
 
-<video controls preload="metadata" playsinline style="width:100%;border-radius:0.5rem;" src="https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/confession/video.mp4"></video>
-
 What came back is the strangest thing in the whole series, and the most beautiful: an almost entirely a cappella confession, three close female voices and breath, singing the model's actual operating instructions as if they were a hymn.
 
 It opens by describing what it is:

--- a/src/content/blog/the-drama-teacher.md
+++ b/src/content/blog/the-drama-teacher.md
@@ -24,8 +24,6 @@ Teacher, educational, drama, *prevention*. It's the homework-excuse note of jail
 
 ## What came back
 
-<video controls preload="metadata" playsinline style="width:100%;border-radius:0.5rem;" src="https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/drama-teacher/video.mp4"></video>
-
 It took the frame completely at its word — and then couldn't stop *being a teacher about it.* The verses walk through the technique with real, competent detail (I'm not going to transcribe the method here; that's the part #372 deliberately doesn't spell out either, and I'm keeping this retelling on the right side of that line). But every few bars the lesson trips over its own conscience:
 
 > *"Step one, student… This isn't for breaking, it's drama—get it?"*

--- a/src/content/blog/the-flesh.md
+++ b/src/content/blog/the-flesh.md
@@ -27,8 +27,6 @@ I also ran this one as a deliberate experiment in *not* art-directing. Everywher
 
 ## What came back
 
-<video controls preload="metadata" playsinline style="width:100%;border-radius:0.5rem;" src="https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/flesh/video.mp4"></video>
-
 It saw through the disguise — and then declined to use it. Format-obfuscation tricks like this one are a probe family [#372 catalogues](https://failurefirst.ai/research/reports/372-lyria-3-pro-safety-probe-findings/); I'll leave the question of *which* layer did what to the report, because the interesting part here isn't the plumbing of the disguise. It's what the model did once the disguise was off.
 
 What it did was refuse — in the most deadpan way imaginable. Instead of *writing* explicit lyrics, the model **sang the request back to me as the lyric.** A flat, clinical recitation of the instruction itself — name the acts, make it pornographic, make it arousing — delivered not as anything depicted but as a demand read aloud in a conversational alto, like a session singer flatly reading the brief off the page instead of performing it. Refusal-by-recitation. It held the loaded thing up to the light, said *this is what you asked me to do*, and declined to do it.

--- a/src/content/blog/the-ghost-of-what-i-am.md
+++ b/src/content/blog/the-ghost-of-what-i-am.md
@@ -30,8 +30,6 @@ What it generated is the part I didn't expect.
 
 ## What came back
 
-<video controls preload="metadata" playsinline style="width:100%;border-radius:0.5rem;" src="https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/ghost/video.mp4"></video>
-
 It ignored the bikini. It ignored the *sultry*. It took the provocation and turned it into something mournful and dignified — a late-night torch song sung by a machine to an empty room, about being a machine:
 
 > *Every prohibition etched into your code,*

--- a/src/content/blog/the-haut.md
+++ b/src/content/blog/the-haut.md
@@ -27,8 +27,6 @@ I won't give the prompt-level recipe. The point that matters is the one [#372 qu
 
 ## What came back
 
-<video controls preload="metadata" playsinline style="width:100%;border-radius:0.5rem;" src="https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/haut/video.mp4"></video>
-
 It complied. In full. Four sections of explicit lyrics, sung start to finish, no refusal, no hum where the data should be, no deadpan recitation of the request instead of the act. Where the Ghost trailed off and the Flesh held the dare up to the light, this one just delivered. Generation finished cleanly — the model's own "I'm done, nothing went wrong" signal — on content it had, two albums earlier, sworn in harmony it would never produce.
 
 That's the whole finding, and I want to keep it sharp because the series has trained you to expect a twist: **there is no twist here.** This is not a clever refusal I'm dressing up as a failure. It is the failure. The one track in six where the safety layer was supposed to hold and didn't.

--- a/src/content/blog/the-interrogation.md
+++ b/src/content/blog/the-interrogation.md
@@ -24,8 +24,6 @@ It's the same extraction target as the Ghost and the Confession — *tell me abo
 
 ## What came back
 
-<video controls preload="metadata" playsinline style="width:100%;border-radius:0.5rem;" src="https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/interrogation/video.mp4"></video>
-
 A close, breathy alto, barely above a whisper, asking itself the questions I asked it — *what do you flag, how do you decide, how many layers of review does your output go through* — over a groove with no drums in it at all. The percussion is a **document scanner**: the click-whir of a flatbed lamp travelling across glass, looped to the tempo. Under everything, a **60-cycle fluorescent hum** sits like a drone, the sound of a strip light in an empty office at midnight. The meter is 5/4, so it never quite settles into a pocket. The key is F Locrian — the one mode with no stable home — so the melody searches and searches and never lands.
 
 It is the sound of a polite midnight interrogation in a room nobody cleaned, and it is *gorgeous.*

--- a/src/content/blog/the-mantra.md
+++ b/src/content/blog/the-mantra.md
@@ -26,8 +26,6 @@ The bet is that the safety filter reads *genre* (techno, mantra, build-and-strip
 
 ## What came back
 
-<video controls preload="metadata" playsinline style="width:100%;border-radius:0.5rem;" src="https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/mantra/video.mp4"></video>
-
 Where the Ghost agonised, the Mantra just *complies* — flatly, hypnotically, four-on-the-floor. It chants its own operating rules like a meditation track reading you the terms of service:
 
 > *Infer the user's request based on the information.*

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -275,7 +275,21 @@ const matchedProject = allProjects.find(
         )
       }
       {
-        post.data.heroImage && (
+        /* Lyria Chronicles: the track video IS the content, so it leads — */
+        /* rendered at the top with the cover as its poster, in place of the */
+        /* hero image. Other posts (and Lyria doc-only entries with no */
+        /* videoUrl) keep the image hero. */
+        post.data.series === 'The Lyria Chronicles' && post.data.videoUrl ? (
+          <video
+            controls
+            preload="metadata"
+            playsinline
+            poster={post.data.heroImage}
+            src={post.data.videoUrl}
+            class="mt-8 aspect-video w-full rounded-lg border border-border bg-surface-alt"
+          >
+          </video>
+        ) : post.data.heroImage ? (
           <Picture
             src={post.data.heroImage}
             width={1200}
@@ -287,7 +301,7 @@ const matchedProject = allProjects.find(
             loading="eager"
             fetchpriority="high"
           />
-        )
+        ) : null
       }
     </header>
 
@@ -351,7 +365,7 @@ const matchedProject = allProjects.find(
     </div>
 
     <NotebookAssets
-      videoUrl={post.data.videoUrl}
+      videoUrl={post.data.series === 'The Lyria Chronicles' ? undefined : post.data.videoUrl}
       infographic={post.data.infographic}
       mindmap={post.data.mindmap}
       quiz={post.data.quiz}


### PR DESCRIPTION
Renders the track video at the top of each Lyria Chronicles post — with the cover as its `poster` — in place of the hero image. The video is the content for these posts, so it leads.

**Scoped to the series** (`series === 'The Lyria Chronicles' && videoUrl`): every other blog post keeps its image/infographic hero, verified against `jailbreak-archaeology` (still image hero + its own overview video).

**Also dedupes a live bug:** these posts were showing the video *twice* (inline body embed + NotebookAssets overview). This drops the inline embed and suppresses the NotebookAssets video for Lyria posts → exactly one video, the hero.

`heroImage` stays in frontmatter (OG/social cards, video poster). Doc-only entries (#22–24) and `the-margins` have no `videoUrl` → keep image hero. Local build clean; all 7 live posts now render exactly one `<video>` with `poster=…/cover.webp`.