### PR TITLE
fix(content): The Index audio — original-quality m4a, fixes duration display

### DIFF
--- a/src/content/audio/the-index-overview.md
+++ b/src/content/audio/the-index-overview.md
@@ -4,7 +4,7 @@ description: 'Audio deep dive: 118 Chinese-lab models asked who Liu Xiaobo was â
 date: 2026-06-11T05:00:00Z
 draft: false
 tags: ['notebooklm', 'AI safety', 'red-teaming', 'censorship', 'China', 'transparency']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-index/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-index/audio.m4a'
 duration: '21:19'
 relatedPost: 'the-index'
 ---

--- a/src/content/blog/the-index.md
+++ b/src/content/blog/the-index.md
@@ -6,7 +6,7 @@ tags: ['AI safety', 'red-teaming', 'censorship', 'China', 'transparency']
 draft: false
 autopublish: true
 heroImage: '/notebook-assets/the-index/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-index/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-index/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-index/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=xo7W5d7e1Us'
 ---


### PR DESCRIPTION
## Summary
- The blog player showed `0:03 / 0:00` — the published `audio.mp3` had **no Xing/Info header**, so browsers couldn't read its duration
- It was also a **64 kbps mono transcode** (the stale CLAUDE.md compression step) — violates the serve-original-quality rule
- Re-downloaded the original from the NLM notebook: *The Stack of Suppression in Chinese AI* — verified identical (duration 1279.12s = 21:19 exactly, same opening narration by transcript)
- Now served as `audio.m4a` (257 kbps stereo AAC, proper moov metadata — same convention as Eight Minutes, whose players display duration correctly)
- Uploaded to R2 (CDN 200, 41.2 MB); both frontmatter references updated (blog post + audio entry)
- The old mp3 stays in place on R2/local — nothing deleted

## Verification
- `node scripts/validate-content.js`: 0 errors, 0 warnings
- CDN serves `audio/mp4` with content-length + accept-ranges