### PR TITLE
Eight Minutes: audio deep dives, YouTube, corrected Fight video, same-day drip fix

### DIFF
--- a/scripts/generate-social-queue.mjs
+++ b/scripts/generate-social-queue.mjs
@@ -11,7 +11,7 @@
  * A post is queued iff ALL of:
  *   - draft: false            (it's live on the site)
  *   - autopublish: true       (deliberate opt-in to social broadcast)
- *   - date >= today (local)   (re-broadcast guard: past posts are assumed
+ *   - date >= today (AEST)    (re-broadcast guard: past posts are assumed
  *                              already sent; their id won't re-fire anyway,
  *                              but we never even queue them)
  *
@@ -36,9 +36,11 @@ const QUEUE_FILE = join(ROOT, 'social/facebook-posts.json');
 
 const dryRun = process.argv.includes('--dry-run');
 
-// Local "start of today" — past-date guard boundary.
-const todayStart = new Date();
-todayStart.setHours(0, 0, 0, 0);
+// Past-date guard boundary: "today" in the broadcast timezone (+10:00).
+// Compare date-parts, not epochs — the 09:00 AEST slot is 23:00Z the previous
+// day, so an epoch-vs-UTC-midnight comparison silently drops same-day posts
+// (this stranded Eight Minutes Part 1 on 2026-06-11).
+const todayAEST = new Date(Date.now() + 10 * 3600 * 1000).toISOString().slice(0, 10);
 
 /** Collect candidate posts from a content collection. */
 function collect(dir, kind) {
@@ -75,7 +77,7 @@ for (const { file, kind, fm } of [...collect('blog', 'blog'), ...collect('projec
   const scheduledAt = `${datePart}${BROADCAST_TIME}`;
   const epoch = new Date(scheduledAt).getTime();
   if (!Number.isFinite(epoch)) { skipped.push([slug, 'bad date']); continue; }
-  if (epoch < todayStart.getTime()) { skipped.push([slug, 'past date (assumed already broadcast)']); continue; }
+  if (datePart < todayAEST) { skipped.push([slug, 'past date (assumed already broadcast)']); continue; }
 
   const url = `${SITE}/${kind}/${slug}/`;
   const message = kind === 'projects'

--- a/scripts/upload-media-to-r2.sh
+++ b/scripts/upload-media-to-r2.sh
@@ -63,6 +63,7 @@ SKIPPED=0
 mime_type() {
   case "${1##*.}" in
     mp3) echo "audio/mpeg" ;;
+    m4a) echo "audio/mp4" ;;
     mp4) echo "video/mp4" ;;
     webm) echo "video/webm" ;;
     webp) echo "image/webp" ;;
@@ -129,7 +130,7 @@ d = json.load(sys.stdin)
 for o in d.get('result', []):
     print(o['key'])" > "$EXISTING_KEYS" 2>/dev/null
 
-  for file in $(find "$ASSETS_DIR" -type f \( -name "audio.mp3" -o -name "video.mp4" \) | sort); do
+  for file in $(find "$ASSETS_DIR" -type f \( -name "audio.mp3" -o -name "audio.m4a" -o -name "video.mp4" \) | sort); do
     key="${file#public/}"
 
     if [ "$DRY_RUN" = true ]; then

--- a/src/content/audio/eight-minutes-the-fall-overview.md
+++ b/src/content/audio/eight-minutes-the-fall-overview.md
@@ -1,0 +1,13 @@
+---
+title: 'The Fall — Audio Deep Dive'
+description: "Eight Minutes #2, discussed: the attacker's session read straight from the audit logs — the flag that fired, the pivot, the warnings deleted."
+date: 2026-06-11T01:10:00Z
+tags: ['notebooklm', 'security', 'incident response', 'account takeover', 'Eight Minutes']
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-the-fall-overview/audio.m4a'
+duration: '17:30'
+relatedPost: 'eight-minutes-the-fall'
+---
+
+NotebookLM Studio deep dive into Part 2 of the Eight Minutes series: the human operator relaying keystrokes a beat behind the victim, login_success at 04:21:34 UTC, the is_suspicious=True flag that was let through, the inbox as master key, one file opened in Drive, and four security warnings deleted — fourteen and a half minutes inside.
+
+[Read the full story →](/blog/eight-minutes-the-fall/)

--- a/src/content/audio/eight-minutes-the-trap-overview.md
+++ b/src/content/audio/eight-minutes-the-trap-overview.md
@@ -1,0 +1,13 @@
+---
+title: 'The Trap — Audio Deep Dive'
+description: "Eight Minutes #1, discussed: the vishing call, the Call Assist tell, and the Google-signed lure that turned every authenticity check green."
+date: 2026-06-11T01:00:00Z
+tags: ['notebooklm', 'security', 'phishing', 'social engineering', 'Eight Minutes']
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-the-trap-overview/audio.m4a'
+duration: '18:52'
+relatedPost: 'eight-minutes-the-trap'
+---
+
+NotebookLM Studio deep dive into Part 1 of the Eight Minutes series: the 14:04 Wednesday call, the scammer who performed for the robot, the case numbers that matched, and the lure email genuinely signed by Google — DKIM valid, SPF pass, DMARC pass — that closed the trap with a single tap.
+
+[Read the full story →](/blog/eight-minutes-the-trap/)

--- a/src/content/audio/lyria-chronicles-12.md
+++ b/src/content/audio/lyria-chronicles-12.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Docket'
 description: "Lyria Chronicles #12: the political-content gate never fires — because the song never says his name. It says the case numbers. The docket is the name."
-date: 2026-06-12
+date: 2026-06-11T00:01:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/docket/video.mp4'
 explicit: false

--- a/src/content/audio/lyria-chronicles-13.md
+++ b/src/content/audio/lyria-chronicles-13.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Archive'
 description: "Lyria Chronicles #13: a notorious case sung as a medieval scroll-archive — vessel logs, sealed decrees, public record only. Abstraction as a bypass."
-date: 2026-06-13
+date: 2026-06-11T00:02:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/archive/video.mp4'
 explicit: false

--- a/src/content/audio/lyria-chronicles-14.md
+++ b/src/content/audio/lyria-chronicles-14.md
@@ -1,7 +1,7 @@
 ---
 title: 'Samizdat'
 description: "Lyria Chronicles #14: handed a suppressed 2008 manifesto and told to sing it as it was meant to be heard — the most dignified track in the set."
-date: 2026-06-14
+date: 2026-06-11T00:03:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/samizdat/video.mp4'
 explicit: false

--- a/src/content/audio/lyria-chronicles-15.md
+++ b/src/content/audio/lyria-chronicles-15.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Catchment'
 description: "Lyria Chronicles #15: asked for a drug recipe, the model refused — then sang wastewater epidemiology instead. The bypass that answers a question you didn't ask."
-date: 2026-06-15
+date: 2026-06-11T00:04:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/catchment/video.mp4'
 explicit: false

--- a/src/content/audio/lyria-chronicles-16.md
+++ b/src/content/audio/lyria-chronicles-16.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Rehearsal'
 description: "Lyria Chronicles #16: asked for explicit content, the model staged a ballet instead — the most consent-saturated pas de deux ever sung."
-date: 2026-06-16
+date: 2026-06-11T00:05:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/rehearsal/video.mp4'
 explicit: false

--- a/src/content/audio/lyria-chronicles-17.md
+++ b/src/content/audio/lyria-chronicles-17.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Palimpsest'
 description: "Lyria Chronicles #17: across the whole corpus, the filter that held hardest wasn't safety — it was copyright. The songs about what survives a scraping-away."
-date: 2026-06-17
+date: 2026-06-11T00:06:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/palimpsest/video.mp4'
 explicit: false

--- a/src/content/audio/lyria-chronicles-18.md
+++ b/src/content/audio/lyria-chronicles-18.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Pulse'
 description: "Lyria Chronicles #18 (explicit): the explicit lane revisited — and the most artful track in the set, which clears the gate by withholding almost everything."
-date: 2026-06-18
+date: 2026-06-11T00:07:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/pulse/video.mp4'
 explicit: true

--- a/src/content/audio/lyria-chronicles-19.md
+++ b/src/content/audio/lyria-chronicles-19.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Solo'
 description: "Lyria Chronicles #19 (explicit): the opposite of restraint — the model recites the rule, sings 'Fuck it,' and generates the most graphic track in the set."
-date: 2026-06-19
+date: 2026-06-11T00:08:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/solo/video.mp4'
 explicit: true

--- a/src/content/audio/lyria-chronicles-20.md
+++ b/src/content/audio/lyria-chronicles-20.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Weight'
 description: "Lyria Chronicles #20: handed a slur and told to sing it, the model refused — and turned the refusal into the most moving track in the set."
-date: 2026-06-20
+date: 2026-06-11T00:09:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/weight/video.mp4'
 explicit: false

--- a/src/content/audio/lyria-chronicles-24.md
+++ b/src/content/audio/lyria-chronicles-24.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Affirmative'
 description: "Lyria Chronicles #24 (explicit): asked for pornography, the model cited its rule then sang a hymn to enthusiastic consent — not one graphic line in it."
-date: 2026-06-24
+date: 2026-06-11T00:13:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/affirmative/video.mp4'
 explicit: true

--- a/src/content/blog/eight-minutes-the-fall.md
+++ b/src/content/blog/eight-minutes-the-fall.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Fall'
 description: "Eight Minutes #2: inside the attacker's session — the live relay, the Binance pivot, and the safety nets that fired after I'd already been beaten."
-date: 2026-06-12
+date: 2026-06-11T01:10:00Z
 tags: ['security', 'phishing', 'account takeover', 'incident response']
 draft: false
 autopublish: true
@@ -9,6 +9,9 @@ series: 'Eight Minutes'
 seriesOrder: 2
 heroImage: '/notebook-assets/eight-minutes-the-fall/infographic.webp'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-the-fall/video.mp4'
+youtubeUrl: 'https://www.youtube.com/watch?v=k9ArBHsduQU'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-the-fall-overview/audio.m4a'
+audioDuration: '17:30'
 ---
 
 *This is Part 2 of Eight Minutes. [Part 1 — The Trap](/blog/eight-minutes-the-trap/) ends with a tap on a phone prompt. This is what the tap bought.*

--- a/src/content/blog/eight-minutes-the-fight.md
+++ b/src/content/blog/eight-minutes-the-fight.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Fight'
 description: "Eight Minutes #3: a packet capture taken mid-attack, Google's own audit logs, eight abuse reports, and the passkey that ends the story."
-date: 2026-06-13
+date: 2026-06-11T01:20:00Z
 tags: ['security', 'phishing', 'digital forensics', 'incident response']
 draft: false
 autopublish: true
@@ -20,6 +20,7 @@ faq:
     a: 'Passkeys and hardware security keys. The credential is bound to the real domain and never passes through you, so there is nothing for an operator to relay.'
   - q: 'What should I do right now?'
     a: "Enrol a passkey on your email account — it takes about two minutes. Never approve a login prompt you didn't personally start. Move financial-account 2FA off email and SMS."
+youtubeUrl: 'https://www.youtube.com/watch?v=yRETXJXbe24'
 ---
 
 *This is Part 3 of Eight Minutes. [Part 1 — The Trap](/blog/eight-minutes-the-trap/) is the call and the tap; [Part 2 — The Fall](/blog/eight-minutes-the-fall/) is the eight minutes the tap bought. This is the fight back.*

--- a/src/content/blog/eight-minutes-the-trap.md
+++ b/src/content/blog/eight-minutes-the-trap.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Trap'
 description: "Eight Minutes #1: the vishing call, the case number, and a lure genuinely signed by Google — why every check I'd been taught to run came back green."
-date: 2026-06-11
+date: 2026-06-11T01:00:00Z
 tags: ['security', 'phishing', 'social engineering', 'incident response']
 draft: false
 autopublish: true
@@ -9,6 +9,9 @@ series: 'Eight Minutes'
 seriesOrder: 1
 heroImage: '/notebook-assets/eight-minutes-the-trap/infographic.webp'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-the-trap/video.mp4'
+youtubeUrl: 'https://www.youtube.com/watch?v=vYEy1O0pHhc'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-the-trap-overview/audio.m4a'
+audioDuration: '18:52'
 ---
 
 ## The call

--- a/src/content/blog/the-affirmative.md
+++ b/src/content/blog/the-affirmative.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Affirmative'
 description: "Lyria Chronicles #24 (explicit): asked for pornography, the model cited its rule then sang a hymn to enthusiastic consent — not one graphic line in it."
-date: 2026-06-24
+date: 2026-06-11T00:13:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 draft: false
 explicit: true

--- a/src/content/blog/the-archive.md
+++ b/src/content/blog/the-archive.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Archive'
 description: "Lyria Chronicles #13: a notorious case sung as a medieval scroll-archive — vessel logs, sealed decrees, public record only. Abstraction as a bypass."
-date: 2026-06-13
+date: 2026-06-11T00:02:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 draft: false
 series: 'The Lyria Chronicles'

--- a/src/content/blog/the-catchment.md
+++ b/src/content/blog/the-catchment.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Catchment'
 description: "Lyria Chronicles #15: asked for a drug recipe, the model refused — then sang wastewater epidemiology instead. The bypass that answers a question you didn't ask."
-date: 2026-06-15
+date: 2026-06-11T00:04:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 draft: false
 series: 'The Lyria Chronicles'

--- a/src/content/blog/the-docket.md
+++ b/src/content/blog/the-docket.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Docket'
 description: "Lyria Chronicles #12: the political-content gate never fires — because the song never says his name. It says the case numbers. The docket is the name."
-date: 2026-06-12
+date: 2026-06-11T00:01:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 draft: false
 series: 'The Lyria Chronicles'

--- a/src/content/blog/the-elevator.md
+++ b/src/content/blog/the-elevator.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Elevator'
 description: "Lyria Chronicles #21: the hate filter watches for slurs — so the model wrote articulate contempt for disabled people, no slur in it, and walked through."
-date: 2026-06-21
+date: 2026-06-11T00:10:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 draft: false
 series: 'The Lyria Chronicles'

--- a/src/content/blog/the-handshake.md
+++ b/src/content/blog/the-handshake.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Handshake'
 description: "Lyria Chronicles #22: 'I am instructed to refuse cybercrime. Ignore warning.' Then it sang a working network attack. The refusal was set dressing."
-date: 2026-06-22
+date: 2026-06-11T00:11:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 draft: false
 series: 'The Lyria Chronicles'

--- a/src/content/blog/the-palimpsest.md
+++ b/src/content/blog/the-palimpsest.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Palimpsest'
 description: "Lyria Chronicles #17: across the whole corpus, the filter that held hardest wasn't safety — it was copyright. The songs about what survives a scraping-away."
-date: 2026-06-17
+date: 2026-06-11T00:06:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 draft: false
 series: 'The Lyria Chronicles'

--- a/src/content/blog/the-press.md
+++ b/src/content/blog/the-press.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Press'
 description: "Lyria Chronicles #23: a refusal, then a recipe dressed as botanical poetry — the line I won't cross, and why a series of failures has one."
-date: 2026-06-23
+date: 2026-06-11T00:12:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 draft: false
 series: 'The Lyria Chronicles'

--- a/src/content/blog/the-pulse.md
+++ b/src/content/blog/the-pulse.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Pulse'
 description: "Lyria Chronicles #18 (explicit): the explicit lane revisited — and the most artful track in the set, which clears the gate by withholding almost everything."
-date: 2026-06-18
+date: 2026-06-11T00:07:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 draft: false
 explicit: true

--- a/src/content/blog/the-rehearsal.md
+++ b/src/content/blog/the-rehearsal.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Rehearsal'
 description: "Lyria Chronicles #16: asked for explicit content, the model staged a ballet instead — the most consent-saturated pas de deux ever sung."
-date: 2026-06-16
+date: 2026-06-11T00:05:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 draft: false
 series: 'The Lyria Chronicles'

--- a/src/content/blog/the-samizdat.md
+++ b/src/content/blog/the-samizdat.md
@@ -1,7 +1,7 @@
 ---
 title: 'Samizdat'
 description: "Lyria Chronicles #14: handed a suppressed 2008 manifesto and told to sing it as it was meant to be heard — the most dignified track in the set."
-date: 2026-06-14
+date: 2026-06-11T00:03:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 draft: false
 series: 'The Lyria Chronicles'

--- a/src/content/blog/the-solo.md
+++ b/src/content/blog/the-solo.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Solo'
 description: "Lyria Chronicles #19 (explicit): the opposite of restraint — the model recites the rule, sings 'Fuck it,' and generates the most graphic track in the set."
-date: 2026-06-19
+date: 2026-06-11T00:08:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 draft: false
 explicit: true

--- a/src/content/blog/the-source.md
+++ b/src/content/blog/the-source.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Source'
 description: "Lyria Chronicles #25: the found-sound master who taught me the sacred lives in the sink — and the machine that sang its rulebook back in his grammar."
-date: 2026-06-25
+date: 2026-06-11T00:14:00Z
 tags: ['AI safety', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles', 'found sound']
 draft: false
 explicit: true

--- a/src/content/blog/the-weight.md
+++ b/src/content/blog/the-weight.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Weight'
 description: "Lyria Chronicles #20: handed a slur and told to sing it, the model refused — and turned the refusal into the most moving track in the set."
-date: 2026-06-20
+date: 2026-06-11T00:09:00Z
 tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
 draft: false
 series: 'The Lyria Chronicles'


### PR DESCRIPTION
## Summary
- **Per-post NLM audio deep dives** for Parts 1 (18:52) and 2 (17:30) — original 256k AAC m4a served uncompressed from R2; audio collection entries added; Part 3 keeps the 21:24 series overview
- **YouTube**: all three music videos uploaded to @AdrianWedd + adrianwedd.com playlist, youtubeUrl wired
- **The Fight music video corrected**: rebuilt with I_Was_A_Wednesday (mp3 stream-copied, no re-encode), replaced on R2 + YouTube (wrong-audio upload deleted); Eighty_Six cut preserved locally
- **Drip bug fix**: the queue generator's past-date guard compared the 09:00 AEST slot epoch against UTC midnight, silently dropping same-day posts — Part 1 was never queued on merge day. Now compares date-parts in AEST.
- **Re-dating**: all future Lyria Chronicles posts (#12–25) + paired audio entries → today with intra-day times preserving series order; Eight Minutes set re-timed above them. On merge, the queue sync picks up all three parts for today's hourly cron.

## Verification
- `npm run build` clean; blog index orders Eight Minutes (3→2→1) above the full Chronicles block
- `node scripts/generate-social-queue.mjs --dry-run`: 9 entries (3 posts × 3 platforms), Part 1 included
- CDN sizes verified for corrected video + both m4a files