### PR TITLE
fix(ux): search deep-linking, no-results guidance, mobile-menu modal (#472)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -115,11 +115,21 @@ const currentPath = Astro.url.pathname;
         // Hamburger button click
         if (e.target.closest && e.target.closest('.mobile-menu-btn')) {
           var expanded = btn.getAttribute('aria-expanded') === 'true';
-          btn.setAttribute('aria-expanded', String(!expanded));
+          var willOpen = !expanded;
+          btn.setAttribute('aria-expanded', String(willOpen));
           btn.setAttribute('aria-label', expanded ? 'Open menu' : 'Close menu');
           menu.classList.toggle('hidden');
           iconOpen.classList.toggle('hidden');
           iconClose.classList.toggle('hidden');
+          // Lock body scroll while the modal menu is open (covers all close
+          // routes: Escape and nav-link clicks both re-enter via btn.click()).
+          document.body.classList.toggle('overflow-hidden', willOpen);
+          // Move focus into the menu on open so keyboard/SR users land inside
+          // the trapped region; Escape returns focus to the button.
+          if (willOpen) {
+            var firstLink = menu.querySelector('a[href], button');
+            if (firstLink) firstLink.focus();
+          }
           return;
         }
 

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -32,23 +32,35 @@ import HeroCanvas from '../components/HeroCanvas.astro';
   <link href="/pagefind/pagefind-ui.css" rel="stylesheet" />
   <script is:inline>
     (function () {
+      function mountUI() {
+        var ui = new PagefindUI({
+          element: '#search',
+          showSubResults: true,
+          showImages: true,
+          translations: {
+            zero_results:
+              "No matches for [SEARCH_TERM]. Try a broader term, a different spelling, or browse the blog, projects, and gallery from the menu.",
+          },
+        });
+        var sk = document.getElementById('search-skeleton');
+        if (sk) sk.remove();
+        // Deep-link support: /search/?q=term (advertised in the homepage
+        // SearchAction schema) pre-fills the box and runs the search.
+        var q = new URLSearchParams(window.location.search).get('q');
+        if (q && typeof ui.triggerSearch === 'function') ui.triggerSearch(q);
+      }
+
       function initPagefind() {
         var container = document.getElementById('search');
         if (!container || container.dataset.pagefindInit) return;
         container.dataset.pagefindInit = '1';
         if (typeof PagefindUI !== 'undefined') {
-          new PagefindUI({ element: '#search', showSubResults: true, showImages: true });
-          var sk = document.getElementById('search-skeleton');
-          if (sk) sk.remove();
+          mountUI();
           return;
         }
         var script = document.createElement('script');
         script.src = '/pagefind/pagefind-ui.js';
-        script.onload = function () {
-          new PagefindUI({ element: '#search', showSubResults: true, showImages: true });
-          var sk = document.getElementById('search-skeleton');
-          if (sk) sk.remove();
-        };
+        script.onload = mountUI;
         document.head.appendChild(script);
       }
       initPagefind();


### PR DESCRIPTION
Second batch from the [#472](https://github.com/adrianwedd/adrianwedd.com/issues/472) frontend audit — the **Discoverability & navigation** section. Independent of #482 (no file overlap).

## D1 — Search deep-linking (functional bug)
The homepage `SearchAction` JSON-LD advertises `https://adrianwedd.com/search/?q={search_term_string}`, but `search.astro` never read `location.search` — so `/search/?q=foo` (and any search-engine deep link using the schema) silently did nothing. Now reads the param and runs the query via `PagefindUI.triggerSearch()`, guarded with a `typeof` check.

## D2 — Site-authored no-results guidance
Replaced Pagefind's bare "No results" with a site-authored message via the supported `translations.zero_results` option, pointing users to broader terms / the content sections.

## C4 — Mobile menu modal completion
Escape-to-close, focus return, and the Tab focus-trap were **already** in place. The two gaps the audit named — **body scroll-lock** and **focus-move-on-open** — are now added, completing the modal treatment. Scroll-lock is removed on every close route (Escape and nav-link clicks both re-enter via `btn.click()`).

## Verification
- `triggerSearch` and `zero_results` both confirmed present in the bundled `pagefind-ui.js` (1.5.2)
- `npm run build` — green
- `npm run lint` — clean