### PR TITLE
fix(security): bound /api/health KV scans + gitignore .dev.vars (#473)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ pnpm-debug.log*
 # environment variables
 .env
 .env.production
+# wrangler local secrets (worker/ + worker-csp/) — never commit
+.dev.vars
+*.dev.vars
 
 # macOS-specific files
 .DS_Store

--- a/worker/src/__tests__/health-counting.test.ts
+++ b/worker/src/__tests__/health-counting.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { countKeysCapped, HEALTH_MAX_LIST_PAGES } from '../index';
+
+// Cursor-paginating KV mock. Ignores the requested `limit` and paginates with a
+// fixed `pageSize` so we can exercise the page-count cap without allocating tens
+// of thousands of keys (the cap is about page count, not key count).
+function makePaginatingKV(names: string[], pageSize: number): KVNamespace {
+  return {
+    list: vi.fn(async ({ prefix, cursor }: { prefix: string; limit?: number; cursor?: string }) => {
+      const matching = names.filter((n) => n.startsWith(prefix));
+      const start = cursor ? parseInt(cursor, 10) : 0;
+      const page = matching.slice(start, start + pageSize);
+      const nextStart = start + pageSize;
+      const complete = nextStart >= matching.length;
+      return {
+        keys: page.map((name) => ({ name })),
+        list_complete: complete,
+        cursor: complete ? undefined : String(nextStart),
+      };
+    }),
+  } as unknown as KVNamespace;
+}
+
+describe('countKeysCapped', () => {
+  it('counts every key when the scan completes under the page cap', async () => {
+    const names = Array.from({ length: 50 }, (_, i) => `post:queued:${i}`);
+    const kv = makePaginatingKV(names, 10); // 5 pages
+
+    const result = await countKeysCapped(kv, 'post:queued:');
+
+    expect(result.count).toBe(50);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('filters by prefix', async () => {
+    const names = [
+      ...Array.from({ length: 7 }, (_, i) => `post:queued:${i}`),
+      ...Array.from({ length: 3 }, (_, i) => `post:failed:${i}`),
+    ];
+    const kv = makePaginatingKV(names, 100);
+
+    expect((await countKeysCapped(kv, 'post:queued:')).count).toBe(7);
+    expect((await countKeysCapped(kv, 'post:failed:')).count).toBe(3);
+  });
+
+  it('invokes onFirstPage with the first page only', async () => {
+    const names = Array.from({ length: 30 }, (_, i) => `post:queued:${i}`);
+    const kv = makePaginatingKV(names, 10);
+    const onFirstPage = vi.fn();
+
+    await countKeysCapped(kv, 'post:queued:', onFirstPage);
+
+    expect(onFirstPage).toHaveBeenCalledTimes(1);
+    expect(onFirstPage.mock.calls[0][0]).toHaveLength(10);
+    expect(onFirstPage.mock.calls[0][0][0]).toEqual({ name: 'post:queued:0' });
+  });
+
+  it('reports a truncated floor and stops at the page cap', async () => {
+    const pageSize = 10;
+    // One page beyond the cap — the helper must NOT scan it.
+    const names = Array.from({ length: (HEALTH_MAX_LIST_PAGES + 1) * pageSize }, (_, i) => `post:published:${i}`);
+    const kv = makePaginatingKV(names, pageSize);
+
+    const result = await countKeysCapped(kv, 'post:published:');
+
+    expect(result.count).toBe(HEALTH_MAX_LIST_PAGES * pageSize); // floor, not the full set
+    expect(result.truncated).toBe(true);
+    expect((kv.list as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(HEALTH_MAX_LIST_PAGES);
+  });
+
+  it('does not truncate when the set ends exactly on the cap', async () => {
+    const pageSize = 10;
+    const names = Array.from({ length: HEALTH_MAX_LIST_PAGES * pageSize }, (_, i) => `fb-flag:${i}`);
+    const kv = makePaginatingKV(names, pageSize);
+
+    const result = await countKeysCapped(kv, 'fb-flag:');
+
+    expect(result.count).toBe(HEALTH_MAX_LIST_PAGES * pageSize);
+    expect(result.truncated).toBe(false);
+  });
+});

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -28,6 +28,37 @@ function json(body: Record<string, unknown>, status = 200): Response {
 
 const VALID_PLATFORMS = new Set<string>(['facebook', 'instagram', 'bluesky', 'twitter']);
 
+// ── Bounded KV counting (DoS guard for /api/health) ────────────────────────────
+// /api/health counts queue/flag keys by paginating KV. Without a ceiling a
+// pathologically large prefix (runaway queue, stuck cron) would make a single
+// authed health probe fan out unbounded list subrequests. Cap the page count
+// and report a truncated floor instead of scanning forever. limit:1000 is KV's
+// max page size, so 25 pages = 25k keys — far above any realistic queue.
+export const HEALTH_LIST_LIMIT = 1000;
+export const HEALTH_MAX_LIST_PAGES = 25;
+
+export async function countKeysCapped(
+  kv: KVNamespace,
+  prefix: string,
+  onFirstPage?: (keys: { name: string }[]) => void,
+): Promise<{ count: number; truncated: boolean }> {
+  let count = 0;
+  let cursor: string | undefined;
+  let pages = 0;
+  do {
+    const list = await kv.list({
+      prefix,
+      limit: HEALTH_LIST_LIMIT,
+      ...(cursor ? { cursor } : {}),
+    });
+    if (pages === 0) onFirstPage?.(list.keys);
+    count += list.keys.length;
+    pages += 1;
+    cursor = list.list_complete ? undefined : list.cursor;
+  } while (cursor && pages < HEALTH_MAX_LIST_PAGES);
+  return { count, truncated: cursor !== undefined };
+}
+
 function validatePlatform(raw: string | undefined, fallback = 'facebook'): Platform | null {
   const name = raw ?? fallback;
   return VALID_PLATFORMS.has(name) ? name as Platform : null;
@@ -630,45 +661,42 @@ app.get('/api/health', async (c) => {
     };
   }
 
-  // Count posts by status
-  let queued = 0;
-  let published = 0;
-  let failed = 0;
+  // Count posts by status (bounded — see countKeysCapped). Capture the first
+  // queued key's name on its first page so the next-scheduled lookup is a
+  // single extra get rather than another scan.
   let nextScheduled: string | null = null;
+  let truncated = false;
+  let firstQueuedKeyName: string | null = null;
 
-  for (const prefix of ['post:queued:', 'post:published:', 'post:failed:']) {
-    let listCursor: string | undefined;
-    do {
-      const list = await env.SOCIAL.list({ prefix, limit: 100, ...(listCursor ? { cursor: listCursor } : {}) });
-      if (prefix === 'post:queued:') {
-        queued += list.keys.length;
-        // Find next scheduled (keys are time-ordered)
-        if (!nextScheduled && list.keys.length > 0) {
-          const raw = await env.SOCIAL.get(list.keys[0].name);
-          if (raw) {
-            try { nextScheduled = JSON.parse(raw).scheduledAt; } catch {}
-          }
-        }
-      }
-      else if (prefix === 'post:published:') published += list.keys.length;
-      else failed += list.keys.length;
-      listCursor = list.list_complete ? undefined : list.cursor;
-    } while (listCursor);
+  const queuedResult = await countKeysCapped(env.SOCIAL, 'post:queued:', (keys) => {
+    if (keys.length > 0) firstQueuedKeyName = keys[0].name; // keys are time-ordered
+  });
+  const publishedResult = await countKeysCapped(env.SOCIAL, 'post:published:');
+  const failedResult = await countKeysCapped(env.SOCIAL, 'post:failed:');
+  const flaggedResult = await countKeysCapped(env.SOCIAL, 'fb-flag:');
+  truncated =
+    queuedResult.truncated || publishedResult.truncated || failedResult.truncated || flaggedResult.truncated;
+
+  if (firstQueuedKeyName) {
+    const raw = await env.SOCIAL.get(firstQueuedKeyName);
+    if (raw) {
+      try { nextScheduled = JSON.parse(raw).scheduledAt; } catch {}
+    }
   }
-
-  // Count flagged comments
-  let flaggedComments = 0;
-  let flagCursor: string | undefined;
-  do {
-    const list = await env.SOCIAL.list({ prefix: 'fb-flag:', limit: 100, ...(flagCursor ? { cursor: flagCursor } : {}) });
-    flaggedComments += list.keys.length;
-    flagCursor = list.list_complete ? undefined : list.cursor;
-  } while (flagCursor);
 
   return json({
     platforms: platformsHealth,
-    queue: { facebook: { queued, published, failed, nextScheduled } },
-    recentActivity: { flaggedComments },
+    queue: {
+      facebook: {
+        queued: queuedResult.count,
+        published: publishedResult.count,
+        failed: failedResult.count,
+        nextScheduled,
+      },
+    },
+    recentActivity: { flaggedComments: flaggedResult.count },
+    // Honest signal that a count is a floor, not silently truncated.
+    ...(truncated ? { countsTruncated: true } : {}),
   });
 });
 


### PR DESCRIPTION
Two #473 hardening items in one focused change to the social worker.

## 1. Bound the `/api/health` KV scans (`worker/src/index.ts`)
The health endpoint counted `post:queued:` / `post:published:` / `post:failed:` / `fb-flag:` keys with **unbounded** `do/while` KV pagination. A pathologically large prefix (runaway queue, stuck cron) would make a single authed `/api/health` probe fan out unlimited `list` subrequests — a self-inflicted amplification vector.

- Extracted counting into `countKeysCapped(kv, prefix, onFirstPage?)`: `limit:1000` (KV's max page size) capped at **25 pages = 25k keys**, returning `{ count, truncated }`.
- 25k is far above any realistic queue; beyond it the count is reported as a **floor** with `countsTruncated: true` on the response — no silent under-reporting.
- `nextScheduled` lookup now captures the first queued key on its first page (one extra `get`) instead of re-deriving it mid-loop.

## 2. gitignore `.dev.vars`
`.gitignore` covered `.env` but not wrangler's `.dev.vars` local-secrets file (used by both `worker/` and `worker-csp/`), leaving an easy path to commit secrets. Added `.dev.vars` + `*.dev.vars`. Confirmed nothing matching is currently tracked.

## Verification
- `cd worker && npm test` → **162 passed** (+5: full scan, prefix filter, `onFirstPage`, page-cap floor, exact-boundary no-truncation)
- `npx wrangler deploy --dry-run` → clean
- `git check-ignore worker/.dev.vars worker-csp/.dev.vars` → both ignored