### PR TITLE
fix(e4): exclude paginated /blog/N/ pages from site-test gates

### DIFF
--- a/scripts/test-site.sh
+++ b/scripts/test-site.sh
@@ -100,7 +100,7 @@ for slug in "${DRAFT_SLUGS[@]}"; do
 done
 
 SRC_POSTS=$(find src/content/blog -name '*.md' -exec grep -L 'draft: true' {} \; | wc -l | tr -d ' ')
-DIST_POSTS=$(find "$DIST/blog" -maxdepth 2 -name 'index.html' -not -path '*/tag/*' -not -path '*/tags/*' | wc -l | tr -d ' ')
+DIST_POSTS=$(find "$DIST/blog" -maxdepth 2 -name 'index.html' -not -path '*/tag/*' -not -path '*/tags/*' | grep -vE '/blog/[0-9]+/index\.html$' | wc -l | tr -d ' ')
 # Subtract 1 for the blog listing page (dist/blog/index.html)
 DIST_POSTS=$((DIST_POSTS - 1))
 if [ "$SRC_POSTS" -eq "$DIST_POSTS" ]; then

--- a/scripts/validate-schema.mjs
+++ b/scripts/validate-schema.mjs
@@ -67,7 +67,9 @@ const blogDir = join(DIST, 'blog');
 if (statSync(blogDir).isDirectory()) {
   for (const entry of readdirSync(blogDir)) {
     const indexPath = join(blogDir, entry, 'index.html');
-    if (entry === 'tag' || entry === 'tags') continue;
+    // Skip tag aggregations and numeric pagination pages (/blog/2/ …) — these
+    // are list pages, not articles, so they carry no Article schema by design.
+    if (entry === 'tag' || entry === 'tags' || /^\d+$/.test(entry)) continue;
     try {
       if (!statSync(indexPath).isFile()) continue;
     } catch {


### PR DESCRIPTION
Second hotfix for the E4 pagination deploy. After #501 fixed `astro check`, the deploy-only **Run site tests** step (`scripts/test-site.sh`) failed on two pagination-unaware checks:

- **validate-schema.mjs**: treated `/blog/2/`…`/blog/7/` as articles → 6 'Missing Article schema' errors. They're list pages; now skips numeric dirs.
- **test-site.sh blog count**: 85 built vs 79 source (the 6 pagination pages); now excludes `/blog/[0-9]+/` from the built count (leading-digit slugs stay counted — the dir must be *all* digits to match).

Same blind spot as #501: this step runs only on push to main, not on PRs.

**Verified locally:** `test-site.sh` exits 0 (schema 0 errors, count 79=79); `check:links` 0 broken across 630 pages.

Follow-up (worth a tracking issue): run `astro check` **and** `test-site.sh` as PR gates so this whole class can't reach main again.

https://claude.ai/code/session_01A1rKHZFSwxpSKMj6rABjoA