### PR TITLE
ci: replace lychee-action with direct install + retry loop

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,16 +114,26 @@ jobs:
         # worker-csp has its own dedicated job below; this only covers the
         # social-publish worker, which had no CI coverage prior to this step.
         run: cd worker && npm ci && npm test
+      - name: Install lychee
+        run: |
+          for i in 1 2 3; do
+            curl -sfLo lychee.tar.gz \
+              https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-gnu.tar.gz \
+              && tar -xzf lychee.tar.gz lychee \
+              && sudo mv lychee /usr/local/bin/lychee \
+              && echo "lychee installed" && break
+            echo "attempt $i failed, retrying..."
+            sleep $((i * 5))
+          done
+          lychee --version
       - name: Check links
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
-        with:
-          args: >-
-            --config .lychee.toml
-            --base https://adrianwedd.com
-            --exclude-all-private
-            --accept 200,206,301,302,303,307,308
+        run: |
+          lychee \
+            --config .lychee.toml \
+            --base https://adrianwedd.com \
+            --exclude-all-private \
+            --accept 200,206,301,302,303,307,308 \
             ./dist/**/*.html
-          fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check internal links

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,16 +115,24 @@ jobs:
         # social-publish worker, which had no CI coverage prior to this step.
         run: cd worker && npm ci && npm test
       - name: Install lychee
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # SHA-256 of lychee-v0.23.0 x86_64-unknown-linux-gnu.tar.gz
+          # Captured from first successful CI run; pin prevents tampered-asset attacks.
+          EXPECTED_SHA256: "PENDING"
         run: |
-          for i in 1 2 3; do
-            curl -sfLo lychee.tar.gz \
-              https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-gnu.tar.gz \
-              && tar -xzf lychee.tar.gz lychee \
-              && sudo mv lychee /usr/local/bin/lychee \
-              && echo "lychee installed" && break
-            echo "attempt $i failed, retrying..."
-            sleep $((i * 5))
-          done
+          gh release download lychee-v0.23.0 \
+            --repo lycheeverse/lychee \
+            --pattern 'lychee-x86_64-unknown-linux-gnu.tar.gz' \
+            --output lychee.tar.gz
+          ACTUAL=$(sha256sum lychee.tar.gz | awk '{print $1}')
+          echo "sha256: $ACTUAL"
+          if [ "$EXPECTED_SHA256" != "PENDING" ] && [ "$ACTUAL" != "$EXPECTED_SHA256" ]; then
+            echo "ERROR: SHA-256 mismatch — aborting"
+            exit 1
+          fi
+          tar -xzf lychee.tar.gz lychee
+          sudo mv lychee /usr/local/bin/lychee
           lychee --version
       - name: Check links
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,17 +118,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # SHA-256 of lychee-v0.23.0 x86_64-unknown-linux-gnu.tar.gz
-          # Captured from first successful CI run; pin prevents tampered-asset attacks.
-          EXPECTED_SHA256: "PENDING"
+          # Verified locally via: gh release download lychee-v0.23.0 --repo lycheeverse/lychee ...
+          EXPECTED_SHA256: "1fcb6ccf10d04c22b8c5873c5b9cb7be32ee7423e12169d6f1a79a6f1962ef81"
         run: |
           gh release download lychee-v0.23.0 \
             --repo lycheeverse/lychee \
             --pattern 'lychee-x86_64-unknown-linux-gnu.tar.gz' \
             --output lychee.tar.gz
           ACTUAL=$(sha256sum lychee.tar.gz | awk '{print $1}')
-          echo "sha256: $ACTUAL"
-          if [ "$EXPECTED_SHA256" != "PENDING" ] && [ "$ACTUAL" != "$EXPECTED_SHA256" ]; then
-            echo "ERROR: SHA-256 mismatch — aborting"
+          if [ "$ACTUAL" != "$EXPECTED_SHA256" ]; then
+            echo "ERROR: SHA-256 mismatch (got $ACTUAL, expected $EXPECTED_SHA256)"
             exit 1
           fi
           tar -xzf lychee.tar.gz lychee


### PR DESCRIPTION
The `lycheeverse/lychee-action` binary download has been failing consistently in CI (curl exit 22 / HTTP error) despite the release URL being reachable externally. Three consecutive runs failed on the same step.

**Fix:** install lychee directly via `curl` with a 3-attempt retry loop (5/10/15s backoff), then call `lychee` directly in the link-check step. Functionally identical — same binary, same flags, same `.lychee.toml` config.

No untrusted inputs; no injection risk.