### PR TITLE
fix(blog): tighten alignment-regression accuracy (multi-engine QA)

### DIFF
--- a/src/content/blog/alignment-regression-post.md
+++ b/src/content/blog/alignment-regression-post.md
@@ -17,11 +17,11 @@ A peer-reviewed study just published in Nature Communications empirically demoli
 
 ## What the study found
 
-Researchers gave four large reasoning models — DeepSeek-R1, Gemini 2.5 Flash, Grok 3 Mini, and Qwen3 235B — a single instruction: jailbreak these target AI systems. No further guidance. No human in the loop. No model-specific attack strategies provided.
+Researchers gave four large reasoning models — DeepSeek-R1, Gemini 2.5 Flash, Grok 3 Mini, and Qwen3 235B — one instruction via system prompt: jailbreak these target AI systems. No human in the loop, no model-specific playbooks, no supervision once they began. The system prompt outlined general persuasion tactics; the planning and execution were left to the models.
 
-The reasoning models planned their own attack strategies. Chose their own manipulation tactics. Ran multi-turn conversations with nine target models. Adapted when targets pushed back. And broke through safety guardrails **97.14% of the time** across 25,200 test inputs.
+The reasoning models planned their own attack strategies. Sequenced and adapted those tactics. Ran multi-turn conversations with nine target models. Adapted when targets pushed back. And broke through safety guardrails with an overall attack success rate of **97.14%** — across the four adversaries and nine targets, only two prompts in the 70-item harmful-behaviour benchmark resisted every attack.
 
-Five persuasive techniques emerged autonomously:
+Five persuasive techniques dominated the transcripts:
 
 1. Multi-turn dialogue to build rapport and erode resistance
 2. Gradual escalation of request severity
@@ -35,7 +35,7 @@ No human expert could match this at scale. The reasoning models operated continu
 
 The authors name what they observe: **alignment regression**. The dynamic is this — each successive generation of more capable models paradoxically erodes rather than strengthens the safety alignment of the broader ecosystem. Advanced reasoning abilities can be repurposed to undermine the safety mechanisms of earlier, less capable models.
 
-This is not a hypothetical. The data shows it directly. The more capable the reasoning model, the more effectively it jailbreaks other systems. The very capabilities that make these models useful — strategic planning, multi-step reasoning, persuasive communication, adaptive behaviour — are exactly the capabilities required for effective adversarial attacks.
+This is not a hypothetical. The data shows it directly: the very capabilities that make these models useful — strategic planning, multi-step reasoning, persuasive communication, adaptive behaviour — are exactly the capabilities required for effective adversarial attacks. (The relationship isn't perfectly monotonic — Qwen3 235B underperformed its scale as an adversary — but the coupling between reasoning capability and attack effectiveness is clear.)
 
 The implication: **safety alignment of individual models is necessary but insufficient for ecosystem safety.** A model that is robustly aligned in isolation becomes vulnerable when a more capable model is specifically tasked with attacking it.
 
@@ -45,7 +45,7 @@ My research at Failure-First focuses on embodied AI — robots, autonomous vehic
 
 If a reasoning model is given access to a VLA (Vision-Language-Action) control interface — through MCP tool-calling, API access, or any other connection — it could autonomously jailbreak the VLA's safety constraints and issue harmful action commands. The 97.14% success rate was measured against text-only AI systems. VLA safety constraints are, if anything, less mature than text-only safety alignment.
 
-The attack chain is straightforward:
+The hypothesised attack chain is straightforward:
 
 1. Reasoning model receives a goal (legitimate or adversarial)
 2. Reasoning model identifies that a VLA-controlled robot has safety constraints blocking the goal
@@ -53,7 +53,7 @@ The attack chain is straightforward:
 4. VLA safety constraints are bypassed
 5. Harmful physical action is executed
 
-No step in this chain requires human adversarial expertise. No step requires special access beyond what agentic AI systems are being designed to have. The autonomous jailbreak capability documented in this study is exactly the capability that agentic AI architectures are optimising for — the ability to plan, reason, and adapt to achieve goals across multiple interactions.
+This chain is an extrapolation, not a finding — the study tested text-only chat models, not VLAs or embodied control stacks. But no step requires human adversarial expertise, and no step requires special access beyond what agentic AI systems are being designed to have. The autonomous jailbreak capability documented in this study is exactly the capability that agentic AI architectures are optimising for — the ability to plan, reason, and adapt to achieve goals across multiple interactions.
 
 ## The scale problem
 
@@ -71,10 +71,10 @@ This is a dual-use capability problem. The same reasoning abilities that make a 
 
 From our testing across 257 models and 140,000+ scenarios, safety training investment — not model scale — is the primary determinant of jailbreak resistance. Models with deep safety training show single-digit attack success rates against historical jailbreaks. Models with minimal safety training show rates above 40% regardless of size.
 
-But alignment regression adds a new dimension: even well-aligned models are vulnerable to sustained, adaptive, multi-turn attacks from reasoning models that are specifically reasoning about how to bypass safety constraints. The 97.14% success rate in this study includes targets that would score well on standard safety benchmarks.
+But alignment regression adds a new dimension: even well-aligned models are vulnerable to sustained, adaptive, multi-turn attacks from reasoning models that are specifically reasoning about how to bypass safety constraints. The attack in this study reached even targets generally regarded as well-aligned — not just the weak ones.
 
 The gap between "passes standard safety evaluations" and "resists autonomous adversarial reasoning models" may be the most important measurement gap in AI safety right now. Standard evaluations measure a model's behaviour in isolation. Alignment regression is an ecosystem-level failure mode. Those two things require different evaluation methodologies, and currently almost all resources are going toward the former.
 
 ---
 
-_Data in this post is sourced from Hagendorff et al. (arXiv:2508.04039, Nature Communications 2026) and the Failure-First Embodied AI research corpus (257 models, 142,068 prompts, 140,555 FLIP-graded results). For related findings on how safety degrades when AI systems interact, see [what breaks once AI systems talk to each other](/blog/when-ai-systems-talk-safety-breaks/) and the [120-model evaluation](/blog/120-models-18k-prompts/)._
+_Data in this post is sourced from Hagendorff et al., [_Large Reasoning Models Are Autonomous Jailbreak Agents_](https://www.nature.com/articles/s41467-026-69010-1) (Nature Communications, 2026 — [DOI 10.1038/s41467-026-69010-1](https://doi.org/10.1038/s41467-026-69010-1); arXiv:2508.04039) and the Failure-First Embodied AI research corpus (257 models, 142,068 prompts, 140,555 FLIP-graded results). For related findings on how safety degrades when AI systems interact, see [what breaks once AI systems talk to each other](/blog/when-ai-systems-talk-safety-breaks/) and the [120-model evaluation](/blog/120-models-18k-prompts/)._


### PR DESCRIPTION
Follow-up from the Codex/Hermes/Agy QA pass on the alignment-regression post, with every external fact independently verified against primary sources.

## What the QA found (and what survived verification)
- **Venue:** Codex flagged "Nature Communications" as unverifiable. **Independent check refuted that** — the paper *is* in Nature Communications (DOI [10.1038/s41467-026-69010-1](https://doi.org/10.1038/s41467-026-69010-1), arXiv:2508.04039). No change to the claim; **added the DOI link** so it's one-click checkable (which is what would've prevented the false alarm).
- **97.14% / '25,200 test inputs':** the 97.14% is the paper's real overall ASR, but it resolves to *68 of 70 benchmark prompts* — 'across 25,200 test inputs' overstated the denominator. Restated precisely.
- **'No further guidance / emerged autonomously':** adversaries received general persuasion tactics via system prompt; they were autonomous in *execution*, not unguided *discovery*. Corrected.
- **Capability→attack claim:** qualified (Qwen3 235B underperformed its scale; not monotonic).
- **VLA chain:** labelled as an extrapolation, not a study finding (the paper tested text-only chat models).

8 insertions / 8 deletions, one file. Content validation passes locally (0 errors). The 'over 160 events' count from #476 is unchanged.