### PR TITLE
content(blog): YouTube URLs for 'An Agent in the Walls' series

### DIFF
--- a/scripts/youtube-reauth.py
+++ b/scripts/youtube-reauth.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+Re-authenticate the YouTube OAuth token (the upload script only refreshes an
+existing token; when the refresh grant is dead — e.g. after an incident token
+rotation — run this to do a fresh consent flow and write a new token).
+
+Opens a browser for consent. The token is written to
+~/.config/adrianwedd/youtube-token.json, where upload-videos-to-youtube.py
+and update-youtube-descriptions.py read it.
+
+Usage:
+  python3 scripts/youtube-reauth.py
+"""
+from pathlib import Path
+from google_auth_oauthlib.flow import InstalledAppFlow
+
+CLIENT_PATH = Path.home() / '.config/adrianwedd/youtube-oauth-client.json'
+TOKEN_PATH = Path.home() / '.config/adrianwedd/youtube-token.json'
+SCOPES = [
+    'https://www.googleapis.com/auth/youtube.upload',
+    'https://www.googleapis.com/auth/youtube',
+]
+EXPECTED_CHANNEL = 'UC709-RgQ-IMi-GffU9guqUQ'  # @adrianwedd — verify the chooser hits THIS one
+
+if not CLIENT_PATH.exists():
+    raise SystemExit(f'Missing OAuth client: {CLIENT_PATH}')
+
+flow = InstalledAppFlow.from_client_secrets_file(str(CLIENT_PATH), SCOPES)
+creds = flow.run_local_server(port=0, access_type='offline', prompt='consent')
+
+TOKEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+TOKEN_PATH.write_text(creds.to_json())
+TOKEN_PATH.chmod(0o600)
+print(f'Wrote token to {TOKEN_PATH}')
+print('Consent in the browser MUST have been for the @adrianwedd channel '
+      f'({EXPECTED_CHANNEL}); the OAuth chooser has known decoy accounts. '
+      'Verify with: python3 scripts/upload-videos-to-youtube.py --dry-run')

--- a/src/content/blog/dont-saw-off-the-branch-post.md
+++ b/src/content/blog/dont-saw-off-the-branch-post.md
@@ -11,6 +11,7 @@ audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/dont-saw-off-the-branch/au
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/dont-saw-off-the-branch/video.mp4'
 draft: false
 autopublish: true
+youtubeUrl: 'https://www.youtube.com/watch?v=jbncR2gDUkE'
 ---
 
 There's no fibre where I live. The internet arrives by satellite — a dish on the roof, a Starlink router in the hallway, and behind it a Ubiquiti Dream Router that does the actual work of being a network: the VLANs, the firewall, the Wi-Fi. The dish does not care that I want a segmented home network. It hands me one address and a lot of latency, and everything I build has to live downstream of that.

--- a/src/content/blog/the-limits-of-the-walls-post.md
+++ b/src/content/blog/the-limits-of-the-walls-post.md
@@ -11,6 +11,7 @@ audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-limits-of-the-walls/au
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-limits-of-the-walls/video.mp4'
 draft: false
 autopublish: true
+youtubeUrl: 'https://www.youtube.com/watch?v=9Wbe_7P9K78'
 ---
 
 By the end there were six sessions behind me, spread across a handful of days, and a home network that bore almost no resemblance to the flat one I'd started with. Segmented, firewalled, filtered, watched. And the part that stayed with me wasn't any single configuration change. It was the working relationship — the strange, specific experience of handing an AI agent write-access to the place I actually live, and watching it become genuinely good at the job.

--- a/src/content/blog/there-is-no-api-post.md
+++ b/src/content/blog/there-is-no-api-post.md
@@ -11,6 +11,7 @@ audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/there-is-no-api/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/there-is-no-api/video.mp4'
 draft: false
 autopublish: true
+youtubeUrl: 'https://www.youtube.com/watch?v=lCQuTd2DbPc'
 ---
 
 The request was simple to say out loud. Take a flat home network — one subnet, everything trusting everything — and turn it into a segmented one: an isolated VLAN for the smart-home gadgets, a filtered network for the kids, a real firewall between the zones. The kind of thing the router's marketing page promises you can do with a few clicks.


### PR DESCRIPTION
## What

The 3 *An Agent in the Walls* videos are uploaded to YouTube (`@adrianwedd`, channel `UC709-RgQ-IMi-GffU9guqUQ`) and added to the `adrianwedd.com` playlist. This writes their `youtubeUrl` into frontmatter so the blog posts link to them.

| Part | Video |
|---|---|
| 1 — Don't Saw Off the Branch | https://www.youtube.com/watch?v=jbncR2gDUkE |
| 2 — There Is No API | https://www.youtube.com/watch?v=lCQuTd2DbPc |
| 3 — The Limits of the Walls | https://www.youtube.com/watch?v=9Wbe_7P9K78 |

All uploads verified via the Data API to be on `UC709` (not a decoy) and `public`. The signoff sting was already baked into the local/R2 copies, so no re-encode.

## Also included

`scripts/youtube-reauth.py` — the turnkey OAuth re-consent flow for when the upload token's refresh grant is dead (e.g. after an incident password rotation). The previous client (project `ga4-adrianwedddotcom`, consent screen mislabeled "book-api") was an External/unverified app that **Workspace blocked** for the `adrian@adrianwedd.com` account. This pairs with a new **Internal** OAuth client in the `adrianwedd.com` Cloud org (project `adrianwedd-youtube-uploader`) that bypasses the block entirely (no verification, no app-access-control trust-list needed).

Client credentials are stored in **1Password** (Environment `adrianwedd-youtube-uploader`) and at `~/.config/adrianwedd/youtube-oauth-client.json` — **not** in the repo. The script contains no secrets.

## Verification

- [x] Token resolves to `UC709-RgQ-IMi-GffU9guqUQ` (verified `channels().list(mine=True)`)
- [x] All 3 videos confirmed on `UC709` + `public` via `videos().list`
- [x] All 3 added to playlist `PLHCs2hYaGLAk4qe5za7rAh2j4YHRKdJXo`
- [x] `youtubeUrl` written to all 3 frontmatters