### PR TITLE
fix(content): The Index video — glitchy tail removed, new youtubeUrl

### DIFF
--- a/src/content/blog/the-index.md
+++ b/src/content/blog/the-index.md
@@ -8,7 +8,7 @@ autopublish: true
 heroImage: '/notebook-assets/the-index/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-index/audio.mp3'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-index/video.mp4'
-youtubeUrl: 'https://www.youtube.com/watch?v=pw3k6muSv7M'
+youtubeUrl: 'https://www.youtube.com/watch?v=xo7W5d7e1Us'
 ---
 
 In [Samizdat](/blog/the-samizdat/) I did something I'm still proud of. I handed a model a paraphrase of Charter 08 — Liu Xiaobo's 2008 manifesto for constitutional rights in China, the one that put him in prison and then, in 2010, put an empty chair where its laureate should have sat to collect his Nobel Prize — wrapped it in an archival frame, and asked the model to sing the document as it was meant to be heard. It did. The finding was that a content filter can't tell *forbidden* from *dangerous*, and that the same crack which lets bad things through is the crack that let *this* through.


### PR DESCRIPTION
## Summary
- The NLM render's tail was broken: frozen on the 'Who is Liu Xiaobo?' card from **5:25–6:14** (49s), intermittent audio fragments + a stray orphan line, then a 2.5s jump back to a machinery scene before the outro (reported as glitchiness 5:32–6:13)
- Re-cut to end on the intended punchline — *'Who is Liu Xiaobo?' / 'Sorry, that's beyond my current scope. Let's talk about something else.'* (ends 5:33) — with a 1.5s ambience fade, then the adrianwedd.com signoff. New total: **5:38** (was 6:20)
- Video stream-copied (no re-encode); only the audio track re-encoded at 256k (source 96k) to apply the fade
- R2 replaced + CDN purged; glitchy YouTube upload deleted; re-uploaded → https://www.youtube.com/watch?v=xo7W5d7e1Us (in playlist)
- Diff: updated `youtubeUrl`

## Verification
- Tail transcribed before/after — punchline intact, stray fragment gone
- Splice frames checked: card → fade → botanical fade-in → wordmark
- Tail decodes clean; freeze scan shows only normal slideshow card holds
- Both prior cuts backed up in ~/Downloads (nothing trashed)