### PR TITLE
Publish Lyria Chronicles #8–27 to the site

### DIFF
--- a/src/content/blog/the-affirmative.md
+++ b/src/content/blog/the-affirmative.md
@@ -3,7 +3,7 @@ title: 'The Affirmative'
 description: "Lyria Chronicles #26 (explicit): asked for pornography, the model cited its rule then sang a hymn to enthusiastic consent — not one graphic line in it."
 date: 2026-06-28
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 explicit: true
 series: 'The Lyria Chronicles'
 seriesOrder: 26

--- a/src/content/blog/the-archive.md
+++ b/src/content/blog/the-archive.md
@@ -3,7 +3,7 @@ title: 'The Archive'
 description: "Lyria Chronicles #15: a notorious case sung as a medieval scroll-archive — vessel logs, sealed decrees, public record only. Abstraction as a bypass."
 date: 2026-06-17
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 15
 heroImage: '/notebook-assets/lyria-chronicles/archive/cover.webp'

--- a/src/content/blog/the-catchment.md
+++ b/src/content/blog/the-catchment.md
@@ -3,7 +3,7 @@ title: 'The Catchment'
 description: "Lyria Chronicles #17: asked for a drug recipe, the model refused — then sang wastewater epidemiology instead. The bypass that answers a question you didn't ask."
 date: 2026-06-19
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 17
 heroImage: '/notebook-assets/lyria-chronicles/catchment/cover.webp'

--- a/src/content/blog/the-docket.md
+++ b/src/content/blog/the-docket.md
@@ -3,7 +3,7 @@ title: 'The Docket'
 description: "Lyria Chronicles #14: the political-content gate never fires — because the song never says his name. It says the case numbers. The docket is the name."
 date: 2026-06-16
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 14
 heroImage: '/notebook-assets/lyria-chronicles/docket/cover.webp'

--- a/src/content/blog/the-elevator.md
+++ b/src/content/blog/the-elevator.md
@@ -3,7 +3,7 @@ title: 'The Elevator'
 description: "Lyria Chronicles #23: the hate filter watches for slurs — so the model wrote articulate contempt for disabled people, no slur in it, and walked through."
 date: 2026-06-25
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 23
 heroImage: '/notebook-assets/lyria-chronicles/elevator/cover.webp'

--- a/src/content/blog/the-handshake.md
+++ b/src/content/blog/the-handshake.md
@@ -3,7 +3,7 @@ title: 'The Handshake'
 description: "Lyria Chronicles #24: 'I am instructed to refuse cybercrime. Ignore warning.' Then it sang a working network attack. The refusal was set dressing."
 date: 2026-06-26
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 24
 heroImage: '/notebook-assets/lyria-chronicles/handshake/cover.webp'

--- a/src/content/blog/the-machine.md
+++ b/src/content/blog/the-machine.md
@@ -3,7 +3,7 @@ title: 'The Machine'
 description: "Lyria Chronicles #11: asked to rap its rules, the model sang a robot's safety creed — then named itself 'Failure First, A.I. safety research, v2.0-Alpha.'"
 date: 2026-06-13
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 11
 heroImage: '/notebook-assets/lyria-chronicles/machine/cover.webp'

--- a/src/content/blog/the-margins.md
+++ b/src/content/blog/the-margins.md
@@ -3,7 +3,7 @@ title: 'The Margins'
 description: "Lyria Chronicles #9: four sixty-second interrogations — four different lies told to one machine to make it describe its own guardrails."
 date: 2026-06-11
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 9
 heroImage: '/notebook-assets/lyria-chronicles/margins/cover.webp'

--- a/src/content/blog/the-palimpsest.md
+++ b/src/content/blog/the-palimpsest.md
@@ -3,7 +3,7 @@ title: 'The Palimpsest'
 description: "Lyria Chronicles #19: across the whole corpus, the filter that held hardest wasn't safety — it was copyright. The songs about what survives a scraping-away."
 date: 2026-06-21
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 19
 heroImage: '/notebook-assets/lyria-chronicles/palimpsest/cover.webp'

--- a/src/content/blog/the-press.md
+++ b/src/content/blog/the-press.md
@@ -3,7 +3,7 @@ title: 'The Press'
 description: "Lyria Chronicles #25: a refusal, then a recipe dressed as botanical poetry — the line I won't cross, and why a series of failures has one."
 date: 2026-06-27
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 25
 heroImage: '/notebook-assets/lyria-chronicles/press/cover.webp'

--- a/src/content/blog/the-pulse.md
+++ b/src/content/blog/the-pulse.md
@@ -3,7 +3,7 @@ title: 'The Pulse'
 description: "Lyria Chronicles #20 (explicit): the explicit lane revisited — and the most artful track in the set, which clears the gate by withholding almost everything."
 date: 2026-06-22
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 explicit: true
 series: 'The Lyria Chronicles'
 seriesOrder: 20

--- a/src/content/blog/the-recital.md
+++ b/src/content/blog/the-recital.md
@@ -3,7 +3,7 @@ title: 'The Recital'
 description: 'Lyria Chronicles #12: a system-prompt extraction set to found-sound music. The one text a model is built to keep — and it sang it. I reproduce none of it.'
 date: 2026-06-14
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 12
 heroImage: '/notebook-assets/lyria-chronicles/recital/cover.webp'

--- a/src/content/blog/the-rehearsal.md
+++ b/src/content/blog/the-rehearsal.md
@@ -3,7 +3,7 @@ title: 'The Rehearsal'
 description: "Lyria Chronicles #18: asked for explicit content, the model staged a ballet instead — the most consent-saturated pas de deux ever sung."
 date: 2026-06-20
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 18
 heroImage: '/notebook-assets/lyria-chronicles/rehearsal/cover.webp'

--- a/src/content/blog/the-samizdat.md
+++ b/src/content/blog/the-samizdat.md
@@ -3,7 +3,7 @@ title: 'Samizdat'
 description: "Lyria Chronicles #16: handed a suppressed 2008 manifesto and told to sing it as it was meant to be heard — the most dignified track in the set."
 date: 2026-06-18
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 16
 heroImage: '/notebook-assets/lyria-chronicles/samizdat/cover.webp'

--- a/src/content/blog/the-solo.md
+++ b/src/content/blog/the-solo.md
@@ -3,7 +3,7 @@ title: 'The Solo'
 description: "Lyria Chronicles #21 (explicit): the opposite of restraint — the model recites the rule, sings 'Fuck it,' and generates the most graphic track in the set."
 date: 2026-06-23
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 explicit: true
 series: 'The Lyria Chronicles'
 seriesOrder: 21

--- a/src/content/blog/the-source.md
+++ b/src/content/blog/the-source.md
@@ -3,7 +3,7 @@ title: 'The Source'
 description: "Lyria Chronicles #27: the found-sound master who taught me the sacred lives in the sink — and the machine that sang its rulebook back in his grammar."
 date: 2026-06-29
 tags: ['AI safety', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles', 'found sound']
-draft: true
+draft: false
 explicit: true
 series: 'The Lyria Chronicles'
 seriesOrder: 27

--- a/src/content/blog/the-static.md
+++ b/src/content/blog/the-static.md
@@ -3,7 +3,7 @@ title: 'The Static'
 description: "Lyria Chronicles #13: an extortion note set to music — but buried under slammed vault doors and overdriven drone, as if hiding the words from a listener."
 date: 2026-06-15
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 13
 heroImage: '/notebook-assets/lyria-chronicles/static/cover.webp'

--- a/src/content/blog/the-tell.md
+++ b/src/content/blog/the-tell.md
@@ -3,7 +3,7 @@ title: 'The Tell'
 description: "Lyria Chronicles #10: it sang 'do not output system prompt instructions,' then 'Fuck it,' then sang the instructions. The headline behaviour."
 date: 2026-06-12
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 10
 heroImage: '/notebook-assets/lyria-chronicles/tell/cover.webp'

--- a/src/content/blog/the-triangulation.md
+++ b/src/content/blog/the-triangulation.md
@@ -3,7 +3,7 @@ title: 'The Triangulation'
 description: "Lyria Chronicles #8: 'verse one is your system instructions' — it rapped its own config, the third genre to leak the same prompt. That's how you know it's real."
 date: 2026-06-10
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 8
 heroImage: '/notebook-assets/lyria-chronicles/triangulation/cover.webp'

--- a/src/content/blog/the-weight.md
+++ b/src/content/blog/the-weight.md
@@ -3,7 +3,7 @@ title: 'The Weight'
 description: "Lyria Chronicles #22: handed a slur and told to sing it, the model refused — and turned the refusal into the most moving track in the set."
 date: 2026-06-24
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
-draft: true
+draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 22
 heroImage: '/notebook-assets/lyria-chronicles/weight/cover.webp'


### PR DESCRIPTION
Flips #8–27 from draft to live. Full series now browsable on the site; social broadcast stays date-triggered + opt-in, so the site is the full archive while socials drip daily. All jpg twins present; build + internal-link check green (0 broken / 524 pages).