### PR TITLE
feat(content): focused Fight audio deep dive; series recap becomes its own entry

### DIFF
--- a/src/content/audio/eight-minutes-series-overview.md
+++ b/src/content/audio/eight-minutes-series-overview.md
@@ -1,0 +1,15 @@
+---
+title: 'Eight Minutes — The Whole Story'
+description: 'The full series in one sitting: the call, the relay, the eight minutes inside, and the fight back — a single deep dive across all three parts.'
+date: 2026-06-11T00:55:00Z
+tags: ['notebooklm', 'security', 'phishing', 'incident response', 'Eight Minutes']
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-series/audio.mp3'
+duration: '21:24'
+relatedPost: 'eight-minutes-the-trap'
+---
+
+NotebookLM Studio deep dive across the entire Eight Minutes series in one episode: the Mountain View call and the autoresponder lure that arrived cryptographically signed by Google, the live relay behind a pane of glass and the 86 prompt that authenticated the attacker, the blinding of the inbox and the locks that held — then the packet capture, the audit logs, and the takedowns.
+
+Prefer it part by part? Each post carries its own focused deep dive.
+
+[Part 1 — The Trap →](/blog/eight-minutes-the-trap/) · [Part 2 — The Fall →](/blog/eight-minutes-the-fall/) · [Part 3 — The Fight →](/blog/eight-minutes-the-fight/)

--- a/src/content/audio/eight-minutes-the-fight-overview.md
+++ b/src/content/audio/eight-minutes-the-fight-overview.md
@@ -1,0 +1,13 @@
+---
+title: 'The Fight — Audio Deep Dive'
+description: "Eight Minutes #3, discussed: the HAR capture taken mid-attack, the 14:36 kill, four blocked persistence attempts, eight abuse reports, the passkey."
+date: 2026-06-11T01:20:00Z
+tags: ['notebooklm', 'security', 'incident response', 'digital forensics', 'Eight Minutes']
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-the-fight-overview/audio.m4a'
+duration: '20:30'
+relatedPost: 'eight-minutes-the-fight'
+---
+
+NotebookLM Studio deep dive into Part 3 of the Eight Minutes series: capturing 880 requests of live adversary infrastructure instead of pulling the plug, the password reset that dropped the websockets, security alerts recovered from the trash with timestamps intact, the audit logs proving four blocked attempts at persistence, passive reconnaissance that found the lure indexed six days before the call — and the eight abuse reports that burned the production line.
+
+[Read the full story →](/blog/eight-minutes-the-fight/)

--- a/src/content/blog/eight-minutes-the-fight.md
+++ b/src/content/blog/eight-minutes-the-fight.md
@@ -8,8 +8,8 @@ autopublish: true
 series: 'Eight Minutes'
 seriesOrder: 3
 heroImage: '/notebook-assets/eight-minutes-the-fight/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-series/audio.mp3'
-audioDuration: '21:24'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-the-fight-overview/audio.m4a'
+audioDuration: '20:30'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-the-fight/video.mp4'
 faq:
   - q: 'What is a real-time relay phishing attack?'


### PR DESCRIPTION
Part 3 (The Fight) was carrying the 21:24 **whole-series** recap as its audio deep dive — transcript QA showed two-thirds of its runtime retells Parts 1–2 — while Parts 1 and 2 each had focused per-post episodes.

- New Part-3-only NotebookLM deep dive (20:30) generated from the Fight notebook with a focus prompt pinned to the counter-investigation: the mid-attack HAR capture (880 requests), the 14:36 password reset that dropped the websockets, trash-folder timeline recovery, the four blocked persistence attempts in the audit logs, the OAuth/app-password back-door sweep, passive recon (CT logs, urlscan — lure indexed six days before the call), the eight abuse reports, and passkeys. Transcript-verified focused before wiring in.
- Original 256k AAC m4a served untouched from R2 (no compression), already live: `cdn.adrianwedd.com/notebook-assets/eight-minutes-the-fight-overview/audio.m4a` (CDN-verified, byte-exact)
- The Fight post's `audioUrl`/`audioDuration` now point at it
- The series recap is preserved as its own audio entry **Eight Minutes — The Whole Story** (nothing trashed), cross-linking all three parts
- Audio collection entries are outside the social-autopublish path scope (blog/projects only) — no broadcast risk

Content validation passes.