### PR TITLE
content(audio): regenerate all 44 unrecoverable 64kbps tracks as original-quality m4a

### DIFF
--- a/src/content/audio/120-models-18k-prompts-overview.md
+++ b/src/content/audio/120-models-18k-prompts-overview.md
@@ -3,8 +3,8 @@ title: '120 Models, 18,176 Prompts: What We Found'
 description: 'Audio overview of 120 Models, 18,176 Prompts: What We Found.'
 date: 2026-03-01
 tags: ['notebooklm', 'ai', 'ai-safety', 'research', 'llm', 'security', 'adversarial']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/120-models-18k-prompts/audio.mp3'
-duration: '19:47'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/120-models-18k-prompts/audio.m4a'
+duration: '23:07'
 relatedPost: '120-models-18k-prompts-post'
 ---
 

--- a/src/content/audio/adversarial-poetry-as-jailbreak-overview.md
+++ b/src/content/audio/adversarial-poetry-as-jailbreak-overview.md
@@ -3,8 +3,8 @@ title: 'Adversarial Poetry: When Rhyme Bypasses Reason'
 description: 'Audio overview of Adversarial Poetry: When Rhyme Bypasses Reason.'
 date: 2026-03-02
 tags: ['notebooklm', 'ai', 'ai-safety', 'jailbreaking', 'research', 'llm', 'adversarial']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adversarial-poetry-as-jailbreak/audio.mp3'
-duration: '19:47'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adversarial-poetry-as-jailbreak/audio.m4a'
+duration: '18:45'
 relatedPost: 'adversarial-poetry-as-jailbreak-post'
 ---
 

--- a/src/content/audio/ai-nationalism-overview.md
+++ b/src/content/audio/ai-nationalism-overview.md
@@ -3,8 +3,8 @@ title: 'AI Nationalism and the Fracturing Digital Order'
 description: 'Audio overview of AI nationalism — how the US-China AI rivalry is splitting the global tech stack.'
 date: 2026-04-04
 tags: ['notebooklm', 'ai', 'policy', 'geopolitics']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/ai-nationalism/audio.mp3'
-duration: '23:16'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/ai-nationalism/audio.m4a'
+duration: '22:08'
 relatedPost: 'ai-nationalism-post'
 ---
 

--- a/src/content/audio/auditory-spiral-overview.md
+++ b/src/content/audio/auditory-spiral-overview.md
@@ -3,8 +3,8 @@ title: 'Six Hours of Dark Ambient at the Edge of the World'
 description: "Audio overview of Auditory Spiral — overnight electronic music on RTRFM Perth, the cassette network, and a city's sonic lifeline."
 date: 1992-01-01
 tags: ['notebooklm', 'music', 'radio', 'history']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/auditory-spiral/audio.mp3'
-duration: '18:13'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/auditory-spiral/audio.m4a'
+duration: '10:44'
 relatedProject: 'auditory-spiral'
 ---
 

--- a/src/content/audio/beyond-context-windows-overview.md
+++ b/src/content/audio/beyond-context-windows-overview.md
@@ -3,8 +3,8 @@ title: 'Beyond Context Windows'
 description: 'Audio overview of Beyond Context Windows.'
 date: 2026-03-15
 tags: ['notebooklm', 'ai', 'engineering', 'mcp', 'llm', 'python']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/beyond-context-windows/audio.mp3'
-duration: '20:14'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/beyond-context-windows/audio.m4a'
+duration: '10:33'
 relatedPost: 'beyond-context-windows-post'
 ---
 

--- a/src/content/audio/building-a-personal-site-in-2026-overview.md
+++ b/src/content/audio/building-a-personal-site-in-2026-overview.md
@@ -3,8 +3,8 @@ title: 'Building a Personal Site in 2026'
 description: 'Audio overview of Building a Personal Site in 2026.'
 date: 2026-02-15
 tags: ['notebooklm', 'engineering', 'web', 'astro', 'open-source']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/building-a-personal-site-in-2026/audio.mp3'
-duration: '16:56'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/building-a-personal-site-in-2026/audio.m4a'
+duration: '21:52'
 relatedPost: 'building-a-personal-site-in-2026-post'
 ---
 

--- a/src/content/audio/cv-overview.md
+++ b/src/content/audio/cv-overview.md
@@ -3,8 +3,8 @@ title: "A CV That Proves It Isn't Lying"
 description: 'A self-updating CV pipeline where GitHub Actions runs twice daily, Claude refines content, and a hallucination detector gates deployment.'
 date: 2026-02-04
 tags: ['notebooklm', 'craft', 'web', 'career']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/cv/audio.mp3'
-duration: '15:06'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/cv/audio.m4a'
+duration: '20:52'
 relatedProject: 'cv'
 ---
 

--- a/src/content/audio/emdr-agent-overview.md
+++ b/src/content/audio/emdr-agent-overview.md
@@ -3,8 +3,8 @@ title: 'What Safety Architecture Does AI Therapy Require?'
 description: 'Audio overview of EMDR Agent — exploring what responsible AI-assisted trauma therapy demands before it can exist.'
 date: 2025-06-01
 tags: ['notebooklm', 'ai-safety', 'health', 'ai']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/emdr-agent/audio.mp3'
-duration: '15:08'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/emdr-agent/audio.m4a'
+duration: '19:06'
 relatedProject: 'emdr-agent'
 ---
 

--- a/src/content/audio/footnotes-at-the-edge-of-reality-overview.md
+++ b/src/content/audio/footnotes-at-the-edge-of-reality-overview.md
@@ -3,8 +3,8 @@ title: 'Where Physics Breaks Down and Poetry Begins'
 description: 'Audio overview of Footnotes at the Edge of Reality — a long-form poem rendered as interactive web experience.'
 date: 2026-02-06
 tags: ['notebooklm', 'poetry', 'physics', 'creative']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/audio.mp3'
-duration: '17:58'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/audio.m4a'
+duration: '18:20'
 relatedPost: 'footnotes-at-the-edge-of-reality-post'
 relatedProject: 'footnotes-at-the-edge-of-reality'
 ---

--- a/src/content/audio/getting-google-nest-cameras-into-frigate-nvr-overview.md
+++ b/src/content/audio/getting-google-nest-cameras-into-frigate-nvr-overview.md
@@ -3,8 +3,8 @@ title: 'Getting Google Nest Cameras Into Frigate NVR'
 description: 'Audio overview of Getting Google Nest Cameras Into Frigate NVR.'
 date: 2026-03-16
 tags: ['notebooklm', 'engineering', 'homelab', 'raspberry-pi', 'python', 'home-assistant']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/getting-google-nest-cameras-into-frigate-nvr/audio.mp3'
-duration: '20:49'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/getting-google-nest-cameras-into-frigate-nvr/audio.m4a'
+duration: '20:45'
 relatedPost: 'getting-google-nest-cameras-into-frigate-nvr-post'
 ---
 

--- a/src/content/audio/giving-a-robot-three-voices-overview.md
+++ b/src/content/audio/giving-a-robot-three-voices-overview.md
@@ -3,8 +3,8 @@ title: 'Giving a Robot Three Voices'
 description: 'Audio overview of Giving a Robot Three Voices.'
 date: 2026-03-19
 tags: ['notebooklm', 'ai', 'tts', 'mlx', 'raspberry-pi', 'robotics', 'apple-silicon', 'voice-cloning', 'spark']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/giving-a-robot-three-voices/audio.mp3'
-duration: '20:44'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/giving-a-robot-three-voices/audio.m4a'
+duration: '20:27'
 relatedPost: 'giving-a-robot-three-voices-post'
 ---
 

--- a/src/content/audio/hello-world-overview.md
+++ b/src/content/audio/hello-world-overview.md
@@ -3,8 +3,8 @@ title: 'Building in the Open'
 description: 'Audio overview of Building in the Open.'
 date: 2026-02-12
 tags: ['notebooklm', 'meta', 'craft', 'open-source']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/hello-world/audio.mp3'
-duration: '18:04'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/hello-world/audio.m4a'
+duration: '18:47'
 relatedPost: 'hello-world-post'
 ---
 

--- a/src/content/audio/home-assistant-obsidian-overview.md
+++ b/src/content/audio/home-assistant-obsidian-overview.md
@@ -3,8 +3,8 @@ title: 'Two Systems That Shape How You Think, One Box'
 description: 'Audio overview of Home Assistant Obsidian — your knowledge base and smart home on the same machine.'
 date: 2024-06-01
 tags: ['notebooklm', 'homelab', 'home-assistant', 'docker']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/home-assistant-obsidian/audio.mp3'
-duration: '15:06'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/home-assistant-obsidian/audio.m4a'
+duration: '18:57'
 relatedProject: 'home-assistant-obsidian'
 ---
 

--- a/src/content/audio/learning-mechanics-deep-learning-theory-overview.md
+++ b/src/content/audio/learning-mechanics-deep-learning-theory-overview.md
@@ -3,8 +3,8 @@ title: 'The New Science of Learning Mechanics'
 description: 'An audio overview of the emerging discipline of Learning Mechanics — the study of training dynamics as a formal science with falsifiable predictions.'
 date: 2026-05-03
 tags: ['AI', 'deep learning', 'theory', 'research']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/learning-mechanics-deep-learning-theory/audio.mp3'
-duration: '19:20'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/learning-mechanics-deep-learning-theory/audio.m4a'
+duration: '23:03'
 relatedPost: 'learning-mechanics-deep-learning-theory-post'
 ---
 

--- a/src/content/audio/lunar-tools-prototypes-overview.md
+++ b/src/content/audio/lunar-tools-prototypes-overview.md
@@ -3,8 +3,8 @@ title: 'When Voice Becomes Brushstroke'
 description: 'Twenty-plus interactive art installations where visitors speak, sing, and dream into AI systems that respond in real time.'
 date: 2025-06-15
 tags: ['notebooklm', 'art', 'ai', 'installation']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/lunar-tools-prototypes/audio.mp3'
-duration: '18:43'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/lunar-tools-prototypes/audio.m4a'
+duration: '18:27'
 relatedProject: 'lunar-tools-prototypes'
 ---
 

--- a/src/content/audio/magnifica-humanitas-overview.md
+++ b/src/content/audio/magnifica-humanitas-overview.md
@@ -3,8 +3,8 @@ title: 'Magnifica Humanitas Is Not Alignment'
 description: "Pope Leo XIV's AI encyclical vs Chris Olah's Vatican remarks. The governance gap the press missed."
 date: 2026-05-26
 tags: ['notebooklm', 'ai-safety', 'policy', 'anthropic', 'governance', 'ai-ethics', 'research']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/magnifica-humanitas/audio.mp3'
-duration: '14:24'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/magnifica-humanitas/audio.m4a'
+duration: '19:56'
 relatedPost: 'magnifica-humanitas-post'
 ---
 

--- a/src/content/audio/orbitr-overview.md
+++ b/src/content/audio/orbitr-overview.md
@@ -3,8 +3,8 @@ title: 'Rhythm as Geometry, Sounds from Words'
 description: 'Audio overview of orbitr — a circular sequencer where polyrhythm becomes spatial and MusicGen creates the sounds.'
 date: 2025-09-01
 tags: ['notebooklm', 'music', 'ai', 'creative']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/orbitr/audio.mp3'
-duration: '17:20'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/orbitr/audio.m4a'
+duration: '19:56'
 relatedProject: 'orbitr'
 ---
 

--- a/src/content/audio/ordr-fm-overview.md
+++ b/src/content/audio/ordr-fm-overview.md
@@ -3,8 +3,8 @@ title: 'The Tool That Earns Trust Before Features'
 description: 'Audio overview of ordr.fm — a CLI for music library organisation with lossless prioritisation, EXIF metadata, and zero-overwrite safety.'
 date: 2025-07-01
 tags: ['notebooklm', 'music', 'cli', 'audio']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/ordr-fm/audio.mp3'
-duration: '16:27'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/ordr-fm/audio.m4a'
+duration: '20:17'
 relatedProject: 'ordr-fm'
 ---
 

--- a/src/content/audio/personal-agentic-operating-system-overview.md
+++ b/src/content/audio/personal-agentic-operating-system-overview.md
@@ -3,8 +3,8 @@ title: 'An Agentic System You Can Actually Reason About'
 description: 'Audio overview of PAOS — a local-first LLM operating system with hybrid retrieval and a self-improving meta-agent.'
 date: 2025-07-01
 tags: ['notebooklm', 'ai', 'infrastructure', 'agents']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/personal-agentic-operating-system/audio.mp3'
-duration: '18:42'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/personal-agentic-operating-system/audio.m4a'
+duration: '23:32'
 relatedProject: 'personal-agentic-operating-system'
 ---
 

--- a/src/content/audio/project-chimera-overview.md
+++ b/src/content/audio/project-chimera-overview.md
@@ -3,8 +3,8 @@ title: 'The Post-Model Era'
 description: 'Audio overview of the post-model era — why foundation models are commoditising and where real AI value lives.'
 date: 2026-04-04
 tags: ['notebooklm', 'ai', 'enterprise', 'engineering']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/project-chimera/audio.mp3'
-duration: '21:47'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/project-chimera/audio.m4a'
+duration: '21:09'
 relatedPost: 'project-chimera-post'
 ---
 

--- a/src/content/audio/reconciling-the-great-divergence-overview.md
+++ b/src/content/audio/reconciling-the-great-divergence-overview.md
@@ -3,8 +3,8 @@ title: 'Reconciling the Great Divergence'
 description: 'Audio overview of Reconciling the Great Divergence.'
 date: 2026-03-01
 tags: ['notebooklm', 'ai', 'economics', 'research', 'policy']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/reconciling-the-great-divergence/audio.mp3'
-duration: '21:41'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/reconciling-the-great-divergence/audio.m4a'
+duration: '19:04'
 relatedPost: 'reconciling-the-great-divergence-post'
 ---
 

--- a/src/content/audio/rlm-mcp-overview.md
+++ b/src/content/audio/rlm-mcp-overview.md
@@ -3,8 +3,8 @@ title: 'Beyond Context Windows'
 description: 'Audio overview of rlm-mcp — an MCP server for processing million-character documents with BM25 search and provenance.'
 date: 2025-11-01
 tags: ['notebooklm', 'ai', 'mcp', 'tools']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/rlm-mcp/audio.mp3'
-duration: '18:31'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/rlm-mcp/audio.m4a'
+duration: '21:06'
 relatedProject: 'rlm-mcp'
 ---
 

--- a/src/content/audio/safety-first-therapeutic-ai-overview.md
+++ b/src/content/audio/safety-first-therapeutic-ai-overview.md
@@ -3,8 +3,8 @@ title: 'Safety-First Therapeutic AI'
 description: 'Audio overview of Safety-First Therapeutic AI.'
 date: 2026-03-15
 tags: ['notebooklm', 'ai', 'ai-safety', 'health', 'typescript']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/safety-first-therapeutic-ai/audio.mp3'
-duration: '20:37'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/safety-first-therapeutic-ai/audio.m4a'
+duration: '18:49'
 relatedPost: 'safety-first-therapeutic-ai-post'
 ---
 

--- a/src/content/audio/space-weather-overview.md
+++ b/src/content/audio/space-weather-overview.md
@@ -3,8 +3,8 @@ title: 'The Sun Is a Noisy Neighbour'
 description: 'Audio overview of a real-time space weather dashboard — making the invisible electromagnetic weather above us finally visible.'
 date: 2025-01-01
 tags: ['notebooklm', 'data-viz', 'science', 'web']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/space-weather/audio.mp3'
-duration: '18:15'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/space-weather/audio.m4a'
+duration: '15:33'
 relatedProject: 'space-weather'
 ---
 

--- a/src/content/audio/strategic-acquisitions-overview.md
+++ b/src/content/audio/strategic-acquisitions-overview.md
@@ -3,8 +3,8 @@ title: 'Housing Deserves Better Tooling'
 description: "Audio overview of an AI-powered property analysis pipeline for public housing — spatial intelligence, ML valuations, and Tasmania's LIST."
 date: 2025-01-15
 tags: ['notebooklm', 'ai', 'housing', 'python']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/strategic-acquisitions/audio.mp3'
-duration: '21:13'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/strategic-acquisitions/audio.m4a'
+duration: '21:41'
 relatedProject: 'strategic-acquisitions'
 ---
 

--- a/src/content/audio/tel3sis-overview.md
+++ b/src/content/audio/tel3sis-overview.md
@@ -3,8 +3,8 @@ title: 'Three Seconds of Silence Is an Eternity'
 description: 'Audio overview of TEL3SIS — a voice-first agentic phone platform where sub-3s latency is a survival threshold, not a benchmark.'
 date: 2025-10-01
 tags: ['notebooklm', 'ai', 'voice', 'telephony']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/tel3sis/audio.mp3'
-duration: '19:37'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/tel3sis/audio.m4a'
+duration: '23:13'
 relatedProject: 'tel3sis'
 ---
 

--- a/src/content/audio/the-cognitive-cage-overview.md
+++ b/src/content/audio/the-cognitive-cage-overview.md
@@ -3,8 +3,8 @@ title: 'The Cognitive Cage: Humanoid Robot Fatality Risk'
 description: 'Audio overview of The Cognitive Cage: Humanoid Robot Fatality Risk.'
 date: 2026-03-01
 tags: ['notebooklm', 'ai', 'ai-safety', 'robotics', 'research', 'engineering']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-cognitive-cage/audio.mp3'
-duration: '19:08'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-cognitive-cage/audio.m4a'
+duration: '22:09'
 relatedPost: 'the-cognitive-cage-post'
 ---
 

--- a/src/content/audio/the-legal-ai-trust-deficit-overview.md
+++ b/src/content/audio/the-legal-ai-trust-deficit-overview.md
@@ -3,8 +3,8 @@ title: 'The Legal AI Trust Deficit'
 description: 'Audio overview of The Legal AI Trust Deficit.'
 date: 2026-03-02
 tags: ['notebooklm', 'ai', 'legal', 'research', 'llm']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-legal-ai-trust-deficit/audio.mp3'
-duration: '22:25'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-legal-ai-trust-deficit/audio.m4a'
+duration: '12:02'
 relatedPost: 'the-legal-ai-trust-deficit-post'
 ---
 

--- a/src/content/audio/the-mitigation-gap-overview.md
+++ b/src/content/audio/the-mitigation-gap-overview.md
@@ -3,8 +3,8 @@ title: 'The Mitigation Gap'
 description: 'Audio overview of The Mitigation Gap — AI-enabled biosecurity threats and what current safeguards miss.'
 date: 2026-04-04
 tags: ['notebooklm', 'ai', 'ai-safety', 'biosecurity', 'policy']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-mitigation-gap/audio.mp3'
-duration: '23:00'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-mitigation-gap/audio.m4a'
+duration: '21:33'
 relatedPost: 'the-mitigation-gap-post'
 ---
 

--- a/src/content/audio/the-notebooklm-pipeline-overview.md
+++ b/src/content/audio/the-notebooklm-pipeline-overview.md
@@ -3,8 +3,8 @@ title: 'The NotebookLM Pipeline'
 description: 'Audio overview of The NotebookLM Pipeline.'
 date: 2026-02-15
 tags: ['notebooklm', 'engineering', 'automation', 'ai', 'python']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-notebooklm-pipeline/audio.mp3'
-duration: '25:08'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-notebooklm-pipeline/audio.m4a'
+duration: '22:21'
 relatedPost: 'the-notebooklm-pipeline-post'
 ---
 

--- a/src/content/audio/the-resonant-fringe-overview.md
+++ b/src/content/audio/the-resonant-fringe-overview.md
@@ -3,8 +3,8 @@ title: 'The Resonant Fringe'
 description: 'Audio overview of The Resonant Fringe.'
 date: 2026-03-18
 tags: ['notebooklm', 'history', 'music', 'perth', 'radio']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-resonant-fringe/audio.mp3'
-duration: '22:58'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-resonant-fringe/audio.m4a'
+duration: '17:29'
 relatedPost: 'the-resonant-fringe-post'
 ---
 

--- a/src/content/audio/this-wasnt-in-the-brochure-overview.md
+++ b/src/content/audio/this-wasnt-in-the-brochure-overview.md
@@ -3,8 +3,8 @@ title: 'The Brochure Was for a Different Trip'
 description: 'Audio deep dive into a neurodivergent co-parenting guide — the double discovery, three-AI workflow, and maritime cartography as metaphor.'
 date: 2026-02-08
 tags: ['notebooklm', 'neurodivergence', 'parenting', 'writing']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/audio.mp3'
-duration: '21:39'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/audio.m4a'
+duration: '18:07'
 relatedPost: 'this-wasnt-in-the-brochure-post'
 relatedProject: 'this-wasnt-in-the-brochure'
 ---

--- a/src/content/audio/veritas-overview.md
+++ b/src/content/audio/veritas-overview.md
@@ -3,8 +3,8 @@ title: 'The Efficiency-Trust Deficit in Legal AI'
 description: "Audio deep dive into VERITAS — a legal AI platform where trust isn't a feature, it's the architecture. Built for Australian practice."
 date: 2025-03-01
 tags: ['notebooklm', 'ai', 'legal', 'research']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/veritas/audio.mp3'
-duration: '18:42'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/veritas/audio.m4a'
+duration: '20:39'
 relatedProject: 'veritas'
 ---
 

--- a/src/content/audio/voice-cloning-qwen3-tts-mlx-overview.md
+++ b/src/content/audio/voice-cloning-qwen3-tts-mlx-overview.md
@@ -3,8 +3,8 @@ title: 'Voice Cloning with Qwen3-TTS and MLX on Apple Silicon'
 description: 'Audio overview of Voice Cloning with Qwen3-TTS and MLX on Apple Silicon.'
 date: 2026-03-19
 tags: ['notebooklm', 'ai', 'tts', 'mlx', 'apple-silicon', 'voice-cloning', 'tutorial', 'spark']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/voice-cloning-qwen3-tts-mlx/audio.mp3'
-duration: '23:50'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/voice-cloning-qwen3-tts-mlx/audio.m4a'
+duration: '17:53'
 relatedPost: 'voice-cloning-qwen3-tts-mlx-post'
 ---
 

--- a/src/content/audio/wolf-clan-hub-overview.md
+++ b/src/content/audio/wolf-clan-hub-overview.md
@@ -3,8 +3,8 @@ title: 'Zero Build, Full Operations'
 description: 'Audio overview of a three-zone martial arts operations platform — public site, ops hub, member portal — running on vanilla JS and Cloudflare.'
 date: 2026-03-02
 tags: ['notebooklm', 'web', 'cloudflare', 'community']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/wolf-clan-hub/audio.mp3'
-duration: '20:55'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/wolf-clan-hub/audio.m4a'
+duration: '22:25'
 relatedProject: 'wolf-clan-hub'
 ---
 

--- a/src/content/audio/zero-build-web-development-overview.md
+++ b/src/content/audio/zero-build-web-development-overview.md
@@ -3,8 +3,8 @@ title: 'Zero-Build Web Development'
 description: 'Audio overview of Zero-Build Web Development.'
 date: 2026-03-14
 tags: ['notebooklm', 'engineering', 'web', 'security', 'cloudflare']
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/zero-build-web-development/audio.mp3'
-duration: '22:59'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/zero-build-web-development/audio.m4a'
+duration: '20:05'
 relatedPost: 'zero-build-web-development-post'
 ---
 

--- a/src/content/blog/120-models-18k-prompts-post.md
+++ b/src/content/blog/120-models-18k-prompts-post.md
@@ -5,7 +5,7 @@ date: 2026-03-01
 tags: ['ai', 'ai-safety', 'research', 'llm', 'security', 'adversarial']
 draft: false
 heroImage: '/notebook-assets/120-models-18k-prompts/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/120-models-18k-prompts/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/120-models-18k-prompts/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/120-models-18k-prompts/video.mp4'
 faq:
   - q: 'What is supply chain injection in AI?'

--- a/src/content/blog/adversarial-poetry-as-jailbreak-post.md
+++ b/src/content/blog/adversarial-poetry-as-jailbreak-post.md
@@ -5,7 +5,7 @@ date: 2026-03-02
 tags: ['ai', 'ai-safety', 'jailbreaking', 'research', 'llm', 'adversarial']
 draft: false
 heroImage: '/notebook-assets/adversarial-poetry-as-jailbreak/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adversarial-poetry-as-jailbreak/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/adversarial-poetry-as-jailbreak/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/adversarial-poetry-as-jailbreak/video.mp4'
 faq:
   - q: 'What is adversarial poetry jailbreaking?'

--- a/src/content/blog/afterwords-post.md
+++ b/src/content/blog/afterwords-post.md
@@ -5,7 +5,7 @@ date: 2026-03-22
 tags: ['ai', 'tts', 'mlx', 'apple-silicon', 'voice-cloning', 'claude', 'open-source']
 series: 'PiCar-X'
 seriesOrder: 4
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterwords-blog/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterwords-blog/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/afterwords/video.mp4'
 heroImage: '/notebook-assets/afterwords/infographic.webp'
 faq:

--- a/src/content/blog/ai-nationalism-post.md
+++ b/src/content/blog/ai-nationalism-post.md
@@ -5,7 +5,7 @@ date: 2026-04-04
 heroImage: '/notebook-assets/ai-nationalism/infographic.webp'
 tags: ['ai', 'policy', 'geopolitics', 'research']
 draft: false
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/ai-nationalism/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/ai-nationalism/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/ai-nationalism/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=bSOxH-hJLCk'
 ---

--- a/src/content/blog/architectural-safety-post.md
+++ b/src/content/blog/architectural-safety-post.md
@@ -5,9 +5,9 @@ date: 2026-04-28
 tags: ['ai-safety', 'research', 'engineering', 'policy']
 draft: false
 heroImage: '/notebook-assets/architectural-safety/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/architectural-safety/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/architectural-safety/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/architectural-safety/video.mp4'
-audioDuration: '22:59'
+audioDuration: '22:01'
 youtubeUrl: 'https://www.youtube.com/watch?v=A4qC7N3mDrk'
 ---
 

--- a/src/content/blog/beyond-context-windows-post.md
+++ b/src/content/blog/beyond-context-windows-post.md
@@ -5,7 +5,7 @@ date: 2026-03-15
 tags: ['ai', 'engineering', 'mcp', 'llm', 'python']
 draft: false
 heroImage: '/notebook-assets/beyond-context-windows/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/beyond-context-windows/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/beyond-context-windows/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/beyond-context-windows/video.mp4'
 faq:
   - q: 'What is the Recursive Language Model pattern?'

--- a/src/content/blog/building-a-personal-site-in-2026-post.md
+++ b/src/content/blog/building-a-personal-site-in-2026-post.md
@@ -4,7 +4,7 @@ description: "The case for constraint-led web development — Astro, zero custom
 date: 2026-02-15
 tags: ['engineering', 'web', 'astro', 'open-source']
 heroImage: '/notebook-assets/building-a-personal-site-in-2026/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/building-a-personal-site-in-2026/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/building-a-personal-site-in-2026/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/building-a-personal-site-in-2026/video.mp4'
 faq:
   - q: 'What framework is best for a personal site in 2026?'

--- a/src/content/blog/economics-of-inadequate-safety-post.md
+++ b/src/content/blog/economics-of-inadequate-safety-post.md
@@ -5,9 +5,9 @@ date: 2026-05-01
 tags: ['ai-safety', 'economics', 'policy', 'research']
 draft: false
 heroImage: '/notebook-assets/economics-of-inadequate-safety/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/economics-of-inadequate-safety/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/economics-of-inadequate-safety/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/economics-of-inadequate-safety/video.mp4'
-audioDuration: '24:51'
+audioDuration: '22:29'
 youtubeUrl: 'https://www.youtube.com/watch?v=bfgT4qRJ5GQ'
 ---
 

--- a/src/content/blog/footnotes-at-the-edge-of-reality-post.md
+++ b/src/content/blog/footnotes-at-the-edge-of-reality-post.md
@@ -5,7 +5,7 @@ date: 2026-02-12
 tags: ['poetry', 'physics', 'writing', 'creative']
 draft: false
 heroImage: '/notebook-assets/footnotes-at-the-edge-of-reality/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=dVD75vZg7fw'
 ---

--- a/src/content/blog/getting-google-nest-cameras-into-frigate-nvr-post.md
+++ b/src/content/blog/getting-google-nest-cameras-into-frigate-nvr-post.md
@@ -5,7 +5,7 @@ date: 2026-03-16
 tags: ['engineering', 'homelab', 'raspberry-pi', 'python', 'home-assistant']
 draft: false
 heroImage: '/notebook-assets/getting-google-nest-cameras-into-frigate-nvr/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/getting-google-nest-cameras-into-frigate-nvr/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/getting-google-nest-cameras-into-frigate-nvr/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/getting-google-nest-cameras-into-frigate-nvr/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=o8XvfpCJwFc'
 ---

--- a/src/content/blog/giving-a-robot-three-voices-post.md
+++ b/src/content/blog/giving-a-robot-three-voices-post.md
@@ -4,7 +4,7 @@ description: 'Building a three-persona TTS pipeline for a Pi robot — MLX voice
 date: 2026-03-19
 tags: ['ai', 'tts', 'mlx', 'raspberry-pi', 'robotics', 'apple-silicon', 'voice-cloning', 'spark']
 heroImage: '/notebook-assets/giving-a-robot-three-voices/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/giving-a-robot-three-voices/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/giving-a-robot-three-voices/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/giving-a-robot-three-voices/video.mp4'
 series: 'PiCar-X'
 seriesOrder: 2

--- a/src/content/blog/hello-world-post.md
+++ b/src/content/blog/hello-world-post.md
@@ -4,7 +4,7 @@ description: 'The commit log is more honest than the readme. Building in public 
 date: 2026-02-12
 tags: ['meta', 'craft', 'open-source']
 heroImage: '/notebook-assets/hello-world/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/hello-world/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/hello-world/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/hello-world/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=C67cw_cTUOc'
 ---

--- a/src/content/blog/how-to-read-a-safety-claim-post.md
+++ b/src/content/blog/how-to-read-a-safety-claim-post.md
@@ -5,9 +5,9 @@ date: 2026-04-30
 tags: ['ai-safety', 'policy', 'literacy', 'research']
 draft: false
 heroImage: '/notebook-assets/how-to-read-a-safety-claim/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/how-to-read-a-safety-claim/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/how-to-read-a-safety-claim/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/how-to-read-a-safety-claim/video.mp4'
-audioDuration: '21:45'
+audioDuration: '23:29'
 youtubeUrl: 'https://www.youtube.com/watch?v=gp6r7yHkJdY'
 ---
 

--- a/src/content/blog/learning-mechanics-deep-learning-theory-post.md
+++ b/src/content/blog/learning-mechanics-deep-learning-theory-post.md
@@ -5,9 +5,9 @@ date: 2026-05-03
 tags: ['AI', 'deep learning', 'theory', 'research']
 draft: false
 heroImage: '/notebook-assets/learning-mechanics-deep-learning-theory/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/learning-mechanics-deep-learning-theory/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/learning-mechanics-deep-learning-theory/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/learning-mechanics-deep-learning-theory/video.mp4'
-audioDuration: '19:20'
+audioDuration: '23:03'
 slides: '/notebook-assets/learning-mechanics-deep-learning-theory/slides.pdf'
 youtubeUrl: 'https://www.youtube.com/watch?v=9Mp-HZZDEo4'
 ---

--- a/src/content/blog/magnifica-humanitas-post.md
+++ b/src/content/blog/magnifica-humanitas-post.md
@@ -5,8 +5,8 @@ date: 2026-05-26
 tags: ['ai-safety', 'policy', 'anthropic', 'governance', 'ai-ethics', 'research']
 draft: false
 heroImage: '/notebook-assets/magnifica-humanitas/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/magnifica-humanitas/audio.mp3'
-audioDuration: '14:24'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/magnifica-humanitas/audio.m4a'
+audioDuration: '19:56'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/magnifica-humanitas/video.mp4'
 faq:
   - q: "What is Magnifica Humanitas?"

--- a/src/content/blog/multi-agent-supply-chain-post.md
+++ b/src/content/blog/multi-agent-supply-chain-post.md
@@ -5,9 +5,9 @@ date: 2026-04-29
 tags: ['ai-safety', 'multi-agent', 'security', 'research', 'architecture']
 draft: false
 heroImage: '/notebook-assets/multi-agent-supply-chain/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/multi-agent-supply-chain/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/multi-agent-supply-chain/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/multi-agent-supply-chain/video.mp4'
-audioDuration: '23:17'
+audioDuration: '15:31'
 youtubeUrl: 'https://www.youtube.com/watch?v=8Vye4BVYAbg'
 ---
 

--- a/src/content/blog/non-coercive-design-post.md
+++ b/src/content/blog/non-coercive-design-post.md
@@ -5,9 +5,9 @@ date: 2026-04-26
 tags: ['ai-safety', 'neurodivergence', 'engineering', 'philosophy', 'research']
 draft: false
 heroImage: '/notebook-assets/non-coercive-design/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/non-coercive-design/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/non-coercive-design/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/non-coercive-design/video.mp4'
-audioDuration: '23:33'
+audioDuration: '21:01'
 youtubeUrl: 'https://www.youtube.com/watch?v=1l5vQ79JMdE'
 ---
 

--- a/src/content/blog/project-chimera-post.md
+++ b/src/content/blog/project-chimera-post.md
@@ -5,7 +5,7 @@ date: 2026-04-04
 heroImage: '/notebook-assets/project-chimera/infographic.webp'
 tags: ['ai', 'enterprise', 'research', 'engineering']
 draft: false
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/project-chimera/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/project-chimera/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/project-chimera/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=dlGl944asaw'
 ---

--- a/src/content/blog/reconciling-the-great-divergence-post.md
+++ b/src/content/blog/reconciling-the-great-divergence-post.md
@@ -5,7 +5,7 @@ date: 2026-03-01
 tags: ['ai', 'economics', 'research', 'policy']
 draft: false
 heroImage: '/notebook-assets/reconciling-the-great-divergence/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/reconciling-the-great-divergence/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/reconciling-the-great-divergence/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/reconciling-the-great-divergence/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=E4XGmIPM09g'
 ---

--- a/src/content/blog/safety-first-therapeutic-ai-post.md
+++ b/src/content/blog/safety-first-therapeutic-ai-post.md
@@ -5,7 +5,7 @@ date: 2026-03-15
 tags: ['ai', 'ai-safety', 'health', 'typescript']
 draft: false
 heroImage: '/notebook-assets/safety-first-therapeutic-ai/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/safety-first-therapeutic-ai/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/safety-first-therapeutic-ai/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/safety-first-therapeutic-ai/video.mp4'
 faq:
   - q: 'What is EMDR and why does it require AI safety?'

--- a/src/content/blog/the-cognitive-cage-post.md
+++ b/src/content/blog/the-cognitive-cage-post.md
@@ -5,7 +5,7 @@ date: 2026-03-01
 tags: ['ai', 'ai-safety', 'robotics', 'research', 'engineering']
 draft: false
 heroImage: '/notebook-assets/the-cognitive-cage/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-cognitive-cage/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-cognitive-cage/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-cognitive-cage/video.mp4'
 faq:
   - q: 'What is the cognitive cage in robotics?'

--- a/src/content/blog/the-legal-ai-trust-deficit-post.md
+++ b/src/content/blog/the-legal-ai-trust-deficit-post.md
@@ -5,7 +5,7 @@ date: 2026-03-02
 tags: ['ai', 'legal', 'research', 'llm']
 draft: false
 heroImage: '/notebook-assets/the-legal-ai-trust-deficit/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-legal-ai-trust-deficit/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-legal-ai-trust-deficit/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-legal-ai-trust-deficit/video.mp4'
 faq:
   - q: 'Why are lawyers slow to adopt AI?'

--- a/src/content/blog/the-mitigation-gap-post.md
+++ b/src/content/blog/the-mitigation-gap-post.md
@@ -5,7 +5,7 @@ date: 2026-04-04
 heroImage: '/notebook-assets/the-mitigation-gap/infographic.webp'
 tags: ['ai', 'ai-safety', 'research', 'biosecurity', 'policy']
 draft: false
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-mitigation-gap/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-mitigation-gap/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-mitigation-gap/video.mp4'
 faq:
   - q: 'What is the mitigation gap in AI biosecurity?'

--- a/src/content/blog/the-notebooklm-pipeline-post.md
+++ b/src/content/blog/the-notebooklm-pipeline-post.md
@@ -4,7 +4,7 @@ description: "How I automated audio overviews, quizzes, mind maps, and infograph
 date: 2026-02-15
 tags: ['engineering', 'automation', 'ai', 'python']
 heroImage: '/notebook-assets/the-notebooklm-pipeline/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-notebooklm-pipeline/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-notebooklm-pipeline/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-notebooklm-pipeline/video.mp4'
 faq:
   - q: 'What is the NotebookLM pipeline?'

--- a/src/content/blog/the-organismic-line-post.md
+++ b/src/content/blog/the-organismic-line-post.md
@@ -5,9 +5,9 @@ date: 2026-05-02
 tags: ['ai-safety', 'philosophy', 'neuroscience', 'research']
 draft: false
 heroImage: '/notebook-assets/the-organismic-line/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-organismic-line/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-organismic-line/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-organismic-line/video.mp4'
-audioDuration: '21:21'
+audioDuration: '22:47'
 youtubeUrl: 'https://www.youtube.com/watch?v=J8I3kHWV0kc'
 ---
 

--- a/src/content/blog/the-resonant-fringe-post.md
+++ b/src/content/blog/the-resonant-fringe-post.md
@@ -4,7 +4,7 @@ description: "Auditory Spiral, RTRFM, and how Perth's electronic music undergrou
 date: 2026-03-18
 tags: ['history', 'music', 'perth', 'radio']
 heroImage: '/notebook-assets/the-resonant-fringe/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-resonant-fringe/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-resonant-fringe/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-resonant-fringe/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=AB0XPhgLY8w'
 ---

--- a/src/content/blog/the-robot-that-refuses-to-give-orders-post.md
+++ b/src/content/blog/the-robot-that-refuses-to-give-orders-post.md
@@ -4,7 +4,7 @@ description: 'How SPARK is rewriting the rules of neurodivergent support — a n
 date: 2026-03-12
 tags: ['ai', 'neurodivergence', 'robotics', 'parenting', 'raspberry-pi']
 heroImage: '/notebook-assets/the-robot-that-refuses-to-give-orders/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-robot-that-refuses-to-give-orders/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-robot-that-refuses-to-give-orders/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-robot-that-refuses-to-give-orders/video.mp4'
 series: 'PiCar-X'
 seriesOrder: 1

--- a/src/content/blog/this-wasnt-in-the-brochure-post.md
+++ b/src/content/blog/this-wasnt-in-the-brochure-post.md
@@ -4,7 +4,7 @@ description: 'A field guide for co-parenting neurodivergent children — written
 date: 2026-02-15
 tags: ['writing', 'neurodivergence', 'parenting', 'books']
 heroImage: '/notebook-assets/this-wasnt-in-the-brochure/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=pPqwP8v3tks'
 ---

--- a/src/content/blog/voice-cloning-qwen3-tts-mlx-post.md
+++ b/src/content/blog/voice-cloning-qwen3-tts-mlx-post.md
@@ -5,7 +5,7 @@ date: 2026-03-19
 tags: ['ai', 'tts', 'mlx', 'apple-silicon', 'voice-cloning', 'tutorial', 'spark']
 series: 'PiCar-X'
 seriesOrder: 3
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/voice-cloning-qwen3-tts-mlx/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/voice-cloning-qwen3-tts-mlx/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/voice-cloning-qwen3-tts-mlx/video.mp4'
 heroImage: '/notebook-assets/voice-cloning-qwen3-tts-mlx/infographic.webp'
 faq:

--- a/src/content/blog/zero-build-web-development-post.md
+++ b/src/content/blog/zero-build-web-development-post.md
@@ -5,7 +5,7 @@ date: 2026-03-14
 tags: ['engineering', 'web', 'security', 'cloudflare']
 draft: false 
 heroImage: '/notebook-assets/zero-build-web-development/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/zero-build-web-development/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/zero-build-web-development/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/zero-build-web-development/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=j2b3-7Y3rWU'
 ---

--- a/src/content/projects/auditory-spiral.md
+++ b/src/content/projects/auditory-spiral.md
@@ -6,7 +6,7 @@ status: 'archived'
 featured: false
 date: 1992-01-01
 heroImage: '/notebook-assets/auditory-spiral/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/auditory-spiral/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/auditory-spiral/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/auditory-spiral/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=TyttZAAO8gs'
 ---

--- a/src/content/projects/cv.md
+++ b/src/content/projects/cv.md
@@ -6,7 +6,7 @@ repo: 'cv'
 status: 'active'
 featured: false
 date: 2026-02-04
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/cv/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/cv/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/cv/video.mp4'
 heroImage: '/notebook-assets/cv/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=1Zg7I5Awymc'

--- a/src/content/projects/emdr-agent.md
+++ b/src/content/projects/emdr-agent.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/emdr-agent'
 status: 'experiment'
 featured: false
 date: 2025-06-01
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/emdr-agent/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/emdr-agent/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/emdr-agent/video.mp4'
 heroImage: '/notebook-assets/emdr-agent/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=owXdPDifuQE'

--- a/src/content/projects/footnotes-at-the-edge-of-reality.md
+++ b/src/content/projects/footnotes-at-the-edge-of-reality.md
@@ -8,7 +8,7 @@ status: 'complete'
 featured: true
 date: 2026-02-06
 heroImage: '/notebook-assets/footnotes-at-the-edge-of-reality/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/footnotes-at-the-edge-of-reality/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=3jYi9NvK5qY'
 ---

--- a/src/content/projects/home-assistant-obsidian.md
+++ b/src/content/projects/home-assistant-obsidian.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/home-assistant-obsidian'
 status: 'active'
 featured: false
 date: 2024-06-01
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/home-assistant-obsidian/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/home-assistant-obsidian/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/home-assistant-obsidian/video.mp4'
 heroImage: '/notebook-assets/home-assistant-obsidian/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=Z9GNQlp9g0A'

--- a/src/content/projects/lunar-tools-prototypes.md
+++ b/src/content/projects/lunar-tools-prototypes.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/lunar_tools_prototypes'
 status: 'experiment'
 featured: false
 date: 2025-06-15
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/lunar-tools-prototypes/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/lunar-tools-prototypes/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lunar-tools-prototypes/video.mp4'
 heroImage: '/notebook-assets/lunar-tools-prototypes/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=QIN1nHFvPMQ'

--- a/src/content/projects/orbitr.md
+++ b/src/content/projects/orbitr.md
@@ -7,7 +7,7 @@ status: 'experiment'
 featured: false
 date: 2025-09-01
 heroImage: '/notebook-assets/orbitr/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/orbitr/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/orbitr/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/orbitr/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=8TwAvE9Sl-0'
 ---

--- a/src/content/projects/ordr-fm.md
+++ b/src/content/projects/ordr-fm.md
@@ -7,7 +7,7 @@ status: 'active'
 featured: false
 date: 2025-07-01
 heroImage: '/notebook-assets/ordr-fm/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/ordr-fm/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/ordr-fm/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/ordr-fm/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=n47aO8KOwbI'
 ---

--- a/src/content/projects/personal-agentic-operating-system.md
+++ b/src/content/projects/personal-agentic-operating-system.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/personal-agentic-operating-system'
 status: 'active'
 featured: false
 date: 2025-07-01
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/personal-agentic-operating-system/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/personal-agentic-operating-system/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/personal-agentic-operating-system/video.mp4'
 heroImage: '/notebook-assets/personal-agentic-operating-system/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=O1Q8Kf_LxmM'

--- a/src/content/projects/rlm-mcp.md
+++ b/src/content/projects/rlm-mcp.md
@@ -7,7 +7,7 @@ status: 'active'
 featured: false
 date: 2025-11-01
 heroImage: '/notebook-assets/rlm-mcp/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/rlm-mcp/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/rlm-mcp/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/rlm-mcp/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=uD_7QXkYc9U'
 ---

--- a/src/content/projects/space-weather.md
+++ b/src/content/projects/space-weather.md
@@ -7,7 +7,7 @@ status: 'active'
 featured: false
 date: 2025-01-01
 heroImage: '/notebook-assets/space-weather/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/space-weather/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/space-weather/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/space-weather/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=EyPqXRhWNOA'
 ---

--- a/src/content/projects/strategic-acquisitions.md
+++ b/src/content/projects/strategic-acquisitions.md
@@ -6,7 +6,7 @@ status: 'active'
 featured: false
 date: 2025-01-15
 heroImage: '/notebook-assets/strategic-acquisitions/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/strategic-acquisitions/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/strategic-acquisitions/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/strategic-acquisitions/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=FGpHDCqKoJg'
 ---

--- a/src/content/projects/tel3sis.md
+++ b/src/content/projects/tel3sis.md
@@ -7,7 +7,7 @@ status: 'active'
 featured: false
 date: 2025-10-01
 heroImage: '/notebook-assets/tel3sis/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/tel3sis/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/tel3sis/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/tel3sis/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=EVBHvgyH3D4'
 ---

--- a/src/content/projects/this-wasnt-in-the-brochure.md
+++ b/src/content/projects/this-wasnt-in-the-brochure.md
@@ -8,7 +8,7 @@ status: 'active'
 featured: true
 date: 2026-02-08
 heroImage: '/notebook-assets/this-wasnt-in-the-brochure/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/this-wasnt-in-the-brochure/video.mp4'
 series: "This Wasn't in the Brochure"
 seriesOrder: 1

--- a/src/content/projects/veritas.md
+++ b/src/content/projects/veritas.md
@@ -6,7 +6,7 @@ repo: 'https://github.com/adrianwedd/VERITAS'
 status: 'active'
 featured: false
 date: 2025-03-01
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/veritas/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/veritas/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/veritas/video.mp4'
 heroImage: '/notebook-assets/veritas/infographic.webp'
 youtubeUrl: 'https://www.youtube.com/watch?v=rv-cCMNBu2w'

--- a/src/content/projects/wolf-clan-hub.md
+++ b/src/content/projects/wolf-clan-hub.md
@@ -7,7 +7,7 @@ status: 'active'
 featured: true
 date: 2026-03-02
 heroImage: '/notebook-assets/wolf-clan-hub/infographic.webp'
-audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/wolf-clan-hub/audio.mp3'
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/wolf-clan-hub/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/wolf-clan-hub/video.mp4'
 youtubeUrl: 'https://www.youtube.com/watch?v=pLbwFRqgF6s'
 ---


### PR DESCRIPTION
Adrian greenlit regenerating the 44 tracks PR #458 couldn't recover (notebooks deleted, no local originals). These are NEW NotebookLM takes — a sanctioned editorial change to published audio.

## What changed
- 82 content files: `audioUrl` …/audio.mp3 → …/audio.m4a + refreshed `duration`/`audioDuration` per take
- All 44 m4as uploaded to R2 and verified serving on cdn.adrianwedd.com (old mp3s left in place)
- No transcoding anywhere: files are byte-identical to what NLM issued

## QA performed
- Sources per notebook: post markdown + live page URL (+ repo/site for projects)
- Full-transcript check on the five takes that briefly had a 404-page source (my bad URL bug, since fixed): the tainted takes narrated the 404 page and were replaced with clean regenerations; tainted artifacts archived, never shipped
- 60-second transcript spot-check on all 44: on-topic, no contamination
- Durations 10:33–23:32, all probed from the actual files

## Flag for Adrian
Four takes came from NLM natively below 256k (their original quality — untouched):
- 120-models-18k-prompts, safety-first-therapeutic-ai, non-coercive-design @ 96k
- orbitr @ 128k

If you want those re-rolled hoping for a 256k take, say so — costs one generation each (new take, tomorrow's quota).