### PR TITLE
fix(ux): stabilize 3 verified P0 issues (A2, A4, B1)

### DIFF
--- a/src/components/RelatedContent.astro
+++ b/src/components/RelatedContent.astro
@@ -68,6 +68,18 @@ const allItems: ContentItem[] = [
       href: `/gallery/${slug(p.id)}/`,
       score: 0,
     })),
+  ...audios
+    .filter((p) => !p.data.draft)
+    .map((p) => ({
+      id: `audio:${p.id}`,
+      type: 'audio' as const,
+      title: p.data.title,
+      description: p.data.description,
+      tags: p.data.tags,
+      date: p.data.date,
+      href: `/audio/${slug(p.id)}/`,
+      score: 0,
+    })),
 ];
 
 // Build tag frequency map for IDF-style weighting (rare tags score higher)

--- a/src/components/islands/AnalyticsDashboard.tsx
+++ b/src/components/islands/AnalyticsDashboard.tsx
@@ -131,7 +131,7 @@ export default function AnalyticsDashboard() {
                   {project.views.toLocaleString()} views · {project.clicks.toLocaleString()} clicks
                 </div>
               </div>
-              <div class="text-2xl font-bold text-accent">{((project.clicks / project.views) * 100).toFixed(1)}%</div>
+              <div class="text-2xl font-bold text-accent">{project.views > 0 ? `${((project.clicks / project.views) * 100).toFixed(1)}%` : '—'}</div>
             </div>
           ))}
         </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -66,6 +66,8 @@ const props = Astro.props;
         }
       })();
     </script>
+    {/* No-JS fallback: ScrollReveal content is opacity:0 until JS reveals it; show it when JS is unavailable */}
+    <noscript set:html={`<style>.scroll-reveal{opacity:1!important;transform:none!important}</style>`}></noscript>
     <ClientRouter />
   </head>
   <body class="flex min-h-screen flex-col">


### PR DESCRIPTION
First execution slice of the UX theme (#472) — the "broken right now" P0 items, **after verifying each** against the actual code/browser.

## Fixed
- **A2** — AnalyticsDashboard CTR divide-by-zero. `clicks/views` rendered `NaN%`/`Infinity%` when `views===0`; now shows `—`. *(AnalyticsDashboard.tsx)*
- **A4** — RelatedContent dropped the entire audio collection. `getCollection('audio')` was fetched but never spread into `allItems`, so audio episodes could never surface as related content. Added the spread (scoring/dedup/`typeLabels.audio`/render were all already type-agnostic). Verified: the "Audio" label now renders in a built related-content block.
- **B1** — ScrollReveal no-JS fallback. Base state is `opacity:0`, revealed by JS; there was no `<noscript>` fallback, so JS failure left wrapped content permanently invisible. Added a `<noscript>` style (via `set:html` so Astro doesn't hoist it) that resets `.scroll-reveal` to visible.

## Verified, NOT a bug — A1 (filter active-state)
The audit's #1 P0 — `classList.toggle('bg-accent/10', match)` allegedly throwing `InvalidCharacterError` and aborting before `aria-pressed` — is a **false positive**. Tested in a real browser (Playwright) on the live `/projects/`:
- `classList.toggle('bg-accent/10', true)` → **no throw** (`DOMTokenList` only rejects whitespace/empty tokens, not `/`)
- clicking the "Active" filter flips `aria-pressed` `false`→`true` and applies `bg-accent/10` + `text-accent` correctly

No change made; A1 will be struck from #472.

## Verification
`npm run build` → green; noscript style confirmed in `dist/index.html`; Audio label confirmed in `dist/blog/architectural-safety/`.

Refs #472.