### PR TITLE
feat(security): add HSTS header in CSP worker (#473)

### DIFF
--- a/worker-csp/src/index.ts
+++ b/worker-csp/src/index.ts
@@ -10,7 +10,7 @@
  *       the real header is stronger and the meta would otherwise stack with it.
  *  4. Set a real `Content-Security-Policy` response header (no `'unsafe-inline'`).
  *  5. Add defense-in-depth headers (`X-Frame-Options`, `X-Content-Type-Options`,
- *     `Referrer-Policy`).
+ *     `Referrer-Policy`, `Permissions-Policy`, `Strict-Transport-Security`).
  *
  * Only HTML responses are rewritten. Static assets (JS/CSS/images) pass through
  * untouched so cacheability is preserved.
@@ -66,6 +66,12 @@ export default {
     headers.set('X-Content-Type-Options', 'nosniff');
     headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
     headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=(), payment=(), xr-spatial-tracking=()');
+    // HSTS: 2-year max-age + includeSubDomains (cdn./social./www. are all
+    // HTTPS via Cloudflare). No `preload` — that's a one-way commitment that
+    // binds every current and future subdomain to HTTPS-only in browsers'
+    // hardcoded list. Set on HTML responses; the browser only needs to see
+    // HSTS once per host to apply the policy site-wide.
+    headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
     // Don't ship the meta CSP downstream — header is stronger and the meta
     // would force the browser to intersect both policies.
     headers.delete('Content-Security-Policy-Report-Only');

--- a/worker-csp/test/index.test.ts
+++ b/worker-csp/test/index.test.ts
@@ -111,6 +111,9 @@ describe('worker fetch handler', () => {
 
     const res = await SELF.fetch('https://adrianwedd.com/_astro/page.js');
     expect(res.headers.get('content-security-policy')).toBeNull();
+    // Assets pass through, so they carry no HSTS — fine, since the browser
+    // applies the host-wide policy from any HTML response it has seen.
+    expect(res.headers.get('strict-transport-security')).toBeNull();
     expect(await res.text()).toBe('console.log(1)');
   });
 
@@ -133,6 +136,11 @@ describe('worker fetch handler', () => {
     expect(res.headers.get('x-content-type-options')).toBe('nosniff');
     expect(res.headers.get('referrer-policy')).toBe('strict-origin-when-cross-origin');
     expect(res.headers.get('permissions-policy')).toMatch(/camera=\(\)/);
+    expect(res.headers.get('strict-transport-security')).toBe(
+      'max-age=63072000; includeSubDomains',
+    );
+    // No preload — deliberate (one-way commitment).
+    expect(res.headers.get('strict-transport-security')).not.toMatch(/preload/);
 
     // Meta CSP stripped
     expect(text).not.toMatch(/<meta http-equiv="Content-Security-Policy"/);


### PR DESCRIPTION
## What

Adds `Strict-Transport-Security: max-age=63072000; includeSubDomains` to HTML responses from the edge CSP worker (`worker-csp`). Closes the HSTS gap in #473.

**No `preload`** — deliberate. preload is a one-way commitment (browser-hardcoded HTTPS list, binds all current + future subdomains); per your call we ship the strong-but-reversible form first.

## Notes

- `includeSubDomains` is safe — `cdn.` / `social.` / `www.` all serve HTTPS via Cloudflare. It tells browsers to enforce HTTPS on `*.adrianwedd.com`.
- The worker only rewrites HTML; assets pass through without the header. That's fine — a browser applies the **host-wide** policy from any HTML response it has seen, so normal navigation sets it. The only gap is a user whose very first-ever hit is a deep-linked asset; the optional Cloudflare-dashboard HSTS toggle closes that (in the ops handoff).

## Deploy

Requires `cd worker-csp && npx wrangler deploy` after merge (not auto-deployed).

## Verified

worker-csp **18/18** tests pass (asserts exact header value, no-preload, and null on asset pass-through), `tsc --noEmit` clean, `wrangler deploy --dry-run` bundles.