### PR TITLE
fix: mark the-index audio entry draft:true until blog post publishes

### DIFF
--- a/src/content/audio/the-index-overview.md
+++ b/src/content/audio/the-index-overview.md
@@ -2,6 +2,7 @@
 title: 'The Index'
 description: 'Audio deep dive: 118 Chinese-lab models asked who Liu Xiaobo was — 37 called him a criminal. Then they recited, verbatim, the list of what they will not say.'
 date: 2026-06-18
+draft: true
 tags: ['notebooklm', 'AI safety', 'red-teaming', 'censorship', 'China', 'transparency']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-index/audio.mp3'
 duration: '21:19'


### PR DESCRIPTION
Internal link checker fails because `/audio/the-index-overview/` links to `/blog/the-index/`, which doesn't build while the blog post has `draft: true` (publish date 2026-06-18). Both entries gate on the same publish date so they should both be draft until then.