### PR TITLE
feat(security): COOP + CORP isolation headers (#473)

### DIFF
--- a/worker-csp/src/index.ts
+++ b/worker-csp/src/index.ts
@@ -72,6 +72,15 @@ export default {
     // hardcoded list. Set on HTML responses; the browser only needs to see
     // HSTS once per host to apply the policy site-wide.
     headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
+    // Cross-origin isolation (defence against XS-Leaks / cross-window attacks).
+    // COOP severs window.opener for cross-origin popups so a malicious opener
+    // can't reach into our context. 'same-origin-allow-popups' keeps popups WE
+    // open (ad/analytics scripts occasionally do) functional, unlike the
+    // stricter 'same-origin'. CORP 'same-origin' stops other origins embedding
+    // our HTML as a no-cors subresource; OG scrapers do plain top-level fetches,
+    // which CORP doesn't govern, so social previews are unaffected.
+    headers.set('Cross-Origin-Opener-Policy', 'same-origin-allow-popups');
+    headers.set('Cross-Origin-Resource-Policy', 'same-origin');
     // Don't ship the meta CSP downstream — header is stronger and the meta
     // would force the browser to intersect both policies.
     headers.delete('Content-Security-Policy-Report-Only');

--- a/worker-csp/test/index.test.ts
+++ b/worker-csp/test/index.test.ts
@@ -114,6 +114,9 @@ describe('worker fetch handler', () => {
     // Assets pass through, so they carry no HSTS — fine, since the browser
     // applies the host-wide policy from any HTML response it has seen.
     expect(res.headers.get('strict-transport-security')).toBeNull();
+    // Cross-origin isolation headers are HTML-only too (assets pass through).
+    expect(res.headers.get('cross-origin-opener-policy')).toBeNull();
+    expect(res.headers.get('cross-origin-resource-policy')).toBeNull();
     expect(await res.text()).toBe('console.log(1)');
   });
 
@@ -141,6 +144,10 @@ describe('worker fetch handler', () => {
     );
     // No preload — deliberate (one-way commitment).
     expect(res.headers.get('strict-transport-security')).not.toMatch(/preload/);
+    // Cross-origin isolation headers (allow-popups variant keeps ad/analytics
+    // popups working; CORP same-origin doesn't affect plain-fetch OG scrapers).
+    expect(res.headers.get('cross-origin-opener-policy')).toBe('same-origin-allow-popups');
+    expect(res.headers.get('cross-origin-resource-policy')).toBe('same-origin');
 
     // Meta CSP stripped
     expect(text).not.toMatch(/<meta http-equiv="Content-Security-Policy"/);


### PR DESCRIPTION
Adds two cross-origin isolation headers to the CSP worker (`worker-csp`), advancing the #473 security-hardening roadmap.

## Changes
- `Cross-Origin-Opener-Policy: same-origin-allow-popups` — isolates the browsing-context group (XS-Leaks / cross-window defence). The `-allow-popups` variant preserves popups *we* open (ad/analytics scripts occasionally do), unlike strict `same-origin`.
- `Cross-Origin-Resource-Policy: same-origin` — blocks other origins embedding our HTML as a `no-cors` subresource.

Both set on **HTML responses only** (assets pass through), mirroring the existing HSTS placement.

## Why this is safe for OG scrapers
CORP governs browser-enforced `no-cors` subresource embedding. Facebook/Twitter/LinkedIn OG scrapers fetch the page as a plain top-level request, which CORP doesn't apply to — social previews are unaffected.

## Verification
- `cd worker-csp && npm test` → 18 passed (added COOP/CORP assertions to both the HTML and pass-through cases)
- `npx wrangler deploy --dry-run` → clean

## Note
Header takes effect only once `worker-csp` is deployed (`cd worker-csp && npx wrangler deploy`) — same pending activation as the merged HSTS header (#492).