### PR TITLE
docs+scripts: kill the 64kbps audio compression step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,11 +233,12 @@ cd scripts/notebooklm
 
 Audio and video are served from `cdn.adrianwedd.com` (Cloudflare R2 bucket `adrianwedd-com-media`). Infographics remain in `public/notebook-assets/` (committed to git).
 
+**NEVER compress or re-encode the audio** — serve it at original quality. NLM delivers 256kbps stereo AAC in an MP4 container (even when the download is named `.mp3`); copy it as-is to `audio.m4a`. Keep the original take forever — deleted notebooks can't re-issue the same narration.
+
 ```bash
-# Compress audio to 64kbps mono
-ffmpeg -y -i exports/project-name/studio/audio/overview.mp3 \
-  -vn -ac 1 -ar 44100 -c:a libmp3lame -b:a 64k \
-  public/notebook-assets/project-name/audio.mp3
+# Copy original-quality audio as-is (no transcode)
+cp exports/project-name/studio/audio/overview.mp3 \
+   public/notebook-assets/project-name/audio.m4a
 
 # Upload audio + video to R2
 ./scripts/upload-media-to-r2.sh
@@ -252,7 +253,7 @@ cp exports/project-name/studio/infographic/*.png \
 ```markdown
 ---
 title: "Project Name"
-audioUrl: "https://cdn.adrianwedd.com/notebook-assets/project-name/audio.mp3"
+audioUrl: "https://cdn.adrianwedd.com/notebook-assets/project-name/audio.m4a"
 videoUrl: "https://cdn.adrianwedd.com/notebook-assets/project-name/video.mp4"
 heroImage: "/notebook-assets/project-name/infographic.webp"
 ---
@@ -266,7 +267,7 @@ title: "Project Name Overview"
 description: "Audio deep dive into..."
 date: 2026-02-13
 tags: ["notebooklm", "relevant-tags"]
-audioUrl: "https://cdn.adrianwedd.com/notebook-assets/project-name/audio.mp3"
+audioUrl: "https://cdn.adrianwedd.com/notebook-assets/project-name/audio.m4a"
 duration: "8:47"
 relatedProject: "project-name"
 ---
@@ -319,7 +320,7 @@ This script:
 1. Identifies projects without audioUrl
 2. Creates NotebookLM configs
 3. Runs parallel audio generation
-4. Compresses to 64kbps mono MP3
+4. Copies original-quality audio as-is (never compress)
 5. Moves assets to public/notebook-assets/
 6. Updates project frontmatter
 

--- a/scripts/generate-all-notebook-assets.sh
+++ b/scripts/generate-all-notebook-assets.sh
@@ -27,7 +27,6 @@ NC='\033[0m'
 # Defaults
 YES=false
 LIMIT=0
-COMPRESS_BITRATE="64k"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -52,11 +51,6 @@ echo
 if ! command -v nlm &>/dev/null; then
     echo -e "${RED}Error: nlm CLI not found. Install: pip install notebooklm-mcp-cli${NC}"
     exit 1
-fi
-
-if ! command -v ffmpeg &>/dev/null; then
-    echo -e "${YELLOW}Warning: ffmpeg not found — audio files will not be compressed${NC}"
-    COMPRESS_BITRATE=""
 fi
 
 if [ ! -d "$NOTEBOOKLM_DIR" ]; then
@@ -182,25 +176,17 @@ EOF
             audio_found=true
             mkdir -p "$PUBLIC_ASSETS/$project"
 
-            # Compress with ffmpeg if available
-            if [ -n "$COMPRESS_BITRATE" ]; then
-                audio_size=$(stat -f%z "$audio_file" 2>/dev/null || stat -c%s "$audio_file" 2>/dev/null)
-                audio_size_mb=$((audio_size / 1048576))
-                echo "  Raw audio: ${audio_size_mb}MB — compressing to ${COMPRESS_BITRATE}bps..."
-                ffmpeg -y -i "$audio_file" -b:a "$COMPRESS_BITRATE" -ac 1 "$PUBLIC_ASSETS/$project/audio.mp3" 2>/dev/null
-                compressed_size=$(stat -f%z "$PUBLIC_ASSETS/$project/audio.mp3" 2>/dev/null || stat -c%s "$PUBLIC_ASSETS/$project/audio.mp3" 2>/dev/null)
-                compressed_mb=$((compressed_size / 1048576))
-                echo -e "  ${GREEN}✓ Audio compressed: ${compressed_mb}MB → public/notebook-assets/$project/audio.mp3${NC}"
-            else
-                cp "$audio_file" "$PUBLIC_ASSETS/$project/audio.mp3"
-                echo -e "  ${GREEN}✓ Audio copied to public/notebook-assets/$project/audio.mp3${NC}"
-            fi
+            # NEVER compress — serve original quality. NLM "mp3" downloads are
+            # AAC in an MP4 container; name them audio.m4a so browsers read
+            # duration metadata correctly.
+            cp "$audio_file" "$PUBLIC_ASSETS/$project/audio.m4a"
+            echo -e "  ${GREEN}✓ Original-quality audio copied to public/notebook-assets/$project/audio.m4a${NC}"
 
             # Update project frontmatter
             cd "$REPO_ROOT"
             if ! grep -q "^audioUrl:" "$project_file"; then
                 sed -i '' "/^date:/a\\
-audioUrl: \"/notebook-assets/$project/audio.mp3\"
+audioUrl: \"https://cdn.adrianwedd.com/notebook-assets/$project/audio.m4a\"
 " "$project_file"
                 echo -e "  ${GREEN}✓ Added audioUrl to project frontmatter${NC}"
             fi


### PR DESCRIPTION
## Summary
- CLAUDE.md NotebookLM pipeline: the "Compress audio to 64kbps mono" step is replaced with **never compress — copy original-quality as-is to `audio.m4a`** (NLM "mp3" downloads are actually AAC in an MP4 container); frontmatter examples now use `.m4a` CDN URLs
- `generate-all-notebook-assets.sh`: removed `COMPRESS_BITRATE` and the ffmpeg transcode entirely; copies the original and writes the `.m4a` CDN URL into frontmatter

This is the root-cause fix behind PR #458 (34 tracks restored) and #457 (The Index duration bug) — the stale step was still live documentation, one batch run away from re-introducing the regression.

`bash -n` passes; no content changes.