### PR TITLE
content(gli): NotebookLM audio + video kit for Governance Lag Index

### DIFF
--- a/src/content/audio/governance-lag-index-overview.md
+++ b/src/content/audio/governance-lag-index-overview.md
@@ -1,0 +1,17 @@
+---
+title: 'The Governance Lag Index: Timing the Gap Between Risk and Rule'
+description: 'Audio deep dive into the Governance Lag Index — a four-stage schema timing how long a documented AI failure mode stays unregulated, and why it may not close.'
+date: 2026-06-16
+tags: ['notebooklm', 'ai-safety', 'governance', 'policy']
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/governance-lag-index/audio.m4a'
+duration: '22:52'
+relatedProject: 'governance-lag-index'
+---
+
+Every safety regime we trust was written in arrears. Aviation grounded the 737 MAX months after the first crash; the NRC rewrote its rulebook within a year of Three Mile Island. In mature high-stakes industries the lag between a documented failure and an enforceable rule is real but *finite* — typically one to three years. The Governance Lag Index asks an uncomfortable question: what if, for AI, that interval doesn't close at all?
+
+This episode walks through the Index's four chronological stages — Documentation, Framework, Enactment, Enforcement — and the deliberately strict v0.1 schema where a stage is either a dated, citable instrument or it is `PENDING`. No partial credit for good intentions. It traces the early entries: prompt injection, named in 2022 and carrying a zero-click CVE by 2025; deceptive alignment, demonstrated in Claude 3 Opus in December 2024 — failure modes that are empirically on the record while their Enforcement columns sit empty in every jurisdiction on earth.
+
+The stakes turn personal at the edge of embodied AI, where a manipulated reasoning trace on a machine with actuators becomes a physical-harm vector governed by workplace-safety law written for forklifts. The Index is the instrument for putting a date on that gap instead of an adjective.
+
+[View the full project →](/projects/governance-lag-index/)

--- a/src/content/projects/governance-lag-index.md
+++ b/src/content/projects/governance-lag-index.md
@@ -5,6 +5,8 @@ tags: ['ai-safety', 'governance', 'policy', 'research']
 status: 'experiment'
 featured: false
 date: 2026-06-15
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/governance-lag-index/audio.m4a'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/governance-lag-index/video.mp4'
 draft: false
 ---
 


### PR DESCRIPTION
## What

NotebookLM Studio kit for the **Governance Lag Index** project page.

| Asset | Detail | Status |
|-------|--------|--------|
| Audio deep-dive | 22:52, AAC **256k stereo**, 44 MB | ✅ live on R2 |
| Video summary | cinematic + branded, 5:06 (incl. 3s adrianwedd.com signoff sting), 72 MB | ✅ live on R2 |
| Infographic hero | portrait, branded focus | ⏳ pending NLM daily-quota reset |

## Changes

- `src/content/projects/governance-lag-index.md` — `audioUrl` + `videoUrl` (CDN)
- `src/content/audio/governance-lag-index-overview.md` — new audio collection entry (`duration: 22:52`, `relatedProject: governance-lag-index`), cross-linked back to the project

Audio/video are served from `cdn.adrianwedd.com` (R2, git-ignored); only content files are committed.

## Verification

- ✅ `node scripts/validate-content.js` → 0 errors / 0 warnings
- ✅ `npm run build` → clean; both `/projects/governance-lag-index/` and `/audio/governance-lag-index-overview/` generated, project page references both CDN URLs
- ✅ CDN `HEAD` 200 for `audio.m4a` (`audio/mp4`, 44,170,492 B) and `video.mp4` (`video/mp4`, 72,169,537 B)
- ✅ Audio re-verified 256k **stereo** after a stale-auth download initially degraded it to 96k mono
- ✅ Video signoff sting appended via TS-concat with `-c copy` (no re-encode of the main video)

## Follow-up

Infographic hero is blocked on the NLM daily infographic quota (~50/day, exhausted today). It will be added to this branch as a follow-up commit once the quota resets — at which point `heroImage` gets wired and the `.webp`/`.jpg` twin committed.