### PR TITLE
docs(repo): governance + accuracy package — README, CHANGELOG, LICENSE, SECURITY, CONTRIBUTING, templates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,38 @@
+# ── Site ──────────────────────────────────────────────────────────────────────
+# Google Analytics 4 measurement ID (public — safe to expose in frontend code)
+PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+
+# ── GA4 data fetch (build-time, CI only) ──────────────────────────────────────
+# GA4 property numeric ID (found in GA4 Admin → Property Settings)
+GA4_PROPERTY_ID=000000000
+
+# Service account JSON key for GA4 Data API (base64-encoded in CI)
+# Local dev: set GA4_SERVICE_ACCOUNT_KEY_PATH instead
+GA4_SERVICE_ACCOUNT_KEY=<base64-encoded JSON>
+GA4_SERVICE_ACCOUNT_KEY_PATH=.ga4-credentials.json
+
+# ── Social worker (worker/) ───────────────────────────────────────────────────
+# Bearer token for POST /api/publish and POST /api/queue (CLI auth)
+PUBLISH_SECRET=<secret>
+CLI_SECRET=<secret>
+
+# Facebook Page access token
+FACEBOOK_PAGE_ACCESS_TOKEN=<token>
+FACEBOOK_PAGE_ID=<page-id>
+
+# Instagram Business Account ID (uses Facebook token above)
+INSTAGRAM_BUSINESS_ACCOUNT_ID=<account-id>
+
+# Bluesky credentials
+BLUESKY_HANDLE=adrianwedd.com
+BLUESKY_APP_PASSWORD=<app-password>
+
+# X / Twitter OAuth 2.0
+TWITTER_CLIENT_ID=<client-id>
+TWITTER_CLIENT_SECRET=<secret>
+TWITTER_ACCESS_TOKEN=<token>
+TWITTER_ACCESS_TOKEN_SECRET=<token-secret>
+
+# ── CV sync (CI only) ─────────────────────────────────────────────────────────
+# GitHub PAT with read access to adrianwedd/cv (private repo)
+CV_GITHUB_TOKEN=<token>

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,39 @@
+name: Bug report
+description: Something on the site is broken or behaving unexpectedly
+labels: ["type:bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to report a bug.
+  - type: input
+    id: url
+    attributes:
+      label: Page URL
+      description: Which page is affected?
+      placeholder: https://adrianwedd.com/blog/...
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you see? What did you expect to see?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error
+    validations:
+      required: false
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and OS
+      placeholder: e.g. Safari 18 on macOS, Chrome 124 on Windows
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/content_fix.yml
+++ b/.github/ISSUE_TEMPLATE/content_fix.yml
@@ -1,0 +1,18 @@
+name: Content fix
+description: A typo, broken link, factual error, or outdated information in site content
+labels: ["type:content"]
+body:
+  - type: input
+    id: url
+    attributes:
+      label: Page URL
+      placeholder: https://adrianwedd.com/blog/...
+    validations:
+      required: true
+  - type: textarea
+    id: issue
+    attributes:
+      label: What needs fixing?
+      description: Quote the text or describe the broken element. If suggesting replacement text, include it here.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/security_contact.yml
+++ b/.github/ISSUE_TEMPLATE/security_contact.yml
@@ -1,0 +1,18 @@
+name: Security issue
+description: "⚠️ Do NOT use this form for security vulnerabilities — see SECURITY.md instead"
+labels: ["type:security"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Please do not report security vulnerabilities as public GitHub issues.**
+
+        See [SECURITY.md](../SECURITY.md) for the responsible disclosure process and contact details.
+
+        This template is for non-sensitive security questions only (e.g. "does the CSP block X?").
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## What does this change?
+
+<!-- One-paragraph summary. Link to any related issues. -->
+
+## Checklist
+
+### Always
+- [ ] `npm run check` passes (type check + lint + content validation)
+- [ ] `npm run build` succeeds locally
+
+### If touching content
+- [ ] No content file has been renamed after publication (would break the URL)
+- [ ] New `.webp` heroImages have a `.jpg` twin at the same path
+- [ ] Descriptions are ≤ 160 characters (`node scripts/validate-content.js`)
+- [ ] `npm run check:links` passes on the build output
+
+### If touching worker code
+- [ ] `cd worker && npm test` passes
+- [ ] `cd worker && npx wrangler deploy --dry-run` succeeds
+
+### If touching worker-csp
+- [ ] `cd worker-csp && npm test && npx tsc --noEmit` passes
+
+### If making visual changes
+- [ ] Screenshot(s) attached below (dark mode + light mode if applicable)
+
+## Screenshots (if visual)
+
+<!-- Paste before/after screenshots here -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,32 @@ updates:
           - minor
           - patch
 
+  - package-ecosystem: npm
+    directory: /worker
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    labels:
+      - "type:infrastructure"
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /worker-csp
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    labels:
+      - "type:infrastructure"
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,122 @@
+# What's been happening
+
+A running account of how this site has grown — what was built, why it was built, and what was learned along the way.
+
+---
+
+## 11–12 June 2026 — Audio quality sweep, Eight Minutes publishes, The Index goes live
+
+**Added:** Eight Minutes three-part phishing series (The Trap, The Fall, The Fight) — each with Lyria music video, branded infographic, audio deep dive. The Index long-form companion essay. `replyTo` support on `POST /api/publish` (worker).
+**Fixed:** All 78 audio episodes restored to original 256kbps quality (34 from kept originals, 44 regenerated). The Index video re-cut (glitchy tail). The Index audio duration display.
+**Changed:** 64kbps compression step deleted from the pipeline permanently. Dependency sweep: Astro 6.4.2, Vitest 4, Hono 4.12.25, Wrangler 4.99.
+
+Three things landed in rapid succession, each connected to the previous one.
+
+The immediate trigger was the audio quality problem. For most of the site's life, NotebookLM audio overviews had been compressed to 64kbps mono MP3 for storage reasons that no longer applied once the media moved to R2. That decision was wrong — the originals that NotebookLM delivers are 256kbps stereo AAC, and the compression had been silently degrading every audio episode on the site. 34 tracks could be restored from originals that had been kept; the other 44 had to be regenerated from NotebookLM and replaced. All 78 are now served at original quality. The 64kbps compression step was deleted from the pipeline and the documentation updated to make it explicit: never compress published audio.
+
+Eight Minutes is a three-part blog series about a Google AiTM phishing incident that happened on 10 June 2026 — the day before publication. The series covers the technical anatomy of the attack (The Trap), how it almost succeeded (The Fall), and how the abuse-report process works after the fact (The Fight). Writing and publishing on the day after the incident was a deliberate choice: the material was still live, the abuse reports were in flight, and the series documented both the event and the institutional response in real time. Each part got its own Lyria music video, branded infographic hero, and audio deep dive; the Fight instalment also got a focused 20-minute audio overview on top of the series recap. The social drip was wired to stagger the posts over three days from publication.
+
+The Index landed the same day. It is a companion to the phishing series — a long-form essay about what the incident revealed about how contemporary AI tools reason about identity, authority, and manipulation. The video had a glitchy tail that required a re-cut before it could go up; the audio duration display had been broken because the frontmatter was pointing at an old URL. Both were fixed the same session.
+
+---
+
+## 5–6 June 2026 — Lyria Chronicles completes
+
+**Added:** Lyria Chronicles #1–27 live on daily drip (1–25 June). Video podcast feed. 37 YouTube URLs wired across the series.
+**Fixed:** Post numbering gaps (Tell + Recital dropped, remainder renumbered). Series date range corrected to one-per-day.
+**Changed:** Social autopublish rewired from push-triggered to date-triggered; `autopublish:true` guard added to prevent re-broadcasting hand-posted content.
+
+The Lyria Chronicles is a 27-post series documenting a music production project using Google's Lyria AI audio model. Posts went live on a daily drip from 1 June through 25 June, with each entry leading with the track's video rather than a static hero image.
+
+The series ran into several structural issues that required repair before publication. A numbering gap had opened up when two posts (Tell and Recital) were dropped from the sequence; the remaining posts were renumbered to close it. The date range was redated to spread one post per day across the series arc. The social autopublish system needed to be rewired to trigger on a post's publication `date` field rather than immediately, which also required adding a guard against re-broadcasting posts that had already been hand-posted to Facebook and Twitter.
+
+The finale — The Source (#27) and The Affirmative (#26) — were the last to be written and the hardest. The Source is a homage to Matthew Herbert's found-sound tradition; The Affirmative closes the arc with a statement about what the project meant to make. 37 posts across the series received YouTube URLs wiring them to the @adrianwedd channel, and a video podcast feed was published alongside the YouTube uploads.
+
+The social publishing infrastructure also got a structural change here: date-triggered posting replaced immediate publishing, so future series with daily drips can be set up in advance without manual scheduling.
+
+---
+
+## 26–30 May 2026 — AI safety series, portfolio refresh, services rewrite, internal-link checker
+
+**Added:** 11 AI safety posts (each with cinematic video + audio). Build-time internal-link checker (`npm run check:links`). Tasmania 2026-27 budget analysis post.
+**Fixed:** 16 dead internal links. Dead YouTube embed and broken gallery reference.
+**Changed:** Project pages rewritten as problem/constraint/punchline case studies. Services copy, pricing, and case studies tightened. Homepage, contact, and about aligned to current positioning.
+
+Eleven AI safety posts went up in a single batch, covering compute governance, AI alignment, and several posts that had been drafted over the preceding weeks. Each got a cinematic NotebookLM video and its own audio collection entry.
+
+The portfolio got a significant content pass. Project pages were rewritten from narrative summaries to something closer to case studies — the pattern across all of them is problem/constraint/punchline. The services, contact, homepage, and about pages were rewritten together as a single positioning pass, aligning the copy across all four to match the operational picture in the internal ops docs. Pricing copy was tightened with a scoped retainer definition and accurate day rates.
+
+A build-time internal-link checker was added to CI. Lychee had been the external link checker, but it deliberately skips same-origin links to avoid pre-deploy 404 false positives. The new checker scans the built HTML for same-origin links that don't resolve to anything in `dist/` — it closed 16 dead internal links that had accumulated unnoticed, including a dead YouTube embed and a broken gallery reference.
+
+---
+
+## 15–23 May 2026 — Worker hardening, OG pipeline, Bluesky video embeds
+
+**Added:** Bluesky video and image embed support. `adrianwedd.com` Bluesky custom handle. `youtubeUrl` → VideoObject JSON-LD with `embedUrl` + `url`.
+**Fixed:** SSRF defense on Bluesky federated PDS endpoint. Cron filter ordering. `CronLock` fencing token race condition. `forceRetry` record-type confusion. OG generator not being called at build time. Project JSON-LD canonical URL override.
+**Changed:** OG image dimensions now read from file headers at build time (replaced filename heuristic).
+
+The social worker received two hardening passes driven by multi-engine QA findings. The first batch closed five critical gaps: SSRF defense on the Bluesky federated PDS endpoint, cron filter ordering, a race condition in the `CronLock` Durable Object's fencing token logic, and a `forceRetry` bypass that wasn't correctly distinguishing failed records from published ones. The second pass folded in findings from a parallel Codex + Hermes review, tightening the worker test contract and the CI `.jpg`-twin guard.
+
+The OG image pipeline had been broken in two ways: the generator wasn't being called during the build, and the project JSON-LD was overriding canonical URLs with a hardcoded value. Both were fixed together. OG image dimensions are now read from actual file headers at build time via a small PNG/JPEG/WebP parser — this replaced an older heuristic that guessed dimensions from the filename and had been silently setting wrong sizes for any hero image that didn't match the naming convention.
+
+---
+
+## 4–9 May 2026 — YouTube, Apple Podcasts, cinematic videos at scale
+
+**Added:** `youtubeUrl` frontmatter field. YouTube + Apple Podcasts links in footer. 16 cinematic videos wired across content.
+**Changed:** Failure-first repo links updated to `failurefirst` GitHub org. CI pages artifact retention cut from 7 days to 1 day.
+
+A batch of 16 content items received cinematic NotebookLM YouTube URLs, and the footer gained links to the YouTube channel and Apple Podcasts feed. The `youtubeUrl` frontmatter field was introduced to connect individual posts to their corresponding YouTube uploads; the JSON-LD on posts with a `youtubeUrl` now emits a full VideoObject with `embedUrl` and `url` fields.
+
+The failure-first project links were updated to point at the new `failurefirst` GitHub organisation rather than the original personal repo. Artifact storage in CI was reduced — pages artifacts had been retaining for 7 days, accumulating significant storage; this was cut to 1 day.
+
+---
+
+## 14–15 May 2026 — Bottom Pub Co-op post, NLM pipeline hardening
+
+**Added:** Bottom Pub Co-op blog post + audio overview.
+**Fixed:** NLM export scripts — atomic writes, tab-delimited output, `--update` mode for incremental runs.
+
+The Bottom Pub Co-op got its own blog post and audio overview — a piece about the community effort to purchase a heritage pub in Tasmania. This was the first post to fully exercise the end-to-end NLM pipeline: notebook creation, audio generation, upload to R2, frontmatter update, and OG infographic committed alongside a `.jpg` twin.
+
+The NotebookLM export scripts received a hardening pass around the same time: atomic writes to prevent partial-file corruption on interrupted runs, tab-delimited output to handle multi-line content correctly, and an `--update` mode for incremental runs on large batches.
+
+---
+
+## 27–30 April 2026 — Astro 6 + Tailwind 4 migration
+
+**Changed:** Astro 5 → 6, Tailwind 3 → 4. `tailwind.config.mjs` replaced by `@theme` block in `global.css`.
+**Added:** `worker-csp/` — Cloudflare Worker for per-request CSP nonce injection (deployed dormant).
+
+The site migrated from Astro 5 + Tailwind 3 to Astro 6 + Tailwind 4. The Tailwind migration was the more structural of the two: the old `tailwind.config.mjs` was replaced entirely by an `@theme` block inside `src/styles/global.css`, collapsing the theming system into a single file. All colour utilities (`bg-surface`, `text-accent`, etc.) continue to resolve through CSS custom properties; the migration didn't change any component code or HTML.
+
+A CSP nonce worker (`worker-csp/`) was built alongside the migration — a Cloudflare Worker that injects per-request nonces into the HTML at the edge and sets a strict `Content-Security-Policy` response header with `strict-dynamic`, `form-action`, and `frame-ancestors`. It was built and tested but deployed dormant during the migration, to be activated once the rest of the migration stabilised.
+
+---
+
+## April 2026 — Cinematic videos, CDN audio fixes, Bluesky infrastructure
+
+**Added:** 20+ cinematic NotebookLM video summaries across posts and projects. Bluesky posting support in the social worker.
+**Fixed:** R2 CORS configuration gap causing Safari audio playback failures. Audio URLs migrated from git-tracked paths to CDN URLs.
+
+A batch run of NotebookLM cinematic video summaries went up for a wide range of posts and projects — 20+ videos across two sessions. The media CDN had a CORS configuration gap that was causing audio playback failures in Safari; this was fixed in the R2 bucket policy alongside an audio URL migration that moved several posts from git-tracked paths to CDN URLs.
+
+The CSP hash infrastructure for the static site was reviewed and a separate `worker-csp/` codebase was initialised for the edge nonce injection approach.
+
+---
+
+## February 2026 — The site launches
+
+**Added:** Everything — Astro 6 static site on GitHub Pages with full content pipeline, NotebookLM integration, social worker, consent-gated analytics, and 14 sprints of features delivered in four days.
+**Changed:** Hosting migrated from Cloudflare Pages to GitHub Pages on day 3 (Cloudflare's 25 MB asset limit required compressing audio — unacceptable).
+
+The site went from nothing to fully published across four days.
+
+**12 February:** The foundation landed in four phases. Phase 1 was the Astro project itself — layout, design tokens, the dark botanical palette with dusty copper accent. Phase 2 was the content layer: blog, projects, gallery, audio, about, with NotebookLM studio assets embedded in each. Phase 3 wired in the intelligence layer: consent-gated GA4 analytics with rich event tracking, personalisation, and transparency disclosures. Phase 4 was polish — performance, accessibility, SEO, and the GitHub Pages deployment.
+
+**13–14 February:** The first content sprint filled in 11 project pages, audio cross-links, voice rewrites, NotebookLM infographics as hero images for 13 projects, and the analytics dashboard wired to real GA4 data. The site moved from Cloudflare Pages to GitHub Pages on the 14th — the 25 MB asset limit on Cloudflare Pages had required compressing the ADHDo audio, which was unacceptable; GitHub Pages has no equivalent limit.
+
+**15 February:** Six sprints ran in rapid succession, covering Pagefind search, table of contents, breadcrumbs, reading time, project tag filters, a `/now` page with GitHub activity, gallery pages, keyboard shortcuts, and a terminal easter egg. Three blog posts and three gallery collections went up the same day.
+
+The site launched with a design system built entirely on CSS custom properties — no hardcoded colours anywhere, dark mode as the baseline, light mode as the `.light` class variation. The decision to use system fonts only (no web font loading) was made on day one and has held. NotebookLM was integrated from launch as the audio/video/infographic pipeline for every post; the automation scripts for batch generation were written during the same week.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing
+
+This is a personal website. External PRs are welcome for bug fixes, broken
+links, accessibility issues, and typos. For anything larger, open an issue
+first so we can discuss whether it fits.
+
+## Prerequisites
+
+- **Node 22** (matches CI — check with `node -v`)
+- npm (bundled with Node)
+- For worker development: [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
+
+## Setup
+
+```bash
+git clone https://github.com/adrianwedd/adrianwedd.com.git
+cd adrianwedd.com
+npm ci
+npm run dev       # dev server at localhost:4321
+```
+
+The site builds without the private `src/data/base-cv.json` (CV data is synced
+from a private repo at deploy time; local dev falls back to defaults).
+
+## Before opening a PR
+
+Run the full local check suite:
+
+```bash
+npm run check          # astro type check + lint + content validation
+npm run build          # full production build including Pagefind indexing
+npm run check:links    # internal-link checker on the built output
+```
+
+If you touched worker code:
+
+```bash
+cd worker && npm test && npx wrangler deploy --dry-run
+cd worker-csp && npm test && npx tsc --noEmit
+```
+
+## Content conventions
+
+- **URLs are permanent.** Never rename a published content file — the filename
+  determines the URL. If a URL truly must change, add a redirect in
+  `astro.config.mjs`.
+- **Descriptions ≤ 160 characters** — enforced by `scripts/validate-content.js`
+  and the CI gate.
+- **Local images use `<Picture>`** from `astro:assets`, never raw `<img>`.
+  CI enforces this.
+- **Every `.webp` heroImage needs a `.jpg` twin** at the same path — OG
+  scrapers can't handle WebP. CI enforces this too.
+- **`audioUrl` must be a full CDN URL** (`cdn.adrianwedd.com/…`), never a
+  local path. Audio is served from Cloudflare R2.
+
+## Commit style
+
+Conventional commits: `type(scope): message`. Common types: `feat`, `fix`,
+`content`, `docs`, `chore`, `ci`.
+
+## Pull request checklist
+
+See `.github/PULL_REQUEST_TEMPLATE.md` — it's pre-filled when you open a PR.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,32 @@
+MIT License — Code
+
+Copyright (c) 2026 Adrian Wedd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+Content copyright
+
+All written content, audio recordings, images, and other creative assets in
+`src/content/`, `public/`, and related directories are copyright © Adrian Wedd,
+all rights reserved. They are not covered by the MIT licence above.
+
+You are welcome to read the source for learning purposes; you may not reproduce
+or redistribute the content itself without permission.

--- a/README.md
+++ b/README.md
@@ -1,86 +1,122 @@
 # adrianwedd.com
 
-Personal website of Adrian Wedd. Astro 5 on GitHub Pages. Dark-first design with botanical earth-tone palette.
+[![Deploy](https://github.com/adrianwedd/adrianwedd.com/actions/workflows/deploy.yml/badge.svg)](https://github.com/adrianwedd/adrianwedd.com/actions/workflows/deploy.yml)
+[![Lighthouse CI](https://github.com/adrianwedd/adrianwedd.com/actions/workflows/lighthouse.yml/badge.svg)](https://github.com/adrianwedd/adrianwedd.com/actions/workflows/lighthouse.yml)
+[![Content Pipeline](https://github.com/adrianwedd/adrianwedd.com/actions/workflows/content-pipeline.yml/badge.svg)](https://github.com/adrianwedd/adrianwedd.com/actions/workflows/content-pipeline.yml)
+
+Personal website of Adrian Wedd. Astro 6 on GitHub Pages. Dark-first design with a botanical earth-tone palette — plum-tinted darks, dusty copper accent.
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Stack](#stack)
+- [Architecture](#architecture)
+  - [Theming](#theming)
+  - [View Transitions](#view-transitions)
+  - [Islands](#islands-13-preact-components)
+  - [Content Collections](#content-collections)
+  - [Permalink Strategy](#permalink-strategy)
+  - [Schema.org JSON-LD](#schemaorg-json-ld)
+  - [OG Image Dimensions](#og-image-dimensions)
+  - [Deployment Topology](#deployment-topology)
+- [Quality Gates](#quality-gates)
+- [Social Media Worker](#social-media-worker)
+- [NotebookLM Automation](#notebooklm-automation)
+- [CI/CD Pipeline](#cicd-pipeline)
+- [Scripts](#scripts)
+- [Key Patterns](#key-patterns)
+- [Design](#design)
+- [Documentation](#documentation)
 
 ## Quick Start
+
+**Prerequisites:** Node 22, npm.
 
 ```bash
 npm install
 npm run dev            # dev server at localhost:4321
 npm run build          # production build (Astro + Pagefind indexing)
 npm run preview        # preview production build
-npm run lint           # ESLint
+npm run check          # type check + lint + content validation
+npm run lint           # ESLint only
 npm run format         # Prettier (write)
 npm run format:check   # Prettier (check only)
+npm run test:worker    # social worker tests
+npm run test:csp       # CSP worker tests + typecheck
 ```
+
+The site builds without `src/data/base-cv.json` (CV data is synced from a private repo at deploy time; local dev falls back to defaults). See `.env.example` for the environment variables needed for GA4 and social posting.
+
+Content validation: `npm run validate` (required fields, descriptions ≤160 chars, heroImage paths).
 
 ## Stack
 
-| Layer              | Technology                                                           |
-| ------------------ | -------------------------------------------------------------------- |
-| **Framework**      | Astro 5 (fully static output), TypeScript strict                     |
-| **Styling**        | Tailwind CSS 3 with CSS custom properties for dark/light theming     |
-| **Islands**        | Preact for 13 interactive components                                 |
-| **Content**        | Astro Content Collections — blog, projects, gallery, audio           |
-| **Search**         | Pagefind (client-side WASM, indexed at build time)                   |
-| **Analytics**      | GA4 + LinkedIn Insight Tag, consent-gated via ConsentBanner          |
-| **Hosting**        | GitHub Pages via GitHub Actions                                      |
-| **DNS**            | Cloudflare                                                           |
-| **Media CDN**      | Cloudflare R2 at `cdn.adrianwedd.com` (audio + video)                |
-| **Enquiry system** | Ops worker at `ops.adrianwedd.com` → GitHub Issues → chat page       |
-| **Bot protection** | Cloudflare Turnstile on contact form                                 |
-| **Social**         | Cloudflare Worker at `social.adrianwedd.com` for Facebook automation |
+| Layer              | Technology                                                                   |
+| ------------------ | ---------------------------------------------------------------------------- |
+| **Framework**      | Astro 6, TypeScript strict, fully static output                              |
+| **Styling**        | Tailwind CSS 4 with CSS custom properties for dark/light theming             |
+| **Islands**        | Preact for 13 interactive components                                         |
+| **Content**        | Astro Content Collections — blog, projects, gallery, audio                   |
+| **Search**         | Pagefind (client-side WASM, indexed at build time)                           |
+| **Analytics**      | GA4 + LinkedIn Insight Tag, consent-gated                                    |
+| **Hosting**        | GitHub Pages via GitHub Actions                                              |
+| **DNS**            | Cloudflare                                                                   |
+| **Media CDN**      | Cloudflare R2 at `cdn.adrianwedd.com` (audio + video)                        |
+| **Social worker**  | Cloudflare Worker at `social.adrianwedd.com` — cross-platform social posting |
+| **CSP worker**     | Cloudflare Worker in `worker-csp/` — per-request nonce injection at the edge |
 
 ## Architecture
 
-### Theming (spans 3 files)
+### Theming
 
-CSS custom properties in `src/styles/global.css` (`:root` = dark, `.light` = light) drive all colours. Tailwind maps them via `tailwind.config.mjs` (e.g. `bg-surface`, `text-accent`). An inline script in `BaseLayout.astro` reads `localStorage('theme')` before paint to prevent flash.
+CSS custom properties in `src/styles/global.css` define all colours (`:root` = dark, `.light` = light). Tailwind 4 maps them via the `@theme` block in that same file — there is no `tailwind.config.mjs`. An inline script in `BaseLayout.astro` reads `localStorage('theme')` before paint to prevent flash.
 
-**Never use Tailwind's `dark:` prefix** — theming is driven by CSS custom properties, not Tailwind dark mode.
+**Never use Tailwind's `dark:` prefix** — theming is driven by CSS custom properties, not Tailwind dark mode classes.
 
 ### View Transitions
 
-All interactive scripts use `is:inline` with sentinel guards on `documentElement.dataset` to survive Astro View Transitions. Pattern:
+All interactive scripts follow this pattern to survive Astro View Transitions:
 
 - `is:inline` (not module `<script>`) so scripts re-execute on VT swap
 - Sentinel on `documentElement.dataset` to prevent duplicate global listeners
-- Event delegation on `document` since DOM elements get replaced
+- Event delegation on `document` since DOM elements get replaced on swap
 - Lazy DOM lookups via functions (not cached references)
-- `astro:after-swap` listener for re-initialising widgets (e.g. Turnstile)
+- `astro:after-swap` listener registered inside the sentinel guard
 
 ### Islands (13 Preact components)
 
 Client-hydrated interactive components in `src/components/islands/`:
 
-| Island             | Purpose                                         |
-| ------------------ | ----------------------------------------------- |
-| AudioPlayer        | Audio playback for blog/project audio overviews |
-| Personalisation    | Dynamic content personalisation                 |
-| Transparency       | AI transparency disclosures                     |
-| Flashcards         | Study cards from NotebookLM                     |
-| Quiz               | Quiz questions from NotebookLM                  |
-| MindMap            | Mind map diagrams                               |
-| DataTable          | Interactive data tables                         |
-| TableOfContents    | Scrolling ToC with active-section highlighting  |
-| ActivityDashboard  | GitHub activity visualisation                   |
-| GitHubActivity     | GitHub contribution data                        |
-| AnalyticsDashboard | GA4 analytics display                           |
-| ShareButton        | Social sharing                                  |
-| TerminalEasterEgg  | Hidden terminal emulator                        |
+| Island             | Purpose                                        |
+| ------------------ | ---------------------------------------------- |
+| AudioPlayer        | Audio playback for blog/project overviews      |
+| Personalisation    | Dynamic content personalisation                |
+| Transparency       | AI transparency disclosures                    |
+| Flashcards         | Study cards from NotebookLM                    |
+| Quiz               | Quiz questions from NotebookLM                 |
+| MindMap            | Mind map diagrams                              |
+| DataTable          | Interactive data tables                        |
+| TableOfContents    | Scrolling ToC with active-section highlighting |
+| ActivityDashboard  | GitHub activity visualisation                  |
+| GitHubActivity     | GitHub contribution data                       |
+| AnalyticsDashboard | GA4 analytics display                          |
+| ShareButton        | Social sharing                                 |
+| TerminalEasterEgg  | Hidden terminal emulator                       |
 
 All other components are Astro (server-rendered, zero JS).
 
 ### Content Collections
 
-Defined in `src/content.config.ts` with four collections:
+Defined in `src/content.config.ts`. The site currently has 79 blog posts, 35 projects, 102 audio episodes, and 7 gallery collections.
 
-| Collection   | Key fields                                                                                                                                                                                                               |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **blog**     | title, description, date, tags, draft, heroImage, `faq` (optional `[{q,a}]` → FAQ schema), `series`/`seriesOrder`, plus `notebookAssets` (audioUrl, videoUrl, infographic, mindmap, quiz, flashcards, dataTable, slides) |
-| **projects** | title, description, date, tags, status (`active\|complete\|archived\|experiment`), featured, url, repo, heroImage, `series`/`seriesOrder`, plus `notebookAssets`                                                         |
-| **gallery**  | title, date, tags, images array (`{src, alt, caption?}`), medium, collection, coverImage                                                                                                                                 |
-| **audio**    | title, description, date, tags, `audioUrl` (required), duration, transcript, heroImage, `relatedProject`, `relatedPost`                                                                                                  |
+| Collection   | Key fields                                                                                                                                                                                           |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **blog**     | title, description, date, tags, draft, heroImage, `faq` (optional `[{q,a}]` → FAQ schema), `series`/`seriesOrder`, plus optional media fields: `audioUrl`, `videoUrl`, `youtubeUrl`, `infographic`, `mindmap`, `quiz`, `flashcards`, `dataTable`, `slides` |
+| **projects** | title, description, date, tags, status (`active\|complete\|archived\|experiment`), featured, url, repo, heroImage, `series`/`seriesOrder`, plus the same optional media fields as blog                |
+| **gallery**  | title, date, tags, images array (`{src, alt, caption?}`), medium, collection, coverImage                                                                                                             |
+| **audio**    | title, description, date, tags, `audioUrl` or `videoUrl` (one required by validation), `duration`, transcript, heroImage, `relatedProject`, `relatedPost`                                           |
+
+The media fields (`audioUrl`, `videoUrl`, `youtubeUrl`, `infographic`, etc.) are defined as a shared Zod object spread directly into each schema — they appear as top-level frontmatter fields, not as a nested object.
 
 ### Permalink Strategy
 
@@ -91,7 +127,7 @@ URLs are permanent. Once published, a page's URL must not change.
 - **Gallery:** `/gallery/{slug}/`, images at `/gallery/{collection}/{image-slug}/`
 - **Audio:** `/audio/{slug}/`
 
-`updatedDate` in frontmatter tracks content revisions without changing URLs.
+`updatedDate` in frontmatter tracks content revisions without changing URLs. Slug is derived from filename, always stripped of the `.md` extension via `slug()` from `src/lib/utils.ts`.
 
 ### Schema.org JSON-LD
 
@@ -101,45 +137,79 @@ URLs are permanent. Once published, a page's URL must not change.
 - `services.astro` — ProfessionalService
 - `Breadcrumb.astro` — BreadcrumbList on all detail pages
 
-## Enquiry System
+### OG Image Dimensions
 
-The contact form at `/contact` creates tracked enquiry tickets via the ops worker:
+`og:image:width`/`og:image:height` are read from the actual file at build time via `src/lib/image-dimensions.ts` — a 256 KB header parser for PNG/JPEG/WebP/GIF. Every `.webp` heroImage also needs a `.jpg` twin at the same path; the OG twin CI gate enforces this.
 
+### Deployment Topology
+
+```mermaid
+graph LR
+    subgraph Build
+        GH[GitHub Actions] -->|astro build| Pages[GitHub Pages]
+        GH -->|cv sync| CV[(adrianwedd/cv)]
+        GH -->|fetch| GA4[(GA4 API)]
+    end
+
+    subgraph Edge ["Cloudflare Edge"]
+        DNS[Cloudflare DNS] --> CSP[worker-csp\nnonce injection]
+        CSP --> Pages
+        DNS --> R2[R2 CDN\naudio · video]
+        DNS --> Social[worker\nsocial.adrianwedd.com]
+    end
+
+    Browser --> DNS
+    Social -->|publish| FB[Facebook]
+    Social -->|publish| BS[Bluesky]
+    Social -->|publish| TW[X/Twitter]
+    Social -->|publish| IG[Instagram]
 ```
-Contact form (Turnstile-gated)
-  → POST ops.adrianwedd.com/api/enquiry (Turnstile + origin validation)
-    → Creates GitHub Issue in adrianwedd/adrianwedd.com
-    → Returns read_token + write_token
-  → Redirect to /enquiry/?t=read_token
-    → Chat page polls ops worker for replies
-    → User can reply (write_token auth)
-```
 
-The ops worker (`adrianwedd/adrianwedd-ops` at `ops.adrianwedd.com`) handles:
+## Quality Gates
 
-- Turnstile verification
-- GitHub Issue creation via GitHub App installation token
-- Conversation token management (30-day KV TTL)
-- Email notification to client
-- Comment classification (AI-powered via Claude) for auto-reply and crisis detection
+Every PR and deploy passes the full suite:
 
-Turnstile widget re-renders on View Transition navigation via explicit `turnstile.render()` in the `astro:after-swap` handler.
+| Gate | Command | Notes |
+|------|---------|-------|
+| Type check | `npx astro check` | Strict TypeScript across all `.astro` and `.ts` files |
+| Lint | `npm run lint` | ESLint with Astro + TypeScript rules |
+| Content validation | `npm run validate` | Required fields, descriptions ≤160 chars, heroImage paths |
+| Build | `npm run build` | Astro + Pagefind indexing must succeed cleanly |
+| Image policy | CI gate | No raw `<img>` on local paths — must use `<Picture>` from `astro:assets` |
+| OG twins | CI gate | Every `.webp` heroImage must have a `.jpg` twin |
+| Build size budget | CI gate | `dist/_astro/` ≤ 100MB; warns on JS chunks >150KB |
+| Internal links | `npm run check:links` | Scans built HTML for same-origin 404s |
+| External links | Lychee | Config in `.lychee.toml` |
+| Lighthouse | `lighthouse.yml` | 90% threshold on 7 pages (PR-only) |
+| Worker tests | `npm run test:worker` | Vitest with per-platform mock registry |
+| CSP worker | `npm run test:csp` | Tests + `tsc --noEmit` |
+
+Run `npm run check` locally to cover the first three in one step.
 
 ## Social Media Worker
 
 Cloudflare Worker (`worker/`) at `social.adrianwedd.com` manages cross-platform social posting.
 
+**Platforms:** Facebook, Instagram, Bluesky, X/Twitter.
+
 **Features:**
 
-- Auto-publish new blog posts and projects on push to `main`
-- Multi-platform: Facebook, Instagram, Bluesky, X/Twitter
+- Content pushes to `main` sync the date-scheduled queue; posts broadcast when their frontmatter `date` arrives (not immediately on merge)
 - Scheduled and ad-hoc post queue (JSON seed in `social/`, KV for state)
 - Comment monitoring with crisis detection, classification, and auto-reply
 - Backdated posting to match original publication dates
-- Idempotency via commit-SHA-based keys (force-retry via `forceRetry: true` for failed records)
+- Idempotency via stable keys (`forceRetry: true` bypasses failed records but never published ones)
 - Atomic cron locking via Durable Object (`CronLock`) with fencing tokens — prevents concurrent cron tick races
 
-**CLI:**
+**Worker endpoints:**
+
+- `POST /api/publish` — immediate publish (`platform` ∈ `facebook|instagram|bluesky|twitter`). Returns `409` if another publish for the same `idempotencyKey` is in flight.
+- `POST /api/queue` + `POST /api/queue/sync` — scheduled queue
+- `POST /api/cron/publish` — hourly publish from queue (DO-locked)
+- `POST /api/cron/comments` — comment monitor, 2-hourly (DO-locked)
+- `GET /api/health` — token health and queue status
+
+**Social CLI:**
 
 ```bash
 scripts/fb-post.sh "Post text"                          # immediate post
@@ -150,16 +220,6 @@ scripts/fb-post.sh --health                             # token + queue status
 scripts/fb-post.sh --sync                               # sync queue JSON to KV
 ```
 
-**Worker endpoints:**
-
-- `POST /api/publish` — immediate publish on the platform named in the request body (`platform` ∈ `facebook|instagram|bluesky|twitter`). `forceRetry: true` retries a `failed` idempotency entry. Returns `409` if another publish for the same `idempotencyKey` is already in flight.
-- `POST /api/queue` + `POST /api/queue/sync` — scheduled queue
-- `POST /api/cron/publish` — hourly publish from queue (DO-locked)
-- `POST /api/cron/comments` — comment monitor, 2-hourly (DO-locked)
-- `GET /api/health` — token health and queue status
-
-Worker tests: `cd worker && npm test`. Local validation: `cd worker && npx wrangler deploy --dry-run`.
-
 ## NotebookLM Automation
 
 Automated generation of audio overviews, video summaries, infographics, and other Studio assets for blog and project pages. Scripts in `scripts/notebooklm/`.
@@ -168,7 +228,7 @@ Automated generation of audio overviews, video summaries, infographics, and othe
 
 ```bash
 cd scripts/notebooklm
-nlm login                                                    # authenticate (one-time)
+nlm login                                                       # authenticate (one-time)
 ./scripts/automate-notebook.sh --config config.json --parallel  # generate assets
 ```
 
@@ -177,7 +237,7 @@ nlm login                                                    # authenticate (one
 **Media pipeline:**
 
 1. Generate assets via NotebookLM
-2. Compress audio to 64kbps mono MP3
+2. Copy audio as-is — **never transcode or compress** (NLM delivers 256kbps stereo AAC; serve it at original quality)
 3. Upload audio + video to R2 (`cdn.adrianwedd.com`)
 4. Keep infographics in `public/notebook-assets/` (committed to git)
 5. Update frontmatter with CDN URLs (audio/video) and local paths (infographic)
@@ -190,39 +250,45 @@ See `docs/NOTEBOOKLM_PIPELINE.md` for the full pipeline reference.
 
 ### Deploy (`deploy.yml`) — triggers on push to `main`
 
-1. `npm ci` → validate content → audit deps → fetch GA4 analytics
-2. Checkout CV data from `adrianwedd/cv` repo → copy to `src/data/base-cv.json`
-3. `npm run build` (Astro + Pagefind)
-4. Build size budget: `dist/_astro/` ≤ 100MB; warn on JS chunks > 150KB
-5. Enforce no raw `<img>` on local paths (must use `<Picture>` from `astro:assets`)
-6. Lychee link check (`dist/**/*.html`) — config in `.lychee.toml`
-7. Upload pages artifact + deploy to GitHub Pages
+1. `npm ci` → `npx astro check` → lint → validate content → audit deps → fetch GA4 analytics
+2. Checkout CV data from `adrianwedd/cv` → copy to `src/data/base-cv.json`
+3. `npm run build` (Astro + OG image generation + Pagefind)
+4. Enforce no raw `<img>` on local paths
+5. Enforce `.jpg` OG twin for every `.webp` heroImage
+6. Build size budget check (`dist/_astro/` ≤ 100MB; warn on JS chunks >150KB)
+7. `scripts/test-site.sh` — smoke tests on built output
+8. Lychee external link check — config in `.lychee.toml`
+9. Internal-link check (`npm run check:links`)
+10. Upload pages artifact + deploy to GitHub Pages
+11. **Parallel job:** `worker-csp` — `npm test` + `tsc --noEmit`
 
 ### Other Workflows
 
-| Workflow                 | Trigger                            | Purpose                                             |
-| ------------------------ | ---------------------------------- | --------------------------------------------------- |
-| `lighthouse.yml`         | PR checks                          | Lighthouse on 7 pages (90% thresholds)              |
-| `social-autopublish.yml` | Push to main                       | Detect new content, post to Facebook (skips drafts) |
-| `social-cron.yml`        | Hourly + 2-hourly                  | Publish from queue + comment monitor                |
-| `content-pipeline.yml`   | Weekly (Sunday 22:00 UTC) + manual | Discover academic papers, create draft blog PRs     |
+| Workflow                 | Trigger                   | Purpose                                                       |
+| ------------------------ | ------------------------- | ------------------------------------------------------------- |
+| `lighthouse.yml`         | PR checks                 | Lighthouse on 7 pages (90% thresholds) + `astro check`       |
+| `social-autopublish.yml` | Push to `main`            | Sync date-scheduled queue to KV; worker cron fires on `date`  |
+| `social-cron.yml`        | Hourly + 2-hourly         | Publish from queue + comment monitor                          |
+| `content-pipeline.yml`   | Weekly (Sunday 22:00 UTC) | Discover academic papers, create draft blog PRs               |
 
 ## Scripts
 
 ### Content Authoring
 
-- `scripts/new-post.sh "Title"` — scaffold blog post
-- `scripts/new-project.sh "Title"` — scaffold project page
-- `scripts/import-gallery.sh dir/` — import image directory as gallery
-- `scripts/import-audio.sh file.mp3` — import audio episode
+```bash
+scripts/new-post.sh "Title"       # scaffold blog post
+scripts/new-project.sh "Title"    # scaffold project page
+scripts/import-gallery.sh dir/    # import image directory as gallery
+scripts/import-audio.sh file.mp3  # import audio episode
+```
 
 ### Validation & Generation
 
-- `scripts/validate-content.js` — check required fields, description ≤ 160 chars, heroImage paths
-- `scripts/generate-og-images.mjs` — generate 1200×630 OG PNGs from frontmatter (skips drafts/existing)
-- `scripts/fetch-ga4-data.mjs` — pull analytics from GA4 service account
+- `scripts/validate-content.js` — required fields, descriptions ≤160 chars, heroImage paths
+- `scripts/generate-og-images.mjs` — 1200×630 OG PNGs for posts without a heroImage (skips existing)
+- `scripts/fetch-ga4-data.mjs` — pull analytics from GA4 service account (CI step)
 - `scripts/extract-frontmatter.mjs` — extract YAML frontmatter as JSON (used by autopublish)
-- `scripts/validate-schema.mjs` — validate structured data
+- `scripts/check-internal-links.mjs` — scan built HTML for same-origin 404s
 
 ### Media & CDN
 
@@ -232,28 +298,26 @@ See `docs/NOTEBOOKLM_PIPELINE.md` for the full pipeline reference.
 
 ### NotebookLM
 
-- `scripts/generate-all-notebook-assets.sh` — batch audio generation
+- `scripts/generate-all-notebook-assets.sh` — batch audio generation for all projects
 - `scripts/generate-all-infographics.sh` — batch infographic generation
 - `scripts/retry-failed-infographics.sh` — retry after rate limits
-- `scripts/regenerate-branded-infographics.sh` — regenerate with consistent branding
-
-### Social
-
-- `scripts/fb-post.sh` — CLI for Facebook posting (immediate, scheduled, backdated)
+- `scripts/regenerate-branded-infographics.sh` — regenerate with consistent branded style
 
 ## Key Patterns
 
-- **Slug utility:** Collection IDs include `.md` extension. Always strip with `slug()` from `src/lib/utils.ts`
+- **Slug utility:** Collection IDs include `.md` extension — always strip with `slug()` from `src/lib/utils.ts`
+- **OG twins:** Every `.webp` heroImage needs a `.jpg` twin at the same path — CI enforces this
 - **No custom fonts:** System font stack only — zero font downloads
-- **Consent-first:** No tracking before user consent. `dns-prefetch` (not `preconnect`) for GA4 origins
-- **Images:** Use `<Picture>` from `astro:assets` for all local images (CI gate enforces this)
-- **CV sync:** `src/data/cv.ts` reads `src/data/base-cv.json` (gitignored, synced from `adrianwedd/cv` at build time)
-- **Class-based selectors:** ThemeToggle and Header use class selectors (not IDs) to avoid duplicate ID issues across desktop/mobile nav
+- **Consent-first:** No tracking before user consent. Use `dns-prefetch` (not `preconnect`) for GA4 origins
+- **Images:** Use `<Picture>` from `astro:assets` for all local images — CI gate enforces this
+- **CV sync:** `src/data/base-cv.json` is gitignored, synced from `adrianwedd/cv` at build time; local dev falls back to defaults
+- **Class-based selectors:** ThemeToggle and Header use class selectors (not IDs) to avoid duplicate ID bugs across desktop/mobile nav
+- **Audio quality:** Never compress or re-encode published audio — serve original-quality `.m4a` at the CDN URL
 
 ## Design
 
-- Botanical earth-tone palette: plum-tinted darks, dusty copper accent, mauve-gray muted
-- Light mode: warm cream backgrounds with umber accent (`#8a5e42`)
+- Botanical earth-tone palette: plum-tinted darks, dusty copper accent (`#c48b6e`), mauve-gray muted tones
+- Light mode: warm cream backgrounds, umber accent (`#8a5e42` for WCAG AA)
 - System fonts only — zero font downloads
 - WCAG 2.1 AA compliant
 - Consent-first: no tracking before user consent
@@ -263,25 +327,23 @@ See `docs/NOTEBOOKLM_PIPELINE.md` for the full pipeline reference.
 ## Documentation
 
 - `CLAUDE.md` — AI agent instructions and full codebase reference
+- `CHANGELOG.md` — narrative project changelog
+- `CONTRIBUTING.md` — setup, conventions, PR checklist
+- `SECURITY.md` — responsible disclosure policy
+- `docs/NOTEBOOKLM_PIPELINE.md` — NotebookLM content pipeline reference
 - `docs/PROJECT_SPEC.md` — Technical specification
 - `docs/DESIGN_CHARTER.md` — Design charter
-- `docs/NOTEBOOKLM_PIPELINE.md` — NotebookLM content pipeline reference
 - `docs/ROADMAP.md` — Feature roadmap
-- `docs/IMPLEMENTATION_PLAN.md` — Implementation plan
-- `docs/superpowers/specs/` — Feature design specs
-- `docs/superpowers/plans/` — Implementation plans
-- `docs/UAT_PROMPT.md` — User acceptance testing prompts
-- `docs/UAT_REPORT_CODEX.md` + `UAT_REPORT_GEMINI.md` — QA reports from multi-engine review
-- `docs/COMPLIANCE_REPORT.md` — Compliance review report
 
 ## QA Tools
 
-Three-way QA with Codex, Gemini, and Claude agent in parallel:
+Three-way QA with Codex, Agy, and Hermes in parallel:
 
 ```bash
 codex exec --full-auto "QA prompt" 2>&1 | tee /tmp/codex-qa.txt &
-gemini -p "QA prompt" --yolo 2>&1 | tee /tmp/gemini-qa.txt &
+agy -p "QA prompt" --dangerously-skip-permissions 2>&1 | tee /tmp/agy-qa.txt &
+hermes chat -q "QA prompt" -Q 2>&1 | tee /tmp/hermes-qa.txt &
 wait
 ```
 
-Each engine catches different things: Codex is strongest on security + correctness, Gemini on design + accessibility, Claude on architecture + spec compliance.
+Codex is strongest on security + correctness. Agy on design + accessibility. Hermes on research + cross-referencing.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Scope
+
+This repository contains:
+
+- A static Astro site deployed to GitHub Pages
+- A Cloudflare Worker (`worker/`) handling social media publishing
+- A Cloudflare Worker (`worker-csp/`) injecting CSP nonces at the edge
+- GitHub Actions workflows for CI/CD and content automation
+
+All three surfaces are in scope for responsible disclosure.
+
+## Reporting a vulnerability
+
+Email **adrian@adrianwedd.com** with:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept
+- Whether you believe it is already being actively exploited
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+I will acknowledge your report within 72 hours and aim to provide a fix or
+mitigation within 14 days for critical issues.
+
+## Out of scope
+
+- Theoretical vulnerabilities with no practical exploitability
+- Issues requiring physical access to a device
+- Social-engineering attacks against me or my infrastructure providers
+
+## Please do not
+
+- Test against the live production endpoints (`social.adrianwedd.com`,
+  `adrianwedd.com`) without prior written permission — the social worker
+  handles real Facebook/Instagram/Bluesky/X tokens and a test run could
+  trigger real posts or exhaust idempotency records
+- Attempt to access, exfiltrate, or modify data in Cloudflare KV, D1, or R2
+- Attempt to bypass Cloudflare Access or Turnstile on production

--- a/package.json
+++ b/package.json
@@ -11,7 +11,12 @@
     "check:links": "node scripts/check-internal-links.mjs",
     "lint": "eslint .",
     "format": "prettier --write 'src/**/*.{astro,ts,tsx,css,md,mdx}'",
-    "format:check": "prettier --check 'src/**/*.{astro,ts,tsx,css,md,mdx}'"
+    "format:check": "prettier --check 'src/**/*.{astro,ts,tsx,css,md,mdx}'",
+    "typecheck": "astro check",
+    "validate": "node scripts/validate-content.js",
+    "check": "astro check && eslint . && node scripts/validate-content.js",
+    "test:worker": "cd worker && npm test",
+    "test:csp": "cd worker-csp && npm test && npx tsc --noEmit"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.9",

--- a/worker/src/__tests__/publish.test.ts
+++ b/worker/src/__tests__/publish.test.ts
@@ -11,6 +11,7 @@ import type { SocialPost, AuthStatus } from '../platforms/types';
 
 interface PlatformMocks {
   publishPost: ReturnType<typeof vi.fn>;
+  replyToComment: ReturnType<typeof vi.fn>;
   debugAuth: ReturnType<typeof vi.fn>;
   getPageIdentity: ReturnType<typeof vi.fn>;
 }
@@ -23,6 +24,7 @@ function getPlatformMocks(platform: string): PlatformMocks {
   if (!mocks) {
     mocks = {
       publishPost: vi.fn(),
+      replyToComment: vi.fn(),
       debugAuth: vi.fn(),
       getPageIdentity: vi.fn().mockReturnValue(`${platform}_identity`),
     };
@@ -44,7 +46,7 @@ vi.mock('../platforms/factory', () => ({
       listRecentPosts: vi.fn().mockResolvedValue([]),
       getComments: vi.fn().mockResolvedValue([]),
       getCommentReplies: vi.fn().mockResolvedValue([]),
-      replyToComment: vi.fn(),
+      replyToComment: m.replyToComment,
       getPageIdentity: m.getPageIdentity,
       debugAuth: m.debugAuth,
     };
@@ -666,6 +668,31 @@ describe('POST /api/publish forceRetry', () => {
     const newRecord = JSON.parse(kv.store.get('idempotent:key-2')!);
     expect(newRecord.status).toBe('published');
     expect(newRecord.platformPostId).toBe('fb_retry_ok');
+  });
+
+  it('routes to replyToComment when replyTo is provided', async () => {
+    const kv = mockKV();
+    setConfiguredPlatforms(['bluesky']);
+    const blueskyMocks = getPlatformMocks('bluesky');
+    blueskyMocks.replyToComment.mockResolvedValueOnce({
+      success: true, platformPostId: 'bsky_reply_1', isTransient: false, isAuthError: false,
+    });
+
+    const res = await app.fetch(
+      publishRequest({
+        platform: 'bluesky', type: 'text', message: 'A reply text',
+        idempotencyKey: 'reply-1', replyTo: 'at://did:plc:abc/app.bsky.feed.post/xyz',
+      }),
+      makeEnv(kv),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.published).toBe(true);
+    expect(body.platformPostId).toBe('bsky_reply_1');
+    expect(blueskyMocks.replyToComment).toHaveBeenCalledWith(
+      'at://did:plc:abc/app.bsky.feed.post/xyz', 'A reply text',
+    );
+    expect(blueskyMocks.publishPost).not.toHaveBeenCalled();
   });
 
   it('publishes via the platform named in the request body, not the default', async () => {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -81,6 +81,7 @@ app.post('/api/publish', async (c) => {
     backdatedTime?: string;
     idempotencyKey: string;
     forceRetry?: boolean;
+    replyTo?: string;
   }>();
 
   const platform = validatePlatform(body.platform);
@@ -144,7 +145,9 @@ app.post('/api/publish', async (c) => {
       error: null,
     };
 
-    const result = await adapter.publishPost(post);
+    const result = body.replyTo
+      ? await adapter.replyToComment(body.replyTo, body.message)
+      : await adapter.publishPost(post);
 
     // Write durable idempotency record. H5: failed records carry a shorter
     // (7d) TTL than published (30d) so a misclassified transient error


### PR DESCRIPTION
## Summary

Repo documentation and governance package from the multi-engine QA session (Codex + Agy + Hermes findings all implemented and re-verified).

### README.md — 10 accuracy and presentation fixes
- CI status badges (Deploy, Lighthouse CI, Content Pipeline)
- Table of Contents, Node 22 prerequisite in Quick Start
- Content Collections table corrected — `notebookAssets` fields are flat (top-level), not nested; `youtubeUrl` added; stale `audioDuration` note removed; audio `audioUrl` requirement corrected to "required or videoUrl"
- Social autopublish description updated to the date-triggered model
- CI/CD pipeline list now matches deploy.yml (astro check, .jpg twin gate, worker-csp job, test-site.sh)
- Quality Gates table + Deployment Topology Mermaid diagram

### CHANGELOG.md
- Out-of-order "26–29 May" section merged into the correct 26–30 May entry
- Added / Fixed / Changed bullet summaries under every entry heading

### New governance files
- `LICENSE` — MIT for code, copyright reserved for content
- `SECURITY.md` — disclosure contact, scope, no-test-production note
- `CONTRIBUTING.md` — setup, pre-PR checklist, content conventions
- `.env.example` — all env vars documented (GA4, social platforms, CV sync)
- `.github/PULL_REQUEST_TEMPLATE.md` + issue templates (bug report, content fix, security contact)

### Config
- `dependabot.yml` — npm entries added for `worker/` and `worker-csp/`
- `package.json` — `typecheck`, `validate`, `check`, `test:worker`, `test:csp` scripts

## Test plan
- [ ] CI deploy workflow green (docs-only + config changes; no content or runtime code touched)
- [ ] Badges render on the repo landing page
- [ ] Issue/PR templates appear in the GitHub UI

## Also included

- `cce5eb0` **feat(worker): add replyTo support to POST /api/publish** — pre-existing local commit on main that had never been pushed; it rode along when this branch was cut. Complete with tests (`worker/src/__tests__/publish.test.ts`). If you'd rather land it separately, say so and I'll split it out.
