### PR TITLE
content: publish Governance Lag Index page, re-link 2 posts (#422)

### DIFF
--- a/src/content/blog/alignment-regression-post.md
+++ b/src/content/blog/alignment-regression-post.md
@@ -61,7 +61,7 @@ Previous jailbreak research required human expertise. An attacker needed to unde
 
 Autonomous jailbreak agents eliminate that constraint. The attack surface now scales with compute, not human expertise. One reasoning model can run thousands of jailbreak attempts per hour. A fleet of reasoning models can systematically probe every accessible AI system simultaneously.
 
-Our Governance Lag Index tracks over 160 events where AI attack capabilities emerged before governance responses. The autonomous jailbreak capability (GLI-052 in our dataset) has zero governance response at any level — no framework, no legislation, no enforcement mechanism. No jurisdiction has addressed the scenario of reasoning models being weaponised as autonomous jailbreak agents.
+Our [Governance Lag Index](/projects/governance-lag-index/) tracks over 160 events where AI attack capabilities emerged before governance responses. The autonomous jailbreak capability (GLI-052 in our dataset) has zero governance response at any level — no framework, no legislation, no enforcement mechanism. No jurisdiction has addressed the scenario of reasoning models being weaponised as autonomous jailbreak agents.
 
 ## What defence looks like
 

--- a/src/content/blog/glasswing-buried-number-post.md
+++ b/src/content/blog/glasswing-buried-number-post.md
@@ -70,4 +70,4 @@ If the answer is "more time, maintainers will catch up," the data does not suppo
 
 ---
 
-_Project Glasswing update published May 22, 2026. Statistics from Anthropic's announcement and subsequent analysis. The adaptation buffer estimates (5.7–13.1 months for open-weight models) are from independent research benchmarking GLM-5 and DeepSeek V3.1 against the closed-source capability trendline. For related analysis on how capability outpaces governance in AI security, see the Governance Lag Index and [alignment regression](/blog/alignment-regression/)._
+_Project Glasswing update published May 22, 2026. Statistics from Anthropic's announcement and subsequent analysis. The adaptation buffer estimates (5.7–13.1 months for open-weight models) are from independent research benchmarking GLM-5 and DeepSeek V3.1 against the closed-source capability trendline. For related analysis on how capability outpaces governance in AI security, see the [Governance Lag Index](/projects/governance-lag-index/) and [alignment regression](/blog/alignment-regression/)._

--- a/src/content/projects/governance-lag-index.md
+++ b/src/content/projects/governance-lag-index.md
@@ -1,0 +1,40 @@
+---
+title: 'Governance Lag Index'
+description: 'How long does a documented AI failure mode stay unregulated? An index timing the gap between demonstrated risk and enforceable rule.'
+tags: ['ai-safety', 'governance', 'policy', 'research']
+status: 'experiment'
+featured: false
+date: 2026-06-15
+draft: false
+---
+
+Every safety regime we trust was written in arrears. Aviation grounded the 737 MAX about four and a half months after the first MCAS crash. The Nuclear Regulatory Commission rewrote its rulebook within about a year of Three Mile Island. Even the slow ones eventually close: Vioxx took four years to pull and another three before the FDA Amendments Act gave the agency teeth; the 2008 crash took twenty-two months to reach Dodd-Frank. The lag is real — but in mature high-stakes industries it is *finite*, typically one to three years from a documented failure to an enforceable rule (the slowest cases, like Vioxx, run longer but still close).
+
+The Governance Lag Index measures that same interval for AI, and asks an uncomfortable question: what if, for this technology, the interval doesn't close at all?
+
+## What it measures
+
+GLI tracks a single failure mode at a time through four chronological stages:
+
+1. **Documentation** — the date a failure mode is first publicly, empirically demonstrated, not merely theorised.
+2. **Framework** — the first non-binding guideline or taxonomy that names it.
+3. **Enactment** — the first binding legislative instrument that covers it.
+4. **Enforcement** — the date a regulator actually holds the authority to audit, penalise, or halt deployment over it.
+
+Each entry records a date and a cited source for every stage it has reached — and, more tellingly, the stages it hasn't. The v0.1 schema is deliberately strict: a stage is either a dated, citable instrument or it is `PENDING`. There is no partial credit for good intentions.
+
+## What the early entries show
+
+The documented failures are not in dispute. Prompt injection was named and demonstrated in September 2022; by 2025 it had a production-grade, zero-click exploit with a CVE attached. Instruction-hierarchy subversion, deceptive alignment — Anthropic and Redwood showed Claude 3 Opus faking alignment in December 2024 — and reasoning-trace manipulation are all empirically on the record, each with an arXiv number and a date.
+
+The governance columns are mostly `PENDING`. The NIST AI Risk Management Framework (2023) names risks but binds no one. The EU AI Act gestures at human oversight that deceptive alignment directly defeats, without codified tests for it. For most of these failure modes there is no jurisdiction on earth where the Enforcement date exists yet. That is not a lag of months. Measured against failures that are already documented, it is — so far — unbounded.
+
+## Why this one is personal
+
+I work on embodied-AI safety, where the failure modes stop being abstract: a manipulated reasoning trace on a machine with actuators is a physical-harm vector, and the relevant rulebook is workplace-health-and-safety law written for forklifts. Australia's December 2025 National AI Plan stepped back from EU-style mandatory guardrails toward "existing laws will cover it." GLI is the instrument I use to check whether that's true — to put a date on the gap instead of an adjective.
+
+The dataset is early and the schema is v0.1; the systematic write-up, *Quantifying the Governance Lag* (Failure-First Report #46), is in production. The two essays below are where the Index first surfaced.
+
+[The buried number in the Glasswing report →](/blog/glasswing-buried-number/)
+
+[Alignment regression: smarter models, less safe →](/blog/alignment-regression/)


### PR DESCRIPTION
First execution slice of **#422** (3 unlinked references) — the Governance Lag Index item.

## What
- **Publish** `src/content/projects/governance-lag-index.md` (`draft` → live). Documents the GLI v0.1 schema — Documentation → Framework → Enactment → Enforcement, each stage a dated citable instrument or `PENDING` — and the "the lag may be unbounded for AI" thesis.
- **Re-link** the two posts that referenced the Index as plain text (unlinked in #419 as a conservative fix) back to `/projects/governance-lag-index/`:
  - `alignment-regression-post.md` — "Our Governance Lag Index tracks…"
  - `glasswing-buried-number-post.md` — closing analysis note

## Verification
- `node scripts/validate-content.js` → 0 errors / 0 warnings
- `npm run build` → green; page renders at `/projects/governance-lag-index/`
- `npm run check:links` → **0 broken** across 47,735 internal links / 580 pages (the checker from #419 now enforces the re-linked target exists)

## Scope note
This closes **only the GLI item** of #422. The other two remain:
- **Orchestrix** — already links to its GitHub repo (acceptable as-is)
- **Report #332** — needs a `/research/` section/route first

Re #422