### PR TITLE
content(blog): fix 'An Agent in the Walls' series feed ordering

### DIFF
--- a/src/content/blog/dont-saw-off-the-branch-post.md
+++ b/src/content/blog/dont-saw-off-the-branch-post.md
@@ -1,7 +1,7 @@
 ---
 title: "Don't Saw Off the Branch"
 description: 'I let an AI agent rebuild my live home network over Starlink — no console, no documented API. Part 1: building three backout paths before a single write.'
-date: 2026-06-25
+date: 2026-06-25T12:00:00Z
 tags: ['engineering', 'networking', 'security', 'homelab', 'AI agents', 'Claude Code']
 series: 'An Agent in the Walls'
 seriesOrder: 1

--- a/src/content/blog/the-limits-of-the-walls-post.md
+++ b/src/content/blog/the-limits-of-the-walls-post.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Limits of the Walls'
 description: "Six sessions handing a live home network to an AI agent. Part 3: the memory that made it work, the division of labour, and what I'd never let it touch."
-date: 2026-06-25
+date: 2026-06-25T12:10:00Z
 tags: ['engineering', 'networking', 'security', 'homelab', 'AI agents', 'Claude Code']
 series: 'An Agent in the Walls'
 seriesOrder: 3

--- a/src/content/blog/there-is-no-api-post.md
+++ b/src/content/blog/there-is-no-api-post.md
@@ -1,7 +1,7 @@
 ---
 title: 'There Is No API'
 description: 'The router I was reconfiguring has no public API. Part 2: driving the private endpoints the web UI calls — and the wall the agent could not script past.'
-date: 2026-06-25
+date: 2026-06-25T12:05:00Z
 tags: ['engineering', 'networking', 'security', 'homelab', 'AI agents', 'Claude Code']
 series: 'An Agent in the Walls'
 seriesOrder: 2


### PR DESCRIPTION
## Problem
All three parts of *An Agent in the Walls* were published with `date: 2026-06-25` and **no time component**. Every listing (blog index, `[...page]` pagination, `rss.xml`) sorts newest-first (`b.date - a.date`); with identical dates the sort tied and fell back to filesystem/filename order, surfacing **Part 1 → Part 3 → Part 2** — the jumbled flow.

## Fix
Stamp each part 5 minutes apart at midday UTC, in publish order:

| Part | Title | Timestamp |
|------|-------|-----------|
| 1 | Don't Saw Off the Branch | `2026-06-25T12:00:00Z` |
| 2 | There Is No API | `2026-06-25T12:05:00Z` |
| 3 | The Limits of the Walls | `2026-06-25T12:10:00Z` |

Newest-first feed now reads **Part 3 → Part 2 → Part 1** top-to-bottom (newest part on top, standard blog chronology — confirmed direction with Adrian).

## Notes
- Midday-UTC times keep the displayed `25 Jun 2026` date stable regardless of build-server timezone.
- Per-post series nav already orders by `seriesOrder`, so it's unaffected.
- No `autopublish` flag on any post, and the autopublish workflow keys on git-*added* files, so this date edit won't re-broadcast to social.
- `validate-content.js`: 0 errors, 0 warnings.

https://claude.ai/code/session_01C5xs3VyWZ8w9DUyacB6tab