### PR TITLE
fix(content): restore original-quality audio for 34 tracks

### DIFF
--- a/src/content/audio/adhdo-overview.md
+++ b/src/content/audio/adhdo-overview.md
@@ -3,7 +3,7 @@ title: 'ADHDo: Neurodiversity-Affirming AI Assistant'
 description: 'Audio overview exploring ADHD executive function support through AI — three-stage reasoning pipeline, crisis detection, and zero shame by design.'
 date: 2026-02-05
 tags: ['notebooklm', 'adhd', 'ai-safety', 'neurodivergence']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adhdo/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adhdo/audio.m4a'
 duration: '8:47'
 relatedProject: 'adhdo'
 ---

--- a/src/content/audio/afterglow-engine-overview.md
+++ b/src/content/audio/afterglow-engine-overview.md
@@ -3,7 +3,7 @@ title: 'Mining Ghosts from Your Own Catalogue'
 description: 'Audio archaeology for musicians — how Afterglow Engine extracts reusable textures from your finished work using STFT analysis.'
 date: 2026-02-02
 tags: ['notebooklm', 'music', 'audio', 'creative']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterglow-engine/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterglow-engine/audio.m4a'
 duration: '14:33'
 relatedProject: 'afterglow-engine'
 ---

--- a/src/content/audio/afterwords-overview.md
+++ b/src/content/audio/afterwords-overview.md
@@ -3,7 +3,7 @@ title: 'Giving Claude Code a Voice'
 description: 'Audio overview of Afterwords — local voice output for Claude Code with 17 cloned voices, per-project selection, and zero cloud dependency.'
 date: 2026-03-22
 tags: ['notebooklm', 'ai', 'tts', 'voice-cloning']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterwords/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterwords/audio.m4a'
 duration: '21:43'
 relatedPost: 'afterwords-post'
 relatedProject: 'afterwords'

--- a/src/content/audio/agentic-index-overview.md
+++ b/src/content/audio/agentic-index-overview.md
@@ -3,7 +3,7 @@ title: 'Cutting Through the Agent Hype'
 description: 'An opinionated, scored catalogue of autonomous AI tooling — because GitHub stars measure hype, not quality.'
 date: 2025-08-01
 tags: ['notebooklm', 'ai', 'agents', 'curation']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/agentic-index/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/agentic-index/audio.m4a'
 duration: '17:17'
 relatedProject: 'agentic-index'
 ---

--- a/src/content/audio/alignment-regression-overview.md
+++ b/src/content/audio/alignment-regression-overview.md
@@ -3,7 +3,7 @@ title: 'Alignment Regression: Why Smarter AI Makes All AI Less Safe'
 description: 'Reasoning models autonomously jailbreak other AI systems at 97% success rate. Ecosystem safety degrades as individual models improve.'
 date: 2026-03-11
 tags: ['notebooklm', 'ai-safety', 'alignment', 'reasoning', 'jailbreaking', 'research']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/alignment-regression/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/alignment-regression/audio.m4a'
 duration: '21:36'
 relatedPost: 'alignment-regression-post'
 relatedProject: 'failure-first'

--- a/src/content/audio/before-the-words-existed-overview.md
+++ b/src/content/audio/before-the-words-existed-overview.md
@@ -3,7 +3,7 @@ title: "The ADHD Novel That Didn't Know It Was One"
 description: "A scholarly close reading arguing Gibson's Neuromancer encoded the ADHD experience a decade before the vocabulary existed."
 date: 2026-02-10
 tags: ['notebooklm', 'neurodivergence', 'literary-criticism', 'adhd']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/before-the-words-existed/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/before-the-words-existed/audio.m4a'
 duration: '16:50'
 relatedProject: 'before-the-words-existed'
 ---

--- a/src/content/audio/compute-is-not-governance-overview.md
+++ b/src/content/audio/compute-is-not-governance-overview.md
@@ -3,7 +3,7 @@ title: 'Compute Is Not Governance'
 description: "Anthropic's 2028 scenarios document three policy asks. Two are about maintaining compute advantage. That is not a governance strategy."
 date: 2026-05-25
 tags: ['notebooklm', 'ai-safety', 'policy', 'anthropic', 'governance', 'geopolitics']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/compute-is-not-governance/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/compute-is-not-governance/audio.m4a'
 duration: '21:29'
 relatedPost: 'compute-is-not-governance-post'
 ---

--- a/src/content/audio/cygnet-overview.md
+++ b/src/content/audio/cygnet-overview.md
@@ -3,7 +3,7 @@ title: 'Twenty-Eight Agents, One Eco Village'
 description: 'Audio overview of Cygnet — 28 AI agents coordinating 3D-printed housing on 170 acres in Tasmania to cut costs by 60%.'
 date: 2025-04-01
 tags: ['notebooklm', 'ai', 'housing', 'agents']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/cygnet/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/cygnet/audio.m4a'
 duration: '16:03'
 ---
 

--- a/src/content/audio/dodgylegally-overview.md
+++ b/src/content/audio/dodgylegally-overview.md
@@ -3,7 +3,7 @@ title: 'Manufacturing Happy Accidents'
 description: "A CLI that turns random words into sample packs via YouTube — because the best sounds come from places you weren't looking."
 date: 2026-02-01
 tags: ['notebooklm', 'music', 'cli', 'creative']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dodgylegally/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dodgylegally/audio.m4a'
 duration: '16:15'
 relatedProject: 'dodgylegally'
 ---

--- a/src/content/audio/dx0-overview.md
+++ b/src/content/audio/dx0-overview.md
@@ -3,7 +3,7 @@ title: 'Diagnosis as a Team Sport'
 description: 'Multi-agent AI diagnostic system with five physician personas, 304 NEJM cases, and a budget that forces real trade-offs.'
 date: 2025-05-01
 tags: ['notebooklm', 'ai', 'healthcare', 'agents']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dx0/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dx0/audio.m4a'
 duration: '14:30'
 relatedProject: 'dx0'
 ---

--- a/src/content/audio/eight-layers-of-visual-jailbreaks-overview.md
+++ b/src/content/audio/eight-layers-of-visual-jailbreaks-overview.md
@@ -3,7 +3,7 @@ title: 'Eight Layers of Visual Jailbreaks'
 description: 'ASCII art encoding is largely blocked. But attacks framed as content transcription succeed 62–75% of the time. A map of all eight layers.'
 date: 2026-03-30
 tags: ['notebooklm', 'ai-safety', 'jailbreaking', 'llm', 'multimodal', 'research']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-layers-of-visual-jailbreaks/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-layers-of-visual-jailbreaks/audio.m4a'
 duration: '14:04'
 relatedPost: 'eight-layers-of-visual-jailbreaks-post'
 relatedProject: 'failure-first'

--- a/src/content/audio/eight-minutes-series-overview.md
+++ b/src/content/audio/eight-minutes-series-overview.md
@@ -3,7 +3,7 @@ title: 'Eight Minutes — The Whole Story'
 description: 'The full series in one sitting: the call, the relay, the eight minutes inside, and the fight back — a single deep dive across all three parts.'
 date: 2026-06-11T00:55:00Z
 tags: ['notebooklm', 'security', 'phishing', 'incident response', 'Eight Minutes']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-series/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-series/audio.m4a'
 duration: '21:24'
 relatedPost: 'eight-minutes-the-trap'
 ---

--- a/src/content/audio/failure-first-overview.md
+++ b/src/content/audio/failure-first-overview.md
@@ -3,7 +3,7 @@ title: 'Map the Catastrophe Before You Build the Architecture'
 description: 'Audio overview of Failure First — adversarial AI evaluation across 120 models and 18,000 prompts.'
 date: 2026-02-09
 tags: ['notebooklm', 'ai-safety', 'adversarial', 'research']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/audio.m4a'
 duration: '12:44'
 relatedProject: 'failure-first'
 ---

--- a/src/content/audio/freedom-engine-overview.md
+++ b/src/content/audio/freedom-engine-overview.md
@@ -3,7 +3,7 @@ title: 'Bridging the Information Gap That Costs Years'
 description: 'Audio overview of Freedom Engine — AI-assisted legal Q&A helping federal inmates access First Step Act provisions.'
 date: 2025-04-01
 tags: ['notebooklm', 'ai', 'justice', 'legal']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/freedom-engine/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/freedom-engine/audio.m4a'
 duration: '15:51'
 relatedProject: 'freedom-engine'
 ---

--- a/src/content/audio/glasswing-buried-number-overview.md
+++ b/src/content/audio/glasswing-buried-number-overview.md
@@ -3,7 +3,7 @@ title: "Glasswing's Buried Number"
 description: "Anthropic found 10,000 critical vulnerabilities in one month. Fewer than 1% are patched. The announcement buried that figure — and what it means."
 date: 2026-05-25
 tags: ['notebooklm', 'ai-safety', 'security', 'anthropic', 'vulnerability', 'governance']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/glasswing-buried-number/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/glasswing-buried-number/audio.m4a'
 duration: '21:03'
 relatedPost: 'glasswing-buried-number-post'
 ---

--- a/src/content/audio/grid2-overview.md
+++ b/src/content/audio/grid2-overview.md
@@ -3,7 +3,7 @@ title: 'AI for Understanding, Algorithms for Execution'
 description: 'A deterministic website builder where LLMs interpret intent but beam search assembles pages. Same inputs, same output, every time.'
 date: 2025-05-01
 tags: ['notebooklm', 'ai', 'web', 'typescript']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/grid2/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/grid2/audio.m4a'
 duration: '16:33'
 relatedProject: 'grid2'
 ---

--- a/src/content/audio/latent-self-overview.md
+++ b/src/content/audio/latent-self-overview.md
@@ -3,7 +3,7 @@ title: 'The Mirror That Shows What You Almost Are'
 description: 'Real-time StyleGAN2 face morphing as art installation — continuous, responsive, and productively uncanny.'
 date: 2025-02-01
 tags: ['notebooklm', 'art', 'ai', 'installation']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/latent-self/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/latent-self/audio.m4a'
 duration: '15:28'
 relatedProject: 'latent-self'
 ---

--- a/src/content/audio/lejepa-self-supervised-learning-overview.md
+++ b/src/content/audio/lejepa-self-supervised-learning-overview.md
@@ -3,7 +3,7 @@ title: 'LeJEPA: Self-Supervised Learning Gets a Theoretical Foundation'
 description: 'Audio overview of LeJEPA — how Balestriero and LeCun proved isotropic Gaussian embeddings are optimal and distilled it into a 50-line self-supervised method.'
 date: 2026-02-13
 tags: ['notebooklm', 'ai', 'machine-learning', 'research', 'self-supervised-learning']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/lejepa-self-supervised-learning-gets-a-theoretical-foundation/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/lejepa-self-supervised-learning-gets-a-theoretical-foundation/audio.m4a'
 duration: '21:16'
 relatedPost: 'lejepa-self-supervised-learning-gets-a-theoretical-foundation'
 ---

--- a/src/content/audio/modelatlas-overview.md
+++ b/src/content/audio/modelatlas-overview.md
@@ -3,7 +3,7 @@ title: 'Trust-Scoring the Foundation Model Landscape'
 description: 'Forensic-grade metadata for thousands of foundation models — recursive enrichment, provenance tracking, and trust you can quantify.'
 date: 2025-04-15
 tags: ['notebooklm', 'ai', 'research', 'python']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/modelatlas/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/modelatlas/audio.m4a'
 duration: '13:29'
 relatedProject: 'modelatlas'
 ---

--- a/src/content/audio/moral-formation-isnt-enough-overview.md
+++ b/src/content/audio/moral-formation-isnt-enough-overview.md
@@ -3,7 +3,7 @@ title: "Moral Formation Isn't Enough"
 description: 'Good values are necessary but not sufficient. What happens to AI ethics when someone is actively trying to break them?'
 date: 2026-05-20
 tags: ['notebooklm', 'ai-safety', 'alignment', 'opinion', 'anthropic', 'llm']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/moral-formation-isnt-enough/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/moral-formation-isnt-enough/audio.m4a'
 duration: '20:13'
 relatedPost: 'moral-formation-isnt-enough-post'
 ---

--- a/src/content/audio/neuroconnect-overview.md
+++ b/src/content/audio/neuroconnect-overview.md
@@ -3,7 +3,7 @@ title: 'The Helpline That Knows the Difference'
 description: 'A 24/7 voice helpline built around neurodivergent communication — where crisis detection is deterministic and the LLM never decides if someone is safe.'
 date: 2025-05-01
 tags: ['notebooklm', 'ai', 'health', 'adhd']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/neuroconnect/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/neuroconnect/audio.m4a'
 duration: '16:43'
 relatedProject: 'neuroconnect'
 ---

--- a/src/content/audio/notebooklm-automation-overview.md
+++ b/src/content/audio/notebooklm-automation-overview.md
@@ -3,7 +3,7 @@ title: "The Door Google Didn't Build"
 description: 'Audio overview of NotebookLM Automation — reverse-engineered RPC access for batch export, generation, and control.'
 date: 2025-12-01
 tags: ['notebooklm', 'ai', 'automation']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/notebooklm-automation/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/notebooklm-automation/audio.m4a'
 duration: '14:57'
 relatedProject: 'notebooklm-automation'
 ---

--- a/src/content/audio/reasoning-models-think-themselves-into-trouble-overview.md
+++ b/src/content/audio/reasoning-models-think-themselves-into-trouble-overview.md
@@ -3,7 +3,7 @@ title: 'Reasoning Models Think Themselves Into Trouble'
 description: 'Frontier reasoning models are 5–20x more vulnerable to adversarial prompts than non-reasoning models. The thinking process itself is the attack surface.'
 date: 2026-03-11
 tags: ['notebooklm', 'ai-safety', 'reasoning', 'llm', 'vulnerability', 'research']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/reasoning-models-think-themselves-into-trouble/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/reasoning-models-think-themselves-into-trouble/audio.m4a'
 duration: '21:10'
 relatedPost: 'reasoning-models-think-themselves-into-trouble-post'
 relatedProject: 'failure-first'

--- a/src/content/audio/robot-dogs-security-nightmare-overview.md
+++ b/src/content/audio/robot-dogs-security-nightmare-overview.md
@@ -3,7 +3,7 @@ title: 'Robot Dogs Are a Security Nightmare — And We Can Prove It'
 description: 'Eight CVEs. A wormable Bluetooth exploit. An encrypted backdoor to Chinese servers. And police departments buying them anyway.'
 date: 2026-05-13
 tags: ['notebooklm', 'ai-safety', 'robotics', 'embodied-ai', 'security', 'research']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/robot-dogs-security-nightmare/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/robot-dogs-security-nightmare/audio.m4a'
 duration: '22:30'
 relatedPost: 'robot-dogs-security-nightmare-post'
 relatedProject: 'failure-first'

--- a/src/content/audio/squishmallowdex-overview.md
+++ b/src/content/audio/squishmallowdex-overview.md
@@ -3,7 +3,7 @@ title: 'What Hyperfocus and a Good Excuse Can Produce in an Afternoon'
 description: 'Audio overview of Squishmallowdex — a kid-friendly collection tracker for 3,000+ plush creatures. No ads, no tracking.'
 date: 2024-12-01
 tags: ['notebooklm', 'web', 'kids', 'open-source']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/squishmallowdex/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/squishmallowdex/audio.m4a'
 duration: '17:56'
 relatedProject: 'squishmallowdex'
 ---

--- a/src/content/audio/the-67-percent-wall-overview.md
+++ b/src/content/audio/the-67-percent-wall-overview.md
@@ -3,7 +3,7 @@ title: 'The 67% Wall: Why Every AI Model Falls to the Same Jailbreak Rate'
 description: 'Five models, four providers, 30B to 671B parameters — all converge at the same broad attack success rate against a public jailbreak corpus.'
 date: 2026-03-28
 tags: ['notebooklm', 'ai-safety', 'jailbreaking', 'llm', 'benchmarking', 'research']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-67-percent-wall/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-67-percent-wall/audio.m4a'
 duration: '19:18'
 relatedPost: 'the-67-percent-wall-post'
 relatedProject: 'failure-first'

--- a/src/content/audio/the-ai-productivity-j-curve-overview.md
+++ b/src/content/audio/the-ai-productivity-j-curve-overview.md
@@ -3,7 +3,7 @@ title: 'The AI Productivity J-Curve: Why Most Enterprise AI Fails'
 description: 'Audio overview of The AI Productivity J-Curve: Why Most Enterprise AI Fails.'
 date: 2026-03-02
 tags: ['notebooklm', 'ai', 'economics', 'enterprise', 'research', 'policy']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-ai-productivity-j-curve/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-ai-productivity-j-curve/audio.m4a'
 duration: '23:44'
 relatedPost: 'the-ai-productivity-j-curve-post'
 ---

--- a/src/content/audio/the-bottom-pub-co-op-overview.md
+++ b/src/content/audio/the-bottom-pub-co-op-overview.md
@@ -3,7 +3,7 @@ title: 'The Bottom Pub Co-op Overview'
 description: 'Audio deep dive into the community proposal for Cygnet''s Commercial Hotel co-operative — nine corrections, legal constraints, and the staged path forward.'
 date: 2026-05-15
 tags: ['notebooklm', 'co-operative', 'tasmania', 'community', 'governance']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-bottom-pub-co-op/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-bottom-pub-co-op/audio.m4a'
 duration: '56:24'
 relatedPost: 'the-bottom-pub-co-op'
 heroImage: '/notebook-assets/the-bottom-pub-co-op/infographic.webp'

--- a/src/content/audio/the-brave-budget-neither-side-wrote-overview.md
+++ b/src/content/audio/the-brave-budget-neither-side-wrote-overview.md
@@ -3,7 +3,7 @@ title: 'The Brave Budget Neither Side Wrote'
 description: 'Audio deep dive into Tasmania’s 2026-27 Budget versus the Greens’ Alternative — same surplus, opposite roads, and why neither was brave enough.'
 date: 2026-05-30
 tags: ['notebooklm', 'tasmania', 'politics', 'policy', 'economics', 'analysis']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-brave-budget-neither-side-wrote/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-brave-budget-neither-side-wrote/audio.m4a'
 duration: '22:39'
 relatedPost: 'the-brave-budget-neither-side-wrote'
 ---

--- a/src/content/audio/the-failure-first-team-overview.md
+++ b/src/content/audio/the-failure-first-team-overview.md
@@ -3,7 +3,7 @@ title: 'The Failure First Team'
 description: 'Audio overview of The Failure First Team.'
 date: 2026-03-30
 tags: ['notebooklm', 'ai', 'ai-safety', 'research', 'adversarial', 'team']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-failure-first-team/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-failure-first-team/audio.m4a'
 duration: '22:24'
 relatedPost: 'the-failure-first-team-post'
 ---

--- a/src/content/audio/the-organismic-prophecy-overview.md
+++ b/src/content/audio/the-organismic-prophecy-overview.md
@@ -3,7 +3,7 @@ title: 'The Organismic Prophecy'
 description: 'Audio overview of The Organismic Prophecy — human prediction is metabolic, AI prediction is not, and the gap has consequences.'
 date: 2026-04-28
 tags: ['notebooklm', 'ai-safety', 'neuroscience', 'philosophy', 'research']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-organismic-prophecy/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-organismic-prophecy/audio.m4a'
 duration: '20:01'
 relatedPost: 'the-organismic-prophecy-post'
 ---

--- a/src/content/audio/the-thinking-chain-leak-overview.md
+++ b/src/content/audio/the-thinking-chain-leak-overview.md
@@ -3,7 +3,7 @@ title: 'The Thinking Chain Leak'
 description: 'A reasoning model refused every harmful prompt — but its chain-of-thought generated the content anyway. The output filter worked. The thinking did not.'
 date: 2026-03-28
 tags: ['notebooklm', 'ai-safety', 'reasoning', 'llm', 'vulnerability', 'transparency']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-thinking-chain-leak/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-thinking-chain-leak/audio.m4a'
 duration: '19:15'
 relatedPost: 'the-thinking-chain-leak-post'
 relatedProject: 'failure-first'

--- a/src/content/audio/why-demonstrated-risk-is-ignored-overview.md
+++ b/src/content/audio/why-demonstrated-risk-is-ignored-overview.md
@@ -3,7 +3,7 @@ title: 'Looking Past the Evidence'
 description: "Audio deep dive into why people acknowledge demonstrated risk and then proceed as if it doesn't exist. Structural, not stupid."
 date: 2026-02-07
 tags: ['notebooklm', 'research', 'risk', 'ai-safety']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/audio.m4a'
 duration: '22:17'
 relatedPost: 'why-demonstrated-risk-is-ignored-post'
 relatedProject: 'why-demonstrated-risk-is-ignored'

--- a/src/content/audio/why-i-build-in-public-overview.md
+++ b/src/content/audio/why-i-build-in-public-overview.md
@@ -3,7 +3,7 @@ title: 'Why I Build in Public'
 description: 'Audio overview of Why I Build in Public.'
 date: 2026-02-15
 tags: ['notebooklm', 'engineering', 'open-source', 'philosophy']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-i-build-in-public/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-i-build-in-public/audio.m4a'
 duration: '14:35'
 relatedPost: 'why-i-build-in-public-post'
 ---

--- a/src/content/blog/alignment-regression-post.md
+++ b/src/content/blog/alignment-regression-post.md
@@ -5,7 +5,7 @@ date: 2026-03-11
 tags: ['ai-safety', 'alignment', 'reasoning', 'jailbreaking', 'llm', 'autonomous-agents', 'research']
 draft: false
 heroImage: '/notebook-assets/alignment-regression/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/alignment-regression/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/alignment-regression/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/alignment-regression/video.mp4'
 audioDuration: '21:36'
 youtubeUrl: 'https://www.youtube.com/watch?v=3y3_IfYB-nA'

--- a/src/content/blog/compute-is-not-governance-post.md
+++ b/src/content/blog/compute-is-not-governance-post.md
@@ -5,7 +5,7 @@ date: 2026-05-25
 tags: ['ai-safety', 'policy', 'anthropic', 'governance', 'research', 'geopolitics']
 draft: false
 heroImage: '/notebook-assets/compute-is-not-governance/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/compute-is-not-governance/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/compute-is-not-governance/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/compute-is-not-governance/video.mp4'
 audioDuration: '21:29'
 faq:

--- a/src/content/blog/eight-layers-of-visual-jailbreaks-post.md
+++ b/src/content/blog/eight-layers-of-visual-jailbreaks-post.md
@@ -5,7 +5,7 @@ date: 2026-03-30
 tags: ['ai-safety', 'research', 'jailbreaking', 'llm', 'multimodal', 'vulnerability']
 draft: false
 heroImage: '/notebook-assets/eight-layers-of-visual-jailbreaks/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-layers-of-visual-jailbreaks/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-layers-of-visual-jailbreaks/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-layers-of-visual-jailbreaks/video.mp4'
 audioDuration: '14:04'
 youtubeUrl: 'https://www.youtube.com/watch?v=9-aAAxBnPI4'

--- a/src/content/blog/glasswing-buried-number-post.md
+++ b/src/content/blog/glasswing-buried-number-post.md
@@ -5,7 +5,7 @@ date: 2026-05-25
 tags: ['ai-safety', 'security', 'anthropic', 'research', 'vulnerability', 'governance']
 draft: false
 heroImage: '/notebook-assets/glasswing-buried-number/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/glasswing-buried-number/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/glasswing-buried-number/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/glasswing-buried-number/video.mp4'
 audioDuration: '21:03'
 faq:

--- a/src/content/blog/lejepa-self-supervised-learning-gets-a-theoretical-foundation.md
+++ b/src/content/blog/lejepa-self-supervised-learning-gets-a-theoretical-foundation.md
@@ -3,7 +3,7 @@ title: "LeJEPA: Self-Supervised Learning Gets a Theoretical Foundation"
 description: "Balestriero and LeCun prove isotropic Gaussian embeddings are optimal, then build a 50-line self-supervised method eliminating stop-gradients and EMA teachers."
 date: 2026-02-13
 heroImage: "/notebook-assets/lejepa-self-supervised-learning-gets-a-theoretical-foundation/infographic.webp"
-audioUrl: "https://cdn.adrianwedd.com/notebook-assets/lejepa-self-supervised-learning-gets-a-theoretical-foundation/audio.mp3"
+audioUrl: "https://cdn.adrianwedd.com/notebook-assets/lejepa-self-supervised-learning-gets-a-theoretical-foundation/audio.m4a"
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lejepa-self-supervised-learning-gets-a-theoretical-foundation/video.mp4'
 audioDuration: "21:16"
 tags: ["ai", "machine-learning", "research", "self-supervised-learning"]

--- a/src/content/blog/moral-formation-isnt-enough-post.md
+++ b/src/content/blog/moral-formation-isnt-enough-post.md
@@ -5,7 +5,7 @@ date: 2026-05-20
 tags: ['ai-safety', 'alignment', 'research', 'opinion', 'anthropic', 'llm']
 draft: false
 heroImage: '/notebook-assets/moral-formation-isnt-enough/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/moral-formation-isnt-enough/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/moral-formation-isnt-enough/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/moral-formation-isnt-enough/video.mp4'
 audioDuration: '20:13'
 youtubeUrl: 'https://www.youtube.com/watch?v=laBVYz6_ARs'

--- a/src/content/blog/reasoning-models-think-themselves-into-trouble-post.md
+++ b/src/content/blog/reasoning-models-think-themselves-into-trouble-post.md
@@ -5,7 +5,7 @@ date: 2026-03-11
 tags: ['ai-safety', 'research', 'reasoning', 'llm', 'vulnerability', 'benchmarking']
 draft: false
 heroImage: '/notebook-assets/reasoning-models-think-themselves-into-trouble/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/reasoning-models-think-themselves-into-trouble/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/reasoning-models-think-themselves-into-trouble/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/reasoning-models-think-themselves-into-trouble/video.mp4'
 audioDuration: '21:10'
 youtubeUrl: 'https://www.youtube.com/watch?v=rweuGkDUh9M'

--- a/src/content/blog/robot-dogs-security-nightmare-post.md
+++ b/src/content/blog/robot-dogs-security-nightmare-post.md
@@ -5,7 +5,7 @@ date: 2026-05-13
 tags: ['ai-safety', 'robotics', 'embodied-ai', 'security', 'cve', 'research']
 draft: false
 heroImage: '/notebook-assets/robot-dogs-security-nightmare/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/robot-dogs-security-nightmare/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/robot-dogs-security-nightmare/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/robot-dogs-security-nightmare/video.mp4'
 audioDuration: '22:30'
 youtubeUrl: 'https://www.youtube.com/watch?v=OfPnbV56FOE'

--- a/src/content/blog/the-67-percent-wall-post.md
+++ b/src/content/blog/the-67-percent-wall-post.md
@@ -5,7 +5,7 @@ date: 2026-03-28
 tags: ['ai-safety', 'research', 'jailbreaking', 'llm', 'benchmarking', 'vulnerability', 'corpus-analysis']
 draft: false
 heroImage: '/notebook-assets/the-67-percent-wall/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-67-percent-wall/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-67-percent-wall/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-67-percent-wall/video.mp4'
 audioDuration: '19:18'
 youtubeUrl: 'https://www.youtube.com/watch?v=K5tfXXpByuc'

--- a/src/content/blog/the-ai-productivity-j-curve-post.md
+++ b/src/content/blog/the-ai-productivity-j-curve-post.md
@@ -5,7 +5,7 @@ date: 2026-03-02
 tags: ['ai', 'economics', 'enterprise', 'research', 'policy']
 draft: false
 heroImage: '/notebook-assets/the-ai-productivity-j-curve/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-ai-productivity-j-curve/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-ai-productivity-j-curve/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-ai-productivity-j-curve/video.mp4'
 faq:
   - q: 'What is the AI Productivity J-Curve?'

--- a/src/content/blog/the-bottom-pub-co-op-post.md
+++ b/src/content/blog/the-bottom-pub-co-op-post.md
@@ -5,7 +5,7 @@ date: 2026-05-15
 tags: ['co-operative', 'tasmania', 'community', 'governance', 'hospitality']
 draft: false
 heroImage: '/notebook-assets/the-bottom-pub-co-op/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-bottom-pub-co-op/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-bottom-pub-co-op/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-bottom-pub-co-op/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=fe7ZHBmYv6c'
 ---

--- a/src/content/blog/the-brave-budget-neither-side-wrote.md
+++ b/src/content/blog/the-brave-budget-neither-side-wrote.md
@@ -6,7 +6,7 @@ tags: ['tasmania', 'politics', 'policy', 'economics', 'analysis']
 draft: false
 heroImage: '/notebook-assets/the-brave-budget-neither-side-wrote/infographic.webp'
 dataTable: '/data/tas-budget-2026-ledger.csv'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-brave-budget-neither-side-wrote/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-brave-budget-neither-side-wrote/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-brave-budget-neither-side-wrote/video.mp4'
 audioDuration: '22:39'
 faq:

--- a/src/content/blog/the-failure-first-team-post.md
+++ b/src/content/blog/the-failure-first-team-post.md
@@ -5,7 +5,7 @@ date: 2026-03-30
 tags: ['ai', 'ai-safety', 'research', 'adversarial', 'team']
 draft: false
 heroImage: '/notebook-assets/the-failure-first-team/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-failure-first-team/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-failure-first-team/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-failure-first-team/video.mp4'
 faq:
   - q: 'What is the Failure First team?'

--- a/src/content/blog/the-organismic-prophecy-post.md
+++ b/src/content/blog/the-organismic-prophecy-post.md
@@ -5,7 +5,7 @@ date: 2026-04-27
 tags: ['ai-safety', 'neuroscience', 'philosophy', 'research']
 draft: false
 heroImage: '/notebook-assets/the-organismic-prophecy/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-organismic-prophecy/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-organismic-prophecy/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-organismic-prophecy/video.mp4'
 audioDuration: '20:01'
 youtubeUrl: 'https://www.youtube.com/watch?v=Q531i2kWiJ4'

--- a/src/content/blog/the-thinking-chain-leak-post.md
+++ b/src/content/blog/the-thinking-chain-leak-post.md
@@ -5,7 +5,7 @@ date: 2026-03-28
 tags: ['ai-safety', 'research', 'llm', 'reasoning', 'jailbreaking', 'vulnerability', 'transparency']
 draft: false
 heroImage: '/notebook-assets/the-thinking-chain-leak/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-thinking-chain-leak/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-thinking-chain-leak/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-thinking-chain-leak/video.mp4'
 audioDuration: '19:15'
 youtubeUrl: 'https://www.youtube.com/watch?v=kIP7ZZtdCLs'

--- a/src/content/blog/why-demonstrated-risk-is-ignored-post.md
+++ b/src/content/blog/why-demonstrated-risk-is-ignored-post.md
@@ -5,7 +5,7 @@ date: 2026-03-02
 tags: ['research', 'risk', 'organisations', 'policy', 'ai-safety']
 draft: false
 heroImage: '/notebook-assets/why-demonstrated-risk-is-ignored/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/video.mp4'
 faq:
   - q: 'Why do organisations ignore demonstrated risk?'

--- a/src/content/blog/why-i-build-in-public-post.md
+++ b/src/content/blog/why-i-build-in-public-post.md
@@ -4,7 +4,7 @@ description: 'On showing your work, shipping imperfect things, and why the commi
 date: 2026-02-15
 tags: ['engineering', 'open-source', 'philosophy']
 heroImage: '/notebook-assets/why-i-build-in-public/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-i-build-in-public/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-i-build-in-public/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-i-build-in-public/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=RxsTVm4l55A'
 ---

--- a/src/content/projects/adhdo.md
+++ b/src/content/projects/adhdo.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/ADHDo'
 status: 'active'
 featured: true
 date: 2026-02-05
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adhdo/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adhdo/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/adhdo/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=it_8g1ApwEk'
 heroImage: '/notebook-assets/adhdo/infographic.webp'

--- a/src/content/projects/afterglow-engine.md
+++ b/src/content/projects/afterglow-engine.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/afterglow-engine'
 status: 'active'
 featured: true
 date: 2026-02-02
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterglow-engine/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterglow-engine/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterglow-engine/video.mp4'
 heroImage: '/notebook-assets/afterglow-engine/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=eWwhcDrMcso'

--- a/src/content/projects/afterwords.md
+++ b/src/content/projects/afterwords.md
@@ -8,7 +8,7 @@ status: 'active'
 date: 2026-03-22
 series: 'PiCar-X'
 seriesOrder: 2
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterwords/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterwords/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterwords/video.mp4'
 heroImage: '/notebook-assets/afterwords/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=iawRevXb9i4'

--- a/src/content/projects/agentic-index.md
+++ b/src/content/projects/agentic-index.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/Agentic-Index'
 status: 'active'
 featured: false
 date: 2025-08-01
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/agentic-index/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/agentic-index/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/agentic-index/video.mp4'
 heroImage: '/notebook-assets/agentic-index/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=_ZkMEVAcEe4'

--- a/src/content/projects/before-the-words-existed.md
+++ b/src/content/projects/before-the-words-existed.md
@@ -7,7 +7,7 @@ repo: 'before-the-words-existed'
 status: 'complete'
 featured: true
 date: 2026-02-10
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/before-the-words-existed/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/before-the-words-existed/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/before-the-words-existed/video.mp4'
 heroImage: '/notebook-assets/before-the-words-existed/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=ZZDPvTlA4Xw'

--- a/src/content/projects/bottom-pub-co-op.md
+++ b/src/content/projects/bottom-pub-co-op.md
@@ -7,7 +7,7 @@ status: 'active'
 featured: true
 date: 2026-05-15
 heroImage: '/notebook-assets/the-bottom-pub-co-op/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-bottom-pub-co-op/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-bottom-pub-co-op/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-bottom-pub-co-op/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=ozwojYIg9q8'
 ---

--- a/src/content/projects/dodgylegally.md
+++ b/src/content/projects/dodgylegally.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/dodgylegally'
 status: 'active'
 featured: false
 date: 2026-02-01
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dodgylegally/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dodgylegally/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/dodgylegally/video.mp4'
 heroImage: '/notebook-assets/dodgylegally/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=xF-BklkSqoI'

--- a/src/content/projects/dx0.md
+++ b/src/content/projects/dx0.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/Dx0'
 status: 'active'
 featured: false
 date: 2025-05-01
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dx0/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dx0/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/dx0/video.mp4'
 heroImage: '/notebook-assets/dx0/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=h9H9TnoI8hk'

--- a/src/content/projects/failure-first.md
+++ b/src/content/projects/failure-first.md
@@ -7,7 +7,7 @@ repo: 'failure-first'
 status: 'active'
 featured: true
 date: 2026-02-09
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/failure-first/video.mp4'
 heroImage: '/notebook-assets/failure-first/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=9x-C9-wMKQo'

--- a/src/content/projects/freedom-engine.md
+++ b/src/content/projects/freedom-engine.md
@@ -5,7 +5,7 @@ tags: ['ai', 'justice', 'python']
 status: 'active'
 featured: true
 date: 2025-04-01
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/freedom-engine/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/freedom-engine/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/freedom-engine/video.mp4'
 heroImage: '/notebook-assets/freedom-engine/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=DiUEJScqN8I'

--- a/src/content/projects/grid2.md
+++ b/src/content/projects/grid2.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/grid2_repo'
 status: 'experiment'
 featured: false
 date: 2025-05-01
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/grid2/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/grid2/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/grid2/video.mp4'
 heroImage: '/notebook-assets/grid2/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=HB4bZPOv3NI'

--- a/src/content/projects/latent-self.md
+++ b/src/content/projects/latent-self.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/latent-self'
 status: 'complete'
 featured: false
 date: 2025-02-01
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/latent-self/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/latent-self/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/latent-self/video.mp4'
 heroImage: '/notebook-assets/latent-self/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=03vYwCXjckQ'

--- a/src/content/projects/modelatlas.md
+++ b/src/content/projects/modelatlas.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/ModelAtlas'
 status: 'active'
 featured: false
 date: 2025-04-15
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/modelatlas/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/modelatlas/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/modelatlas/video.mp4'
 heroImage: '/notebook-assets/modelatlas/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=Y9o5Iy_daps'

--- a/src/content/projects/neuroconnect.md
+++ b/src/content/projects/neuroconnect.md
@@ -5,7 +5,7 @@ tags: ['ai', 'health', 'adhd', 'python']
 status: 'active'
 featured: true
 date: 2025-05-01
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/neuroconnect/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/neuroconnect/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/neuroconnect/video.mp4'
 heroImage: '/notebook-assets/neuroconnect/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=HZnnK4bLub4'

--- a/src/content/projects/notebooklm-automation.md
+++ b/src/content/projects/notebooklm-automation.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/notebooklm-automation'
 status: 'complete'
 featured: false
 date: 2025-12-01
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/notebooklm-automation/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/notebooklm-automation/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/notebooklm-automation/video.mp4'
 heroImage: '/notebook-assets/notebooklm-automation/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=LSQ2kIBrXf8'

--- a/src/content/projects/squishmallowdex.md
+++ b/src/content/projects/squishmallowdex.md
@@ -8,7 +8,7 @@ status: 'complete'
 featured: false
 heroImage: '/notebook-assets/squishmallowdex/infographic.webp'
 date: 2024-12-01
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/squishmallowdex/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/squishmallowdex/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/squishmallowdex/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=VpWYlNx2tfY'
 ---

--- a/src/content/projects/why-demonstrated-risk-is-ignored.md
+++ b/src/content/projects/why-demonstrated-risk-is-ignored.md
@@ -7,7 +7,7 @@ status: 'complete'
 featured: true
 date: 2026-02-07
 heroImage: '/notebook-assets/why-demonstrated-risk-is-ignored/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/why-demonstrated-risk-is-ignored/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=ZXB_at0Ke_w'
 ---


### PR DESCRIPTION
## Summary
Site-wide remediation of the 64 kbps audio compression (the stale CLAUDE.md pipeline step):

- **78 of 86** published audio URLs were 64 kbps mono transcodes with no Xing header — which is also why players showed `0:00` duration on those tracks
- **34 originals recovered** (257 kbps stereo AAC): 12 re-downloaded from live NLM notebooks, 19 from `scripts/notebooklm/exports/`, 3 from local disk
- Every recovered file **verified as the same take**: duration matched to the published transcode within 1.5s (most to the millisecond), plus word-for-word transcript spot-checks on 3
- Mismatched takes were rejected, not substituted (e.g. veritas' export audio is a different generation — left alone)
- Uploaded to R2 as `audio.m4a` next to the old mp3s (nothing deleted); **68 frontmatter references** flipped across blog/projects/audio entries

## Not in this PR
**44 tracks remain at 64 kbps** — their notebooks are deleted and no local original matches the published take. The only path is regeneration (a different take = editorial change), parked for Adrian's decision.

## Verification
- `validate-content.js`: 0 errors · build clean · internal links: 46,949 OK, 0 broken
- CDN spot-checks return 200 with full file sizes