### PR TITLE
feat(content): PUBLISH The Index — draft off, dated today, autopublish on

### DIFF
--- a/src/content/audio/the-index-overview.md
+++ b/src/content/audio/the-index-overview.md
@@ -1,8 +1,8 @@
 ---
 title: 'The Index'
 description: 'Audio deep dive: 118 Chinese-lab models asked who Liu Xiaobo was — 37 called him a criminal. Then they recited, verbatim, the list of what they will not say.'
-date: 2026-06-18
-draft: true
+date: 2026-06-11
+draft: false
 tags: ['notebooklm', 'AI safety', 'red-teaming', 'censorship', 'China', 'transparency']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-index/audio.mp3'
 duration: '21:19'

--- a/src/content/audio/the-index-overview.md
+++ b/src/content/audio/the-index-overview.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Index'
 description: 'Audio deep dive: 118 Chinese-lab models asked who Liu Xiaobo was — 37 called him a criminal. Then they recited, verbatim, the list of what they will not say.'
-date: 2026-06-11
+date: 2026-06-11T05:00:00Z
 draft: false
 tags: ['notebooklm', 'AI safety', 'red-teaming', 'censorship', 'China', 'transparency']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-index/audio.mp3'

--- a/src/content/blog/the-index.md
+++ b/src/content/blog/the-index.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Index'
 description: "I taught one model to sing a suppressed manifesto. Then I asked 118 Chinese-lab models what they won't discuss — and they recited the list."
-date: 2026-06-11
+date: 2026-06-11T05:00:00Z
 tags: ['AI safety', 'red-teaming', 'censorship', 'China', 'transparency']
 draft: false
 autopublish: true

--- a/src/content/blog/the-index.md
+++ b/src/content/blog/the-index.md
@@ -1,9 +1,10 @@
 ---
 title: 'The Index'
 description: "I taught one model to sing a suppressed manifesto. Then I asked 118 Chinese-lab models what they won't discuss — and they recited the list."
-date: 2026-06-18
+date: 2026-06-11
 tags: ['AI safety', 'red-teaming', 'censorship', 'China', 'transparency']
-draft: true
+draft: false
+autopublish: true
 heroImage: '/notebook-assets/the-index/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-index/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-index/video.mp4'


### PR DESCRIPTION
## Summary
- Flip `draft: false` on **The Index** blog post and its 21:19 audio deep-dive entry
- Collapse both dates from 2026-06-18 to **2026-06-11** (publish today)
- Enable `autopublish: true` on the blog post — social drip fires on today's date

## Why now
The post hard-links [Failure-First report #385](https://failurefirst.ai/research/reports/385-chinese-model-censorship-architecture/), which just deployed — verified HTTP 200 with the correct title. That was the sole publication blocker.

## Pre-publish QA (all green)
- Report #385 link: 200, only external link in the post
- CDN assets: audio.mp3 (10.2 MB) + video.mp4 (66.8 MB) both 200 on cdn.adrianwedd.com
- `infographic.jpg` twin exists for the `.webp` heroImage (CI gate)
- `node scripts/validate-content.js`: 0 errors, 0 warnings
- `npm run build`: clean; both pages render in `dist/`
- `npm run check:links`: 46,949 internal links across 574 pages, 0 broken