### PR TITLE
content(blog): autopublish drip on for 'An Agent in the Walls' series

### DIFF
--- a/src/content/blog/dont-saw-off-the-branch-post.md
+++ b/src/content/blog/dont-saw-off-the-branch-post.md
@@ -10,6 +10,7 @@ heroAlt: 'Dark botanical infographic: building independent backout paths and saf
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dont-saw-off-the-branch/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/dont-saw-off-the-branch/video.mp4'
 draft: false
+autopublish: true
 ---
 
 There's no fibre where I live. The internet arrives by satellite — a dish on the roof, a Starlink router in the hallway, and behind it a Ubiquiti Dream Router that does the actual work of being a network: the VLANs, the firewall, the Wi-Fi. The dish does not care that I want a segmented home network. It hands me one address and a lot of latency, and everything I build has to live downstream of that.

--- a/src/content/blog/the-limits-of-the-walls-post.md
+++ b/src/content/blog/the-limits-of-the-walls-post.md
@@ -10,6 +10,7 @@ heroAlt: 'Dark botanical infographic: the division of labour and the limits of h
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-limits-of-the-walls/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-limits-of-the-walls/video.mp4'
 draft: false
+autopublish: true
 ---
 
 By the end there were six sessions behind me, spread across a handful of days, and a home network that bore almost no resemblance to the flat one I'd started with. Segmented, firewalled, filtered, watched. And the part that stayed with me wasn't any single configuration change. It was the working relationship — the strange, specific experience of handing an AI agent write-access to the place I actually live, and watching it become genuinely good at the job.

--- a/src/content/blog/there-is-no-api-post.md
+++ b/src/content/blog/there-is-no-api-post.md
@@ -10,6 +10,7 @@ heroAlt: 'Dark botanical infographic: reverse-engineering an undocumented router
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/there-is-no-api/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/there-is-no-api/video.mp4'
 draft: false
+autopublish: true
 ---
 
 The request was simple to say out loud. Take a flat home network — one subnet, everything trusting everything — and turn it into a segmented one: an isolated VLAN for the smart-home gadgets, a filtered network for the kids, a real firewall between the zones. The kind of thing the router's marketing page promises you can do with a few clicks.


### PR DESCRIPTION
Flip autopublish:true on all three parts so the date-scheduled social queue picks them up.

Posts are dated 2026-06-25; the 09:00 AEST slot (23:00Z prev day) has already passed, so the hourly cron will broadcast all 9 entries (3 posts × facebook/bluesky/twitter) on its next tick.

Verified via `scripts/generate-social-queue.mjs --dry-run`: 9 queue entries, stable ids drip-<platform>-<slug>, videoUrl attached. No re-broadcast risk — these posts have never had autopublish set (confirmed via git history) and were not hand-posted to social.