### PR TITLE
fix(ci): harden raw-<img> deploy gate against Prettier-wrapped tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,18 +71,17 @@ jobs:
           echo "✓ Build size within budget"
       - name: Enforce no raw <img> on local paths
         run: |
-          # Raw <img> on local paths must use Astro <Picture>. Flatten each
-          # <img …> tag onto one line FIRST — Prettier wraps long tags (putting
-          # `<img` alone on a line), which hid the src="" / URL exclusions from
-          # the old per-line grep and let a wrapped tag slip through (#472 / #486
-          # Lightbox CLS regression). Catches both single-line and wrapped tags.
+          # Raw <img> on local paths must use Astro <Picture>. Parse each <img …>
+          # tag (quote-aware so a `>` inside an attribute can't truncate it; case-
+          # insensitive) and test ONLY its src value — flag unless src is empty
+          # (JS-populated, e.g. the lightbox), a remote http(s) URL, or a data: URI.
+          # The old per-line grep was fooled two ways: Prettier wrapping the tag
+          # (`<img` alone on a line) AND a URL in a non-src attribute excluding the
+          # whole line. src-specific parsing fixes both. (#472 / #486 Lightbox CLS)
+          # \x27 = single-quote, so the Perl program nests inside the shell quotes.
           offenders=$(
             find src/pages src/layouts src/components -name '*.astro' -print0 \
-            | xargs -0 perl -0777 -ne 'while (/<img\b[^>]*>/g) { my $t = $&; $t =~ s/\s+/ /g; print "$ARGV: $t\n"; }' \
-            | grep -v 'https\?://' \
-            | grep -v 'data:' \
-            | grep -v 'src=""' \
-            || true
+            | xargs -0r perl -0777 -ne 'while (/<img\b(?:"[^"]*"|\x27[^\x27]*\x27|[^>])*>/gi) { my $tag = $&; my ($src) = $tag =~ /\bsrc\s*=\s*"([^"]*)"/i; ($src) = $tag =~ /\bsrc\s*=\s*\x27([^\x27]*)\x27/i unless defined $src; next if defined($src) && ($src eq "" || $src =~ m{^\s*https?://}i || $src =~ m{^\s*data:}i); (my $flat = $tag) =~ s/\s+/ /g; print "$ARGV: $flat\n"; }'
           )
           if [ -n "$offenders" ]; then
             echo "ERROR: Raw <img> tags with local paths found. Use Astro <Picture> instead."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,20 +71,22 @@ jobs:
           echo "✓ Build size within budget"
       - name: Enforce no raw <img> on local paths
         run: |
-          if grep -rn '<img' src/pages/ src/layouts/ src/components/ \
-            --include='*.astro' \
+          # Raw <img> on local paths must use Astro <Picture>. Flatten each
+          # <img …> tag onto one line FIRST — Prettier wraps long tags (putting
+          # `<img` alone on a line), which hid the src="" / URL exclusions from
+          # the old per-line grep and let a wrapped tag slip through (#472 / #486
+          # Lightbox CLS regression). Catches both single-line and wrapped tags.
+          offenders=$(
+            find src/pages src/layouts src/components -name '*.astro' -print0 \
+            | xargs -0 perl -0777 -ne 'while (/<img\b[^>]*>/g) { my $t = $&; $t =~ s/\s+/ /g; print "$ARGV: $t\n"; }' \
             | grep -v 'https\?://' \
             | grep -v 'data:' \
-            | grep -v 'src/components/islands/' \
             | grep -v 'src=""' \
-            | grep -q .; then
+            || true
+          )
+          if [ -n "$offenders" ]; then
             echo "ERROR: Raw <img> tags with local paths found. Use Astro <Picture> instead."
-            grep -rn '<img' src/pages/ src/layouts/ src/components/ \
-              --include='*.astro' \
-              | grep -v 'https\?://' \
-              | grep -v 'data:' \
-              | grep -v 'src/components/islands/' \
-              | grep -v 'src=""'
+            echo "$offenders"
             exit 1
           fi
           echo "✓ No raw <img> tags on local paths found."


### PR DESCRIPTION
## Problem

The main deploy went red after #486 merged: the **`Enforce no raw <img> on local paths`** gate failed on `src/components/Lightbox.astro:62`.

Root cause: the gate matched **per line**. #486's Lightbox CLS fix added `style="height:auto"`, pushing the `<img>` tag past Prettier's print-width so Prettier wrapped it — leaving a bare `<img` on its own line with `src=""` on a *later* line. The `grep -v 'src=""'` exclusion never saw it, so the gate flagged a perfectly valid empty-src lightbox image.

This gate runs **only in `deploy.yml`** (not in PR/lighthouse checks), so #486 was green on the PR and only broke once on `main`. The live site is unaffected (Pages still serves #482's last good deploy).

## Fix

Flatten each `<img …>` tag onto one logical line **before** applying the exclusion filters. Now robust to both single-line and Prettier-wrapped tags.

## Verification (local)
- ✅ Passes the current clean tree (Lightbox `src=""` correctly excluded once flattened)
- ✅ Still **catches** injected raw local `<img>` — both `<img src="/x.png">` and the multiline-wrapped form (the old gate missed the latter)
- ✅ Correctly excludes `http(s)://`, `data:`, and `src=""`
- ✅ `deploy.yml` parses as valid YAML; gate passes under `set -e`

No untrusted GitHub event input — static scan over repo files only.

Refs #472, #486.