### PR TITLE
fix(social): raise cron batch cap to 12 + run every 10 min for ordered series drip

### DIFF
--- a/.github/workflows/social-cron.yml
+++ b/.github/workflows/social-cron.yml
@@ -2,7 +2,7 @@ name: Social Cron
 
 on:
   schedule:
-    - cron: '15 * * * *'      # Publish: hourly at :15
+    - cron: '7,17,27,37,47,57 * * * *'  # Publish: every 10 min (offset avoids :00/:30 GH-Actions load; never lands on comments' :45)
     - cron: '45 */2 * * *'    # Comments: every 2 hours at :45
   workflow_dispatch:
     inputs:
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   publish:
-    if: (github.event_name == 'workflow_dispatch' && github.event.inputs.endpoint == 'publish') || github.event.schedule == '15 * * * *'
+    if: (github.event_name == 'workflow_dispatch' && github.event.inputs.endpoint == 'publish') || github.event.schedule == '7,17,27,37,47,57 * * * *'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger publish cron
@@ -28,7 +28,7 @@ jobs:
             "${SOCIAL_WORKER_URL}/api/cron/publish" \
             -H "Authorization: Bearer ${SOCIAL_CRON_SECRET}" \
             -H "Content-Type: application/json" \
-            --max-time 30)
+            --max-time 300)
           HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
           BODY=$(echo "$RESPONSE" | sed '$d')
           echo "HTTP status: $HTTP_CODE"

--- a/worker/src/__tests__/publish.test.ts
+++ b/worker/src/__tests__/publish.test.ts
@@ -229,13 +229,13 @@ describe('POST /api/cron/publish', () => {
     expect(mockPublishPost).not.toHaveBeenCalled();
   });
 
-  it('processes due posts oldest-first, max 5 from 7 queued', async () => {
+  it('processes due posts oldest-first, max 12 from 14 queued', async () => {
     const kv = mockKV();
     mockDebugAuth.mockResolvedValueOnce(healthyToken);
     mockPublishPost.mockResolvedValue({ success: true, platformPostId: 'fb_post_id', isTransient: false, isAuthError: false });
 
-    // Create 7 queued posts with distinct epochs (oldest first = smallest epoch)
-    const posts = Array.from({ length: 7 }, (_, i) => makePost(`p${i + 1}`, -(i + 1) * 1000));
+    // Create 14 queued posts with distinct epochs (oldest first = smallest epoch)
+    const posts = Array.from({ length: 14 }, (_, i) => makePost(`p${i + 1}`, -(i + 1) * 1000));
     const keys = posts.map(p => ({ name: `post:queued:${p.scheduledAtEpoch}:${p.id}` }));
 
     for (const p of posts) {
@@ -249,9 +249,9 @@ describe('POST /api/cron/publish', () => {
     const res = await app.fetch(cronRequest(), makeEnv(kv));
     expect(res.status).toBe(200);
     const body = await res.json() as Record<string, unknown>;
-    expect(body.published).toBe(5);
+    expect(body.published).toBe(12);
     expect(body.remaining).toBe(2);
-    expect(mockPublishPost).toHaveBeenCalledTimes(5);
+    expect(mockPublishPost).toHaveBeenCalledTimes(12);
   });
 
   it('skips posts with existing idempotency records and cleans queued key', async () => {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -452,7 +452,16 @@ app.post('/api/cron/publish', async (c) => {
     // `post:publishing:` orphan in place rather than risk double-publishing.
     let orphanedAfterSuccess = 0;
 
-    for (const { key, post } of processable.slice(0, 5)) {
+    // Batch cap per cron run. Sized for a multi-part series × 3 platforms (a
+    // 3-part series = 9 entries) with headroom, so a same-day-staggered series
+    // publishes in one ordered run instead of splintering across hours. The
+    // work is I/O-bound (CDN video fetch + platform upload; Bluesky polls up to
+    // 25s but that's fetch wait, not CPU), so a 12-post run stays well under
+    // the Workers Paid fetch CPU limit. The caller (social-cron.yml) sets
+    // --max-time to outlast a full batch so curl doesn't drop the connection
+    // and abort the run mid-publish.
+    const CRON_PUBLISH_BATCH_CAP = 12;
+    for (const { key, post } of processable.slice(0, CRON_PUBLISH_BATCH_CAP)) {
       // C1 — Per-post publish lock. The cron run and an ad-hoc /api/publish call
       // can race on the same post.id (e.g. a manual retry triggered while cron
       // is mid-run). /api/publish takes `publish:<idempotencyKey>` where the
@@ -579,7 +588,7 @@ app.post('/api/cron/publish', async (c) => {
       }
     }
 
-    const remaining = Math.max(0, processable.length - 5) + skippedBlocked.length;
+    const remaining = Math.max(0, processable.length - CRON_PUBLISH_BATCH_CAP) + skippedBlocked.length;
     if (remaining > 10) console.error(`Post queue backlog: ${remaining}`);
     else if (remaining > 0) console.warn(`${remaining} posts still queued`);
 


### PR DESCRIPTION
Follow-up to #509. The generator now reads the minutes, but the worker cron ran hourly with a 5-post-per-run cap, so a 9-entry series (3 parts × 3 platforms) splintered 5+4 across two hours with platform interleaving — parts landed out of sync across FB/Bluesky/Twitter.

**Changes:**
- `worker/src/index.ts`: raise `CRON_PUBLISH_BATCH_CAP` 5 → 12 (named constant, used in both the slice and the backlog calc). A 9-entry series now publishes in one ordered run (Part 1/2/3 per platform). Safe on Workers Paid — the work is I/O-bound (video fetch + upload; Bluesky polls up to 25s but that's fetch wait, not CPU), well under the per-fetch CPU limit. Confirmed via Cloudflare docs.
- `social-cron.yml`: publish cron hourly → every 10 min (offset `7,17,27,37,47,57`), so posts land within ~10 min of their stamped time. `if` condition updated to match.
- `social-cron.yml`: publish job `curl --max-time` 30 → 300, so a full 12-post batch (~4 min I/O) doesn't drop the connection and abort the worker mid-publish (which would strand a post in `post:publishing:` with no `idempotent:` record).

**Tests:** updated the cap test (14 queued → 12 published, 2 remaining). All 162 worker tests pass. `wrangler deploy --dry-run` clean.

**⚠️ Needs a manual worker deploy:** the cap change is in worker code and only takes effect after `cd worker && npx wrangler deploy` (per the manual-deploy pattern). The cron + max-time changes are workflow-only and live on merge. Until the worker deploys, the cap stays 5 and the 9 entries would still splinter (now every 10 min instead of hourly).