### PR TITLE
fix(e4): type getStaticPaths/paginate in paginated routes (unbreak deploy)

### DIFF
--- a/src/pages/audio/[...page].astro
+++ b/src/pages/audio/[...page].astro
@@ -3,16 +3,18 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import HeroCanvas from '../../components/HeroCanvas.astro';
 import Pagination from '../../components/Pagination.astro';
 import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+import type { GetStaticPaths, Page } from 'astro';
 import { slug } from '../../lib/utils';
 
-export async function getStaticPaths({ paginate }) {
+export const getStaticPaths = (async ({ paginate }) => {
   const episodes = (await getCollection('audio'))
     .filter((e) => !e.data.draft)
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
   return paginate(episodes, { pageSize: 12 });
-}
+}) satisfies GetStaticPaths;
 
-const { page } = Astro.props;
+const { page } = Astro.props as { page: Page<CollectionEntry<'audio'>> };
 const isFirst = page.currentPage === 1;
 
 const allEpisodes = (await getCollection('audio')).filter((e) => !e.data.draft);

--- a/src/pages/audio/tag/[tag]/[...page].astro
+++ b/src/pages/audio/tag/[tag]/[...page].astro
@@ -2,9 +2,11 @@
 import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import Pagination from '../../../../components/Pagination.astro';
 import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+import type { GetStaticPaths, Page } from 'astro';
 import { slug } from '../../../../lib/utils';
 
-export async function getStaticPaths({ paginate }) {
+export const getStaticPaths = (async ({ paginate }) => {
   const episodes = (await getCollection('audio')).filter((e) => !e.data.draft);
   const tags = [...new Set(episodes.flatMap((e) => e.data.tags))];
   return tags.flatMap((tag) => {
@@ -13,9 +15,9 @@ export async function getStaticPaths({ paginate }) {
       .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
     return paginate(tagged, { params: { tag }, props: { tag }, pageSize: 12 });
   });
-}
+}) satisfies GetStaticPaths;
 
-const { page, tag } = Astro.props;
+const { page, tag } = Astro.props as { page: Page<CollectionEntry<'audio'>>; tag: string };
 const isFirst = page.currentPage === 1;
 
 const allEpisodes = (await getCollection('audio')).filter((e) => !e.data.draft);

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -5,16 +5,18 @@ import ContentCarousel from '../../components/ContentCarousel.astro';
 import Pagination from '../../components/Pagination.astro';
 import ScrollReveal from '../../components/ScrollReveal.astro';
 import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+import type { GetStaticPaths, Page } from 'astro';
 import { slug } from '../../lib/utils';
 
-export async function getStaticPaths({ paginate }) {
+export const getStaticPaths = (async ({ paginate }) => {
   const posts = (await getCollection('blog'))
     .filter((p) => !p.data.draft)
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
   return paginate(posts, { pageSize: 12 });
-}
+}) satisfies GetStaticPaths;
 
-const { page } = Astro.props;
+const { page } = Astro.props as { page: Page<CollectionEntry<'blog'>> };
 const isFirst = page.currentPage === 1;
 
 // Tag chips (and the page-1 carousel) need the full post set, not this page's slice.

--- a/src/pages/blog/tag/[tag]/[...page].astro
+++ b/src/pages/blog/tag/[tag]/[...page].astro
@@ -3,9 +3,11 @@ import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import Breadcrumb from '../../../../components/Breadcrumb.astro';
 import Pagination from '../../../../components/Pagination.astro';
 import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+import type { GetStaticPaths, Page } from 'astro';
 import { slug } from '../../../../lib/utils';
 
-export async function getStaticPaths({ paginate }) {
+export const getStaticPaths = (async ({ paginate }) => {
   const all = (await getCollection('blog')).filter((p) => !p.data.draft);
   const tags = [...new Set(all.flatMap((p) => p.data.tags))];
   return tags.flatMap((tag) => {
@@ -14,9 +16,9 @@ export async function getStaticPaths({ paginate }) {
       .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
     return paginate(posts, { params: { tag }, props: { tag }, pageSize: 12 });
   });
-}
+}) satisfies GetStaticPaths;
 
-const { page, tag } = Astro.props;
+const { page, tag } = Astro.props as { page: Page<CollectionEntry<'blog'>>; tag: string };
 const isFirst = page.currentPage === 1;
 
 const allPosts = await getCollection('blog');


### PR DESCRIPTION
Hotfix for main: PR #500 broke the deploy because the four paginated routes used untyped `getStaticPaths({ paginate })`, making `Astro.props.page` infer as `never` — 30 `astro check` errors.

**Why it slipped:** `astro build`/`npm run build` don't type-check, so it passed locally and on the PR. The `npx astro check` gate (deploy.yml:28) runs **only on push to main**, not on PRs — so it surfaced post-merge.

**Fix:** `satisfies GetStaticPaths` + cast `page` to `Page<CollectionEntry<...>>` (+`tag: string` on tag routes), all four routes.

**Verified locally:** `npx astro check` → 0 errors / 0 warnings; `npm run build` → 628 pages.

Follow-up worth considering: add `astro check` as a PR gate so this class of error can't reach main again.

https://claude.ai/code/session_01A1rKHZFSwxpSKMj6rABjoA