### PR TITLE
fix(social): attach infographic card + fire Agent-in-the-Walls series

### DIFF
--- a/scripts/generate-social-queue.mjs
+++ b/scripts/generate-social-queue.mjs
@@ -104,6 +104,14 @@ for (const { file, kind, fm } of [...collect('blog', 'blog'), ...collect('projec
     ? `New project: ${fm.title}\n\n${fm.description ?? ''}\n\n${url}`
     : `${fm.title}\n\n${fm.description ?? ''}\n\n${url}`;
   const imageUrl = resolveImage(fm.heroImage);
+  // Prefer the .jpg twin as the social card — FB Graph /photos and Twitter
+  // v1.1 media/upload are unreliable with .webp; the CI gate guarantees a .jpg
+  // twin for every .webp heroImage.
+  let socialImageUrl = imageUrl;
+  if (imageUrl && imageUrl.endsWith('.webp')) {
+    const twin = fm.heroImage.replace(/\.webp$/, '.jpg');
+    if (existsSync(join(ROOT, 'public', twin))) socialImageUrl = `${SITE}${twin}`;
+  }
   const videoUrl = fm.videoUrl ?? fm.notebookAssets?.videoUrl;
 
   for (const platform of PLATFORMS) {
@@ -112,7 +120,11 @@ for (const { file, kind, fm } of [...collect('blog', 'blog'), ...collect('projec
       platform,
       type: 'text',
       message,
-      ...(videoUrl ? { videoUrl } : imageUrl ? { imageUrl } : {}),
+      // Worker can't deliver NLM-sized videos (FB no video path; Twitter image-only
+      // ≤5MB; Bluesky ≤20MB; NLM videos are 30-100MB) — attach the infographic as
+      // the card and drop the undeliverable videoUrl. FB renders the link card via
+      // og:image on type:'text' (ignores imageUrl).
+      ...(socialImageUrl ? { imageUrl: socialImageUrl } : videoUrl ? { videoUrl } : {}),
       scheduledAt,
       scheduledAtEpoch: epoch,
     });

--- a/social/facebook-posts.json
+++ b/social/facebook-posts.json
@@ -1,6 +1,88 @@
 {
   "version": 1,
-  "description": "Facebook post queue — seed input for scheduled content (KV is authoritative for state)",
+  "description": "Date-scheduled social queue — generated from content by scripts/generate-social-queue.mjs (KV authoritative for state)",
   "pageId": "35753603727",
-  "posts": []
+  "posts": [
+    {
+      "id": "drip-facebook-dont-saw-off-the-branch",
+      "platform": "facebook",
+      "type": "text",
+      "message": "Don't Saw Off the Branch\n\nI let an AI agent rebuild my live home network over Starlink — no console, no documented API. Part 1: building three backout paths before a single write.\n\nhttps://adrianwedd.com/blog/dont-saw-off-the-branch/",
+      "imageUrl": "https://adrianwedd.com/notebook-assets/dont-saw-off-the-branch/infographic.jpg",
+      "scheduledAt": "2026-06-25T02:00:00.000Z",
+      "scheduledAtEpoch": 1782352800000
+    },
+    {
+      "id": "drip-bluesky-dont-saw-off-the-branch",
+      "platform": "bluesky",
+      "type": "text",
+      "message": "Don't Saw Off the Branch\n\nI let an AI agent rebuild my live home network over Starlink — no console, no documented API. Part 1: building three backout paths before a single write.\n\nhttps://adrianwedd.com/blog/dont-saw-off-the-branch/",
+      "imageUrl": "https://adrianwedd.com/notebook-assets/dont-saw-off-the-branch/infographic.jpg",
+      "scheduledAt": "2026-06-25T02:00:00.000Z",
+      "scheduledAtEpoch": 1782352800000
+    },
+    {
+      "id": "drip-twitter-dont-saw-off-the-branch",
+      "platform": "twitter",
+      "type": "text",
+      "message": "Don't Saw Off the Branch\n\nI let an AI agent rebuild my live home network over Starlink — no console, no documented API. Part 1: building three backout paths before a single write.\n\nhttps://adrianwedd.com/blog/dont-saw-off-the-branch/",
+      "imageUrl": "https://adrianwedd.com/notebook-assets/dont-saw-off-the-branch/infographic.jpg",
+      "scheduledAt": "2026-06-25T02:00:00.000Z",
+      "scheduledAtEpoch": 1782352800000
+    },
+    {
+      "id": "drip-facebook-there-is-no-api",
+      "platform": "facebook",
+      "type": "text",
+      "message": "There Is No API\n\nThe router I was reconfiguring has no public API. Part 2: driving the private endpoints the web UI calls — and the wall the agent could not script past.\n\nhttps://adrianwedd.com/blog/there-is-no-api/",
+      "imageUrl": "https://adrianwedd.com/notebook-assets/there-is-no-api/infographic.jpg",
+      "scheduledAt": "2026-06-25T02:05:00.000Z",
+      "scheduledAtEpoch": 1782353100000
+    },
+    {
+      "id": "drip-bluesky-there-is-no-api",
+      "platform": "bluesky",
+      "type": "text",
+      "message": "There Is No API\n\nThe router I was reconfiguring has no public API. Part 2: driving the private endpoints the web UI calls — and the wall the agent could not script past.\n\nhttps://adrianwedd.com/blog/there-is-no-api/",
+      "imageUrl": "https://adrianwedd.com/notebook-assets/there-is-no-api/infographic.jpg",
+      "scheduledAt": "2026-06-25T02:05:00.000Z",
+      "scheduledAtEpoch": 1782353100000
+    },
+    {
+      "id": "drip-twitter-there-is-no-api",
+      "platform": "twitter",
+      "type": "text",
+      "message": "There Is No API\n\nThe router I was reconfiguring has no public API. Part 2: driving the private endpoints the web UI calls — and the wall the agent could not script past.\n\nhttps://adrianwedd.com/blog/there-is-no-api/",
+      "imageUrl": "https://adrianwedd.com/notebook-assets/there-is-no-api/infographic.jpg",
+      "scheduledAt": "2026-06-25T02:05:00.000Z",
+      "scheduledAtEpoch": 1782353100000
+    },
+    {
+      "id": "drip-facebook-the-limits-of-the-walls",
+      "platform": "facebook",
+      "type": "text",
+      "message": "The Limits of the Walls\n\nSix sessions handing a live home network to an AI agent. Part 3: the memory that made it work, the division of labour, and what I'd never let it touch.\n\nhttps://adrianwedd.com/blog/the-limits-of-the-walls/",
+      "imageUrl": "https://adrianwedd.com/notebook-assets/the-limits-of-the-walls/infographic.jpg",
+      "scheduledAt": "2026-06-25T02:10:00.000Z",
+      "scheduledAtEpoch": 1782353400000
+    },
+    {
+      "id": "drip-bluesky-the-limits-of-the-walls",
+      "platform": "bluesky",
+      "type": "text",
+      "message": "The Limits of the Walls\n\nSix sessions handing a live home network to an AI agent. Part 3: the memory that made it work, the division of labour, and what I'd never let it touch.\n\nhttps://adrianwedd.com/blog/the-limits-of-the-walls/",
+      "imageUrl": "https://adrianwedd.com/notebook-assets/the-limits-of-the-walls/infographic.jpg",
+      "scheduledAt": "2026-06-25T02:10:00.000Z",
+      "scheduledAtEpoch": 1782353400000
+    },
+    {
+      "id": "drip-twitter-the-limits-of-the-walls",
+      "platform": "twitter",
+      "type": "text",
+      "message": "The Limits of the Walls\n\nSix sessions handing a live home network to an AI agent. Part 3: the memory that made it work, the division of labour, and what I'd never let it touch.\n\nhttps://adrianwedd.com/blog/the-limits-of-the-walls/",
+      "imageUrl": "https://adrianwedd.com/notebook-assets/the-limits-of-the-walls/infographic.jpg",
+      "scheduledAt": "2026-06-25T02:10:00.000Z",
+      "scheduledAtEpoch": 1782353400000
+    }
+  ]
 }

--- a/src/content/blog/dont-saw-off-the-branch-post.md
+++ b/src/content/blog/dont-saw-off-the-branch-post.md
@@ -1,7 +1,7 @@
 ---
 title: "Don't Saw Off the Branch"
 description: 'I let an AI agent rebuild my live home network over Starlink — no console, no documented API. Part 1: building three backout paths before a single write.'
-date: 2026-06-25T12:00:00Z
+date: 2026-06-25T12:00:00+10:00
 tags: ['engineering', 'networking', 'security', 'homelab', 'AI agents', 'Claude Code']
 series: 'An Agent in the Walls'
 seriesOrder: 1

--- a/src/content/blog/the-limits-of-the-walls-post.md
+++ b/src/content/blog/the-limits-of-the-walls-post.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Limits of the Walls'
 description: "Six sessions handing a live home network to an AI agent. Part 3: the memory that made it work, the division of labour, and what I'd never let it touch."
-date: 2026-06-25T12:10:00Z
+date: 2026-06-25T12:10:00+10:00
 tags: ['engineering', 'networking', 'security', 'homelab', 'AI agents', 'Claude Code']
 series: 'An Agent in the Walls'
 seriesOrder: 3

--- a/src/content/blog/there-is-no-api-post.md
+++ b/src/content/blog/there-is-no-api-post.md
@@ -1,7 +1,7 @@
 ---
 title: 'There Is No API'
 description: 'The router I was reconfiguring has no public API. Part 2: driving the private endpoints the web UI calls — and the wall the agent could not script past.'
-date: 2026-06-25T12:05:00Z
+date: 2026-06-25T12:05:00+10:00
 tags: ['engineering', 'networking', 'security', 'homelab', 'AI agents', 'Claude Code']
 series: 'An Agent in the Walls'
 seriesOrder: 2


### PR DESCRIPTION
## What

Fires the 3-part "An Agent in the Walls" series to social (FB / Bluesky / Twitter, 9 posts total) with the infographic as a visual card, and corrects the stamps so they fire on the next cron tick after merge.

## Why

Two problems found while wiring the fire:

**1. The videos can't be delivered by the worker** (checked each platform's code + file sizes):
- `facebook.ts` — no video path; `videoUrl` ignored.
- `twitter.ts` — `media/upload` is image-only, ≤5 MB.
- `bluesky.ts` — has a video path but caps at 20 MB (CF Worker outgoing-request limit). The series videos are **56 / 49 / 38 MB**.

So the queue's `videoUrl` was dead weight: FB/Twitter posted text+link with no media, and Bluesky's `uploadVideo` returned null → bare text+URL (no card, since Bluesky doesn't auto-scrape `og:image`).

**2. The stamps were `12:00:00Z` = 22:00 AEST tonight**, not noon AEST today as intended — the `Z` suffix was an unintended UTC encoding of a local-noon intent. Noon AEST had already passed with nothing posted.

## Changes

- `scripts/generate-social-queue.mjs` — emit the heroImage's `.jpg` twin as `imageUrl` instead of the undeliverable `videoUrl` (FB Graph `/photos` and Twitter v1.1 `media/upload` are unreliable with `.webp`; the CI gate guarantees a `.jpg` twin for every `.webp` heroImage). FB keeps `type:"text"` and renders the link card via `og:image`; Twitter and Bluesky attach the `.jpg` as an image embed.
- 3 series posts — `date: 12:00:00Z` → `12:00:00+10:00` (noon AEST today, now past).
- `social/facebook-posts.json` — regenerated seed (was `[]`; the autopublish workflow regenerates in CI but doesn't commit back, so it had drifted empty).

## Fire sequence

merge → `social-autopublish.yml` regenerates the queue + POSTs `/api/queue/sync` → KV updates the 9 existing entries (same `drip-<platform>-<slug>` ids; idempotency records are absent — the series was never hand-posted) → next 10-min cron tick (`social-cron.yml`, cap-12, `--max-time 300`) fires all 9 in one ordered run.

Verified: dry-run produces 9 entries with `.jpg` imageUrl, stamps `02:00/02:05/02:10Z`; `.jpg` twins are live on adrianwedd.com (image/jpeg, ~600-680 KB, under the 5 MB cap); `npm run build` passes; `datePublished` renders `2026-06-25T02:00:00.000Z`.

## Out of scope

YouTube upload of the 3 videos is a separate follow-up — the OAuth token is dead (`invalid_grant`, revoked in the incident rotations) and needs a fresh consent flow before the uploader can run.