### PR TITLE
chore(email): add MTA-STS policy worker for adrianwedd.com

### DIFF
--- a/worker-mta-sts/index.js
+++ b/worker-mta-sts/index.js
@@ -1,0 +1,35 @@
+/**
+ * MTA-STS policy host for adrianwedd.com
+ * Serves the policy at https://mta-sts.adrianwedd.com/.well-known/mta-sts.txt
+ *
+ * Mode is "testing": receivers report TLS failures (via TLS-RPT) but do NOT
+ * block mail. Once TLS-RPT reports confirm clean delivery, switch mode to
+ * "enforce" below AND bump the `id` in the _mta-sts.adrianwedd.com TXT record
+ * (e.g. the date) so receivers re-fetch the policy.
+ *
+ * MX list mirrors the live Google Workspace MX for adrianwedd.com exactly.
+ */
+const POLICY = `version: STSv1
+mode: testing
+mx: aspmx.l.google.com
+mx: alt1.aspmx.l.google.com
+mx: alt2.aspmx.l.google.com
+mx: aspmx2.googlemail.com
+mx: aspmx3.googlemail.com
+max_age: 604800
+`;
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    if (url.pathname === '/.well-known/mta-sts.txt') {
+      return new Response(POLICY, {
+        headers: {
+          'content-type': 'text/plain; charset=utf-8',
+          'cache-control': 'public, max-age=3600',
+        },
+      });
+    }
+    return new Response('Not found', { status: 404 });
+  },
+};

--- a/worker-mta-sts/wrangler.toml
+++ b/worker-mta-sts/wrangler.toml
@@ -1,0 +1,10 @@
+name = "adrianwedd-mta-sts"
+main = "index.js"
+compatibility_date = "2025-01-01"
+workers_dev = false
+
+# Custom domain — wrangler auto-creates the DNS record + edge cert for the
+# mta-sts hostname. MTA-STS requires the policy at https://mta-sts.<domain>/.
+[[routes]]
+pattern = "mta-sts.adrianwedd.com"
+custom_domain = true


### PR DESCRIPTION
## Summary

Adds a tiny Cloudflare Worker that hosts the MTA-STS policy for `adrianwedd.com` at `https://mta-sts.adrianwedd.com/.well-known/mta-sts.txt`. This is the policy-host half of the MTA-STS deployment (the `_mta-sts` and `mta-sts` DNS records are already live).

MTA-STS lets sending mail servers discover that `adrianwedd.com` requires TLS for inbound mail, closing the STARTTLS-stripping downgrade window.

## What's in here

- `worker-mta-sts/index.js` — serves the static policy; 404s everything else.
- `worker-mta-sts/wrangler.toml` — custom-domain route on `mta-sts.adrianwedd.com` (wrangler auto-provisions the DNS record + edge cert).

## Policy

- `mode: testing` — receivers report TLS failures via TLS-RPT but do **not** block mail yet. Flip to `enforce` (and bump the `id` in the `_mta-sts` TXT record) once TLS-RPT reports confirm clean delivery.
- `mx:` list mirrors the live Google Workspace MX for the domain.
- `max_age: 604800` (7 days).

## Deploy

Not auto-deployed by CI — deploy manually with `cd worker-mta-sts && npx wrangler deploy` after merge.