### PR TITLE
fix(blog): correct stale GLI event count (59 → over 160)

### DIFF
--- a/src/content/blog/alignment-regression-post.md
+++ b/src/content/blog/alignment-regression-post.md
@@ -61,7 +61,7 @@ Previous jailbreak research required human expertise. An attacker needed to unde
 
 Autonomous jailbreak agents eliminate that constraint. The attack surface now scales with compute, not human expertise. One reasoning model can run thousands of jailbreak attempts per hour. A fleet of reasoning models can systematically probe every accessible AI system simultaneously.
 
-Our Governance Lag Index tracks 59 events where AI attack capabilities emerged before governance responses. The autonomous jailbreak capability (GLI-052 in our dataset) has zero governance response at any level — no framework, no legislation, no enforcement mechanism. No jurisdiction has addressed the scenario of reasoning models being weaponised as autonomous jailbreak agents.
+Our Governance Lag Index tracks over 160 events where AI attack capabilities emerged before governance responses. The autonomous jailbreak capability (GLI-052 in our dataset) has zero governance response at any level — no framework, no legislation, no enforcement mechanism. No jurisdiction has addressed the scenario of reasoning models being weaponised as autonomous jailbreak agents.
 
 ## What defence looks like
 


### PR DESCRIPTION
The alignment-regression post's Governance Lag Index reference still reads **59 events** on the live site. The dataset now holds 170.

Using **"over 160 events"** rather than a hardcoded `170`: a durable lower bound that stays true as the dataset grows and won't go stale on a dated post.

One line changed; `GLI-052` reference and the 97.14% figures are untouched (verified consistent with the dataset). No edits to the EchoLeak/`gli_002` `t_doc` question — that's failure-first's call.