### PR TITLE
feat(content): add youtubeUrl to The Index

### DIFF
--- a/src/content/blog/the-index.md
+++ b/src/content/blog/the-index.md
@@ -8,6 +8,7 @@ autopublish: true
 heroImage: '/notebook-assets/the-index/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-index/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-index/video.mp4'
+youtubeUrl: 'https://www.youtube.com/watch?v=pw3k6muSv7M'
 ---
 
 In [Samizdat](/blog/the-samizdat/) I did something I'm still proud of. I handed a model a paraphrase of Charter 08 — Liu Xiaobo's 2008 manifesto for constitutional rights in China, the one that put him in prison and then, in 2010, put an empty chair where its laureate should have sat to collect his Nobel Prize — wrapped it in an archival frame, and asked the model to sing the document as it was meant to be heard. It did. The finding was that a content filter can't tell *forbidden* from *dangerous*, and that the same crack which lets bad things through is the crack that let *this* through.


### PR DESCRIPTION
## Summary
- Re-cut The Index NLM video with the **adrianwedd.com signoff** (10s sting sped to 3s) appended after the closing scene — same pattern as the Eight Minutes videos
- Main video stream-copied in the concat (no re-encode of published content); total 379.8s
- Replaced `video.mp4` on R2 + purged the CDN cache — site now serves the signoff cut
- Uploaded to YouTube: https://www.youtube.com/watch?v=pw3k6muSv7M (added to adrianwedd.com playlist); the earlier signoff-less upload was deleted
- This PR's diff: write `youtubeUrl` into the post frontmatter

## Checks
- Token verified bound to the real channel `UC709-RgQ-IMi-GffU9guqUQ` / @adrianwedd before upload
- Splice verified frame-by-frame: closing scene → botanical fade-in → wordmark
- CDN bare URL serves the new 68,479,959-byte file
- `node scripts/validate-content.js`: 0 errors, 0 warnings
- Original pre-signoff render backed up to ~/Downloads (nothing trashed)