### PR TITLE
ci: run validation gates on PRs, not just post-merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,16 +3,21 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened] # exclude closed/merged → no double-run
   workflow_dispatch:
 
+# Least privilege at the top level (PR validation only reads). The deploy job
+# re-grants pages:write / id-token:write for itself.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  # Production deploys share the 'pages' lane and never cancel; each PR gets its
+  # own lane so a new push supersedes the old run without touching deploys.
+  group: ${{ github.event_name == 'push' && 'pages' || format('pr-{0}', github.event.pull_request.number) }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   build:
@@ -30,12 +35,16 @@ jobs:
         run: node scripts/validate-content.js
       - name: Audit dependencies
         run: npm audit --audit-level=high --omit=dev
+      # Deploy-only: needs repo secrets (absent on fork PRs) and is deploy input,
+      # not validation. PR builds fall back to default analytics + CV data.
       - name: Fetch GA4 analytics data
+        if: github.event_name != 'pull_request'
         run: node scripts/fetch-ga4-data.mjs
         env:
           GA4_PROPERTY_ID: ${{ vars.GA4_PROPERTY_ID }}
           GA4_SERVICE_ACCOUNT_KEY: ${{ secrets.GA4_SERVICE_ACCOUNT_KEY }}
       - name: Checkout CV data
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: adrianwedd/cv
@@ -43,6 +52,7 @@ jobs:
           token: ${{ secrets.PIPELINE_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Copy CV data
+        if: github.event_name != 'pull_request'
         run: |
           mkdir -p src/data
           if [ -f cv-repo/data/base-cv.json ]; then
@@ -115,7 +125,11 @@ jobs:
         # worker-csp has its own dedicated job below; this only covers the
         # social-publish worker, which had no CI coverage prior to this step.
         run: cd worker && npm ci && npm test
+      # External link check is network-flaky/slow and its value is pre-deploy,
+      # not pre-merge — keep it push-only so PRs stay fast and deterministic.
+      # (check:links below still covers same-origin links on every PR.)
       - name: Install lychee
+        if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # SHA-256 of lychee-v0.23.0 x86_64-unknown-linux-gnu.tar.gz
@@ -135,6 +149,7 @@ jobs:
           sudo mv lychee /usr/local/bin/lychee
           lychee --version
       - name: Check links
+        if: github.event_name != 'pull_request'
         run: |
           lychee \
             --config .lychee.toml \
@@ -150,7 +165,9 @@ jobs:
         run: npm run check:links
       - name: Run site tests
         run: bash scripts/test-site.sh
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: dist
           retention-days: 1
@@ -173,7 +190,12 @@ jobs:
 
   deploy:
     needs: [build, worker-csp]
+    # Never deploy from a PR — only on push to main (or a manual dispatch).
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,8 +1,6 @@
 name: Lighthouse CI
 
 on:
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -12,7 +10,7 @@ jobs:
   lighthouse:
     # Lighthouse runs on-demand only — run it locally with `npm run lighthouse`
     # (same config), or trigger this job manually via the Actions tab.
-    if: github.event_name == 'workflow_dispatch'
+    # PR validation (astro check, build, worker-csp, etc.) lives in deploy.yml.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -33,19 +31,3 @@ jobs:
           uploadArtifacts: false
           temporaryPublicStorage: true
           configPath: .github/lighthouse/lighthouserc.json
-
-  worker-csp:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: worker-csp/package-lock.json
-      - name: Install worker CSP dependencies
-        run: cd worker-csp && npm ci
-      - name: Run worker CSP tests
-        run: cd worker-csp && npm test
-      - name: Type check worker CSP
-        run: cd worker-csp && npx tsc --noEmit

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typecheck": "astro check",
     "validate": "node scripts/validate-content.js",
     "check": "astro check && eslint . && node scripts/validate-content.js",
+    "verify": "astro check && node scripts/validate-content.js && npm run build && bash scripts/test-site.sh && npm run check:links",
     "test:worker": "cd worker && npm test",
     "test:csp": "cd worker-csp && npm test && npx tsc --noEmit",
     "lighthouse": "lhci autorun --config=.github/lighthouse/lighthouserc.json --upload.target=filesystem --upload.outputDir=.lighthouseci"


### PR DESCRIPTION
## Why
Two E4 pagination PRs (#501, #502) broke main's deploy because the **entire** validation suite — `astro check`, content validation, build, size/img/jpg gates, worker tests, link checks, `test-site.sh` — ran only in `deploy.yml`'s `build` job, gated to `push:[main]`. A fully green PR could still break the deploy on merge. This closes that blind spot.

## Approach
Three engines (Codex / Agy / Hermes) independently converged on the **single-workflow PR-gate** pattern over reusable-workflow / composite-action (no DRY gain for a 2-job, single-contributor repo; avoids step drift and secret-passing ceremony).

**`deploy.yml`:**
- Add `pull_request` trigger (`types: [opened, synchronize, reopened]` — no closed/merged double-run).
- Per-PR concurrency lane (`pr-<n>`) so PR checks never block or cancel the `pages` deploy lane; deploys still never cancel.
- Gate deploy-only / secret-dependent steps to non-PR: GA4 fetch, CV checkout/copy, Pages artifact upload, and the whole `deploy` job. Fork PRs lack these secrets and the build falls back to defaults (same as local dev).
- **lychee** (external links) stays push-only — network-flaky, value is pre-deploy not pre-merge; `check:links` still covers same-origin links on every PR.
- Least privilege: `pages: write`/`id-token: write` moved to the `deploy` job; top-level is now `contents: read`.

**`lighthouse.yml`:** drop the duplicated `worker-csp` job (now runs on PRs via `deploy.yml`) and the `pull_request` trigger — Lighthouse stays dispatch-only.

**`package.json`:** add `npm run verify` (`astro check && validate-content && build && test-site.sh && check:links`) — the same deterministic gates, runnable locally pre-push. This is the real shift-left: it catches **both** breakages before they leave the laptop.

## What now runs on PRs
astro check · content validation · npm audit · build · size budget · no-raw-img · jpg-twin · worker tests · internal-link check · test-site.sh · worker-csp. (Deploy, GA4/CV secrets, lychee, Lighthouse stay main/dispatch-only.)

## Verified
- `actionlint` clean on both workflows.
- `npm run verify` exits 0 (astro check 0 errors, site tests PASS, 0 broken links).
- This PR is itself the first real exercise of the new PR gates.

After merge I'll update branch-protection required checks to `build` + `worker-csp` from this workflow.

https://claude.ai/code/session_01A1rKHZFSwxpSKMj6rABjoA