### PR TITLE
feat(security): sprint 37 close-out — security.txt, CSP report analysis + GA4 fixes

### DIFF
--- a/docs/ROADMAP-2026-H2.md
+++ b/docs/ROADMAP-2026-H2.md
@@ -25,10 +25,10 @@ Goal: make `main`, the deployed workers, and the branch list agree with reality.
 
 Goal: check every box in #473 that doesn't depend on external parties.
 
-- [ ] Cloudflare rate-limit rule on `social.adrianwedd.com/api/*` (per `worker/docs/rate-limiting.md`, #493) — apply in dashboard, verify with a burst test
-- [ ] First analysis of collected CSP Report-Only data (#497 collector); fix genuine violations; write the enforce-flip criteria
+- [ ] Cloudflare rate-limit rule on `social.adrianwedd.com/api/*` (per `worker/docs/rate-limiting.md`, #493) — apply in dashboard, verify with a burst test _(verified absent on the zone 2026-07-03; API token lacks WAF write, so dashboard it is)_
+- [x] First analysis of collected CSP Report-Only data (#497 collector); fix genuine violations; write the enforce-flip criteria — `worker-csp/docs/csp-report-analysis-2026-07-03.md`; two GA4 gaps fixed in `csp.ts`, live on next manual `wrangler deploy`
 - [ ] Meta-CSP fallback fix in `SEOHead.astro` (`'unsafe-inline'` on the worker-bypass path) — **needs Adrian's pick** of the three documented tradeoffs (hashes vs drop vs origin lock)
-- [ ] `/.well-known/security.txt` if absent (SECURITY.md exists; the machine-readable twin may not)
+- [x] `/.well-known/security.txt` if absent (SECURITY.md exists; the machine-readable twin may not) — added, expires 2027-07-01
 
 **Exit:** #473 High section fully checked; CSP report pipeline observed with real traffic; enforce-flip date set.
 
@@ -86,7 +86,7 @@ Goal: full asset coverage and a one-command video path.
 - [ ] The 4 flagged sub-256k NLM-native audio takes — **needs Adrian's re-roll-or-accept call**, then action it
 - [ ] YouTube upload automation: script + checklist (3s signoff sting concat with `-c copy`, channel-identity verification step)
 - [ ] Audio RSS enclosure audit (enclosure URLs, durations, MIME types across the audio collection feed)
-- [ ] *(Gated on AI Studio credits)* Index suite render: apex track + the unpaired 06+02
+- [ ] _(Gated on AI Studio credits)_ Index suite render: apex track + the unpaired 06+02
 
 **Exit:** no published content missing its kit; YouTube publish is one command; index suite rendered or still explicitly credit-gated.
 
@@ -140,7 +140,7 @@ Goal: finish the 2026-06-15 email-security sweep's tail and close the H2 arc.
 
 - [ ] DS records at registrars for the 7 external domains (manual: GoDaddy/Porkbun/.ch)
 - [ ] MTA-STS `testing` → `enforce` flip (after a clean TLS-RPT window)
-- [ ] *(Gated on Google Workspace recovery)* rotate the 1024-bit Google DKIM key
+- [ ] _(Gated on Google Workspace recovery)_ rotate the 1024-bit Google DKIM key
 - [ ] Secret-rotation runbook: worker secrets, GH PATs, GA4 service-account key — schedule + procedure
 - [ ] Close #473; H2 retro; draft the next roadmap
 
@@ -150,13 +150,13 @@ Goal: finish the 2026-06-15 email-security sweep's tail and close the H2 arc.
 
 ## Decisions Adrian owes (blocking specific items, not sprints)
 
-| Decision | Blocks | Sprint |
-|----------|--------|--------|
-| Meta-CSP approach (hashes / drop / origin lock — 3 tradeoffs documented) | SEOHead fallback fix | S37 |
-| the-tell / the-recital: renumber or cut | Draft publication | S40 |
-| 4 sub-256k audio takes: re-roll or accept | Audio coverage closure | S42 |
-| FB token alert channel beyond GitHub issues | Alerting design | S39 |
-| Dependabot auto-merge policy sign-off | Auto-merge enablement | S36 |
+| Decision                                                                 | Blocks                 | Sprint |
+| ------------------------------------------------------------------------ | ---------------------- | ------ |
+| Meta-CSP approach (hashes / drop / origin lock — 3 tradeoffs documented) | SEOHead fallback fix   | S37    |
+| the-tell / the-recital: renumber or cut                                  | Draft publication      | S40    |
+| 4 sub-256k audio takes: re-roll or accept                                | Audio coverage closure | S42    |
+| FB token alert channel beyond GitHub issues                              | Alerting design        | S39    |
+| Dependabot auto-merge policy sign-off                                    | Auto-merge enablement  | S36    |
 
 ## Externally gated
 

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,7 @@
+# Security policy for adrianwedd.com — machine-readable twin of SECURITY.md
+# https://github.com/adrianwedd/adrianwedd.com/blob/main/SECURITY.md
+Contact: mailto:adrian@adrianwedd.com
+Expires: 2027-07-01T00:00:00.000Z
+Policy: https://github.com/adrianwedd/adrianwedd.com/blob/main/SECURITY.md
+Canonical: https://adrianwedd.com/.well-known/security.txt
+Preferred-Languages: en

--- a/worker-csp/docs/csp-report-analysis-2026-07-03.md
+++ b/worker-csp/docs/csp-report-analysis-2026-07-03.md
@@ -1,0 +1,53 @@
+# CSP Report-Only analysis — 2026-07-03
+
+First analysis of violation reports collected by the `/__csp-report` endpoint
+(#497 collector), per Sprint 37 / #473. Tracked here so the enforce-flip
+decision has a written baseline.
+
+## Data window
+
+Workers Logs (`[observability]` on `adrianwedd-csp`) queried 2026-07-03 via
+`POST /accounts/{id}/workers/observability/telemetry/query`, filter
+`$metadata.service = adrianwedd-csp` + message `csp-violation`.
+
+- **3 reports** in the retention window, all 2026-06-30, all from a single
+  real visitor (iOS 18.7, Firefox for iOS 152).
+- Query quirk: a 7-day window returned 0 events while a 72-hour window
+  returned 3 (same filters, same day). Query narrow windows and widen
+  stepwise; don't trust a single wide-window zero.
+
+## Findings — both genuine, both fixed
+
+The Report-Only header mirrors the enforced policy exactly, so every
+`disposition: report` entry is also a request the **enforced** policy silently
+blocked in production. Both findings are consented-GA4 data loss, not attacks:
+
+| #    | Directive     | Blocked URL                                     | Cause                                                                                                                                              | Fix (csp.ts)                                                               |
+| ---- | ------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| 1    | `connect-src` | `https://www.google.com/g/collect?...`          | gtag sends `/g/collect` beacons to `www.google.com` when ad-signal features are active; host was in `script-src`/`frame-src` but not `connect-src` | added `https://www.google.com` to `connect-src`                            |
+| 2 ×2 | `img-src`     | `https://stats.g.doubleclick.net/g/collect?...` | gtag image-pixel fallback; `connect-src` trusted `*.g.doubleclick.net` but `img-src` only listed `googleads.g.doubleclick.net`                     | widened `img-src` to `https://*.g.doubleclick.net` (matches `connect-src`) |
+
+Both traced to `sourceFile: https://www.googletagmanager.com/gtag/js?id=G-ET0FJJS7C7`.
+No violations implicating site code (nonce misses, VT-injected scripts/styles,
+Pagefind WASM, Turnstile) — the core policy is holding.
+
+## Enforce-flip criteria
+
+The enforced CSP has been live all along; the "flip" that remains is moving
+the reporting directives onto the **enforced** policy and retiring the
+Report-Only mirror (it duplicates a ~2 KB header on every HTML response).
+Flip when both hold:
+
+1. The two fixes above are deployed (`wrangler deploy` of worker-csp — manual).
+2. **14 consecutive days** of Report-Only data show zero violations, ignoring
+   browser-extension noise (`moz-extension://`, `chrome-extension://`,
+   `blockedURL: inline` with an extension `sourceFile`).
+
+Then: pass `reporting` to the enforced `buildCsp()` call in
+`src/index.ts`, drop the Report-Only header, keep the collector and the
+`Reporting-Endpoints` header. Violations keep flowing with
+`disposition: enforce`.
+
+Ongoing cadence after the flip: re-run this query after adding any new
+third-party embed, and otherwise monthly. Retention is short — export
+anything you want to keep the same week.

--- a/worker-csp/src/csp.ts
+++ b/worker-csp/src/csp.ts
@@ -57,8 +57,14 @@ export function buildCsp(opts: {
     "style-src 'self' 'unsafe-inline'",
     // GA4 audience pixels use country-specific google TLDs (e.g. google.com.au).
     // ep1/ep2.adtrafficquality.google serve the sodar tracking pixel as an image.
-    "img-src 'self' data: https://cdn.adrianwedd.com https://www.google-analytics.com https://*.google-analytics.com https://*.ads.linkedin.com https://www.googletagmanager.com https://*.tile.openstreetmap.org https://tpc.googlesyndication.com https://googleads.g.doubleclick.net https://www.linkedin.com https://www.google.com.au https://ep1.adtrafficquality.google https://ep2.adtrafficquality.google",
-    "connect-src 'self' https://*.google-analytics.com https://analytics.google.com https://*.g.doubleclick.net https://adservice.google.com https://ep1.adtrafficquality.google https://ep2.adtrafficquality.google https://snap.licdn.com https://*.ads.linkedin.com https://pagead2.googlesyndication.com https://api.book.adrianwedd.com https://api.github.com https://cdn.adrianwedd.com https://ops.adrianwedd.com https://challenges.cloudflare.com",
+    // *.g.doubleclick.net (not just googleads.): gtag falls back to an image
+    // pixel on stats.g.doubleclick.net — observed blocked in CSP reports, and
+    // connect-src already trusts the same wildcard.
+    "img-src 'self' data: https://cdn.adrianwedd.com https://www.google-analytics.com https://*.google-analytics.com https://*.ads.linkedin.com https://www.googletagmanager.com https://*.tile.openstreetmap.org https://tpc.googlesyndication.com https://*.g.doubleclick.net https://www.linkedin.com https://www.google.com.au https://ep1.adtrafficquality.google https://ep2.adtrafficquality.google",
+    // www.google.com in connect-src: gtag sends /g/collect beacons there when
+    // ad-signal features are active — observed blocked in CSP reports; the host
+    // is already trusted in script-src and frame-src.
+    "connect-src 'self' https://*.google-analytics.com https://analytics.google.com https://*.g.doubleclick.net https://adservice.google.com https://www.google.com https://ep1.adtrafficquality.google https://ep2.adtrafficquality.google https://snap.licdn.com https://*.ads.linkedin.com https://pagead2.googlesyndication.com https://api.book.adrianwedd.com https://api.github.com https://cdn.adrianwedd.com https://ops.adrianwedd.com https://challenges.cloudflare.com",
     "media-src 'self' https://cdn.adrianwedd.com",
     'frame-src https://www.openstreetmap.org https://challenges.cloudflare.com https://www.google.com https://tpc.googlesyndication.com https://googleads.g.doubleclick.net https://ep2.adtrafficquality.google',
     "font-src 'self'",

--- a/worker-csp/test/index.test.ts
+++ b/worker-csp/test/index.test.ts
@@ -5,8 +5,7 @@ import { generateNonce } from '../src/nonce.js';
 
 afterEach(() => vi.restoreAllMocks());
 
-const htmlBody = (body: string) =>
-  `<!doctype html><html><head>${body}</head><body></body></html>`;
+const htmlBody = (body: string) => `<!doctype html><html><head>${body}</head><body></body></html>`;
 
 // vitest-pool-workers 0.16 removed fetchMock from cloudflare:test; the
 // upstream origin fetch is mocked by spying on globalThis.fetch instead.
@@ -22,9 +21,7 @@ function mockOrigin(...routes: MockRoute[]) {
   vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
     const request = new Request(input as RequestInfo, init);
     const url = new URL(request.url);
-    const route = routes.find(
-      (r) => url.origin === 'https://adrianwedd.com' && url.pathname === r.path
-    );
+    const route = routes.find((r) => url.origin === 'https://adrianwedd.com' && url.pathname === r.path);
     if (!route) throw new Error(`No mock for ${request.method} ${request.url}`);
     return new Response(route.body, { status: route.status ?? 200, headers: route.headers });
   });
@@ -106,6 +103,17 @@ describe('buildCsp', () => {
     expect(csp).toMatch(/report-uri https:\/\/adrianwedd\.com\/__csp-report/);
   });
 
+  it('allows GA4 beacon fallbacks observed in CSP reports (www.google.com connect, *.g.doubleclick.net img)', () => {
+    // Live Report-Only data (2026-06-30) showed gtag beacons blocked in
+    // production: /g/collect on www.google.com (connect-src) and the image
+    // pixel on stats.g.doubleclick.net (img-src).
+    const csp = buildCsp({ nonce: 'x', strictDynamic: false });
+    const connectSrc = csp.split(';').find((d) => d.trim().startsWith('connect-src'))!;
+    const imgSrc = csp.split(';').find((d) => d.trim().startsWith('img-src'))!;
+    expect(connectSrc).toMatch(/https:\/\/www\.google\.com(\s|$)/);
+    expect(imgSrc).toMatch(/https:\/\/\*\.g\.doubleclick\.net/);
+  });
+
   it('keeps adservice.google.com in both script-src and connect-src', () => {
     // adservice issues XHR/beacon calls in addition to loading scripts; if
     // one side is missing the request fails silently in production.
@@ -155,9 +163,7 @@ describe('worker fetch handler', () => {
     expect(res.headers.get('x-content-type-options')).toBe('nosniff');
     expect(res.headers.get('referrer-policy')).toBe('strict-origin-when-cross-origin');
     expect(res.headers.get('permissions-policy')).toMatch(/camera=\(\)/);
-    expect(res.headers.get('strict-transport-security')).toBe(
-      'max-age=63072000; includeSubDomains',
-    );
+    expect(res.headers.get('strict-transport-security')).toBe('max-age=63072000; includeSubDomains');
     // No preload — deliberate (one-way commitment).
     expect(res.headers.get('strict-transport-security')).not.toMatch(/preload/);
     // Cross-origin isolation headers (allow-popups variant keeps ad/analytics
@@ -178,7 +184,11 @@ describe('worker fetch handler', () => {
   });
 
   it('ships a Report-Only mirror + Reporting-Endpoints, but keeps the enforced policy report-free', async () => {
-    mockOrigin({ path: '/report-headers', body: htmlBody('<script>x</script>'), headers: { 'content-type': 'text/html; charset=utf-8' } });
+    mockOrigin({
+      path: '/report-headers',
+      body: htmlBody('<script>x</script>'),
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
 
     const res = await SELF.fetch('https://adrianwedd.com/report-headers');
     const enforced = res.headers.get('content-security-policy')!;
@@ -217,7 +227,16 @@ describe('worker fetch handler', () => {
     // Body is mutated by HTMLRewriter (nonce + meta-CSP strip), so origin's
     // ETag/Last-Modified/Content-Length no longer match. Leaving them risks
     // truncated responses and incorrect 304 cache hits.
-    mockOrigin({ path: '/cached', body: htmlBody('<script>x</script>'), headers: { 'content-type': 'text/html; charset=utf-8', etag: 'W/"abc123"', 'last-modified': 'Wed, 21 Oct 2026 07:28:00 GMT', 'content-length': '999', } });
+    mockOrigin({
+      path: '/cached',
+      body: htmlBody('<script>x</script>'),
+      headers: {
+        'content-type': 'text/html; charset=utf-8',
+        etag: 'W/"abc123"',
+        'last-modified': 'Wed, 21 Oct 2026 07:28:00 GMT',
+        'content-length': '999',
+      },
+    });
 
     const res = await SELF.fetch('https://adrianwedd.com/cached');
     expect(res.headers.get('etag')).toBeNull();
@@ -229,7 +248,12 @@ describe('worker fetch handler', () => {
   it('preserves upstream status and statusText (not silently 200)', async () => {
     // Regression: spreading a Response copies own enumerable props only,
     // which loses status/statusText. 404 must remain 404.
-    mockOrigin({ path: '/missing', status: 404, body: htmlBody('<h1>not found</h1>'), headers: { 'content-type': 'text/html; charset=utf-8' } });
+    mockOrigin({
+      path: '/missing',
+      status: 404,
+      body: htmlBody('<h1>not found</h1>'),
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
 
     const res = await SELF.fetch('https://adrianwedd.com/missing');
     expect(res.status).toBe(404);
@@ -243,7 +267,11 @@ describe('worker fetch handler', () => {
     // The mock always returns 200; if Range were forwarded the origin would return
     // 206 and the worker would pass it through — so asserting 200 here verifies
     // the round-trip behaviour even if it can't inspect the outgoing request headers.
-    mockOrigin({ path: '/og-test', body: htmlBody('<script>x</script>'), headers: { 'content-type': 'text/html; charset=utf-8' } });
+    mockOrigin({
+      path: '/og-test',
+      body: htmlBody('<script>x</script>'),
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
 
     const res = await SELF.fetch('https://adrianwedd.com/og-test', {
       headers: { Range: 'bytes=0-1023' },
@@ -253,7 +281,12 @@ describe('worker fetch handler', () => {
   });
 
   it('preserves upstream redirects without rewriting body', async () => {
-    mockOrigin({ path: '/legacy', status: 301, body: '', headers: { 'content-type': 'text/html; charset=utf-8', location: '/new-location/', } });
+    mockOrigin({
+      path: '/legacy',
+      status: 301,
+      body: '',
+      headers: { 'content-type': 'text/html; charset=utf-8', location: '/new-location/' },
+    });
 
     const res = await SELF.fetch('https://adrianwedd.com/legacy', { redirect: 'manual' });
     expect(res.status).toBe(301);
@@ -266,7 +299,9 @@ describe('worker fetch handler', () => {
     const res = await SELF.fetch('https://adrianwedd.com/__csp-report', {
       method: 'POST',
       headers: { 'content-type': 'application/csp-report' },
-      body: JSON.stringify({ 'csp-report': { 'violated-directive': 'script-src', 'blocked-uri': 'https://evil.example' } }),
+      body: JSON.stringify({
+        'csp-report': { 'violated-directive': 'script-src', 'blocked-uri': 'https://evil.example' },
+      }),
     });
     expect(res.status).toBe(204);
   });
@@ -290,7 +325,11 @@ describe('worker fetch handler', () => {
     // ORIGIN_HOST="adrianwedd.com". Even if the inbound arrives on www, the
     // worker rewrites to the configured origin. The interceptor is on
     // adrianwedd.com; an unmatched call to www would make the fetch mock throw.
-    mockOrigin({ path: '/about/', body: htmlBody('<script>x</script>'), headers: { 'content-type': 'text/html; charset=utf-8' } });
+    mockOrigin({
+      path: '/about/',
+      body: htmlBody('<script>x</script>'),
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
 
     const res = await SELF.fetch('https://www.adrianwedd.com/about/');
     expect(res.status).toBe(200);


### PR DESCRIPTION
Sprint 37 (Security Close-Out, #473) — the non-blocked items.

## What's here

### /.well-known/security.txt
RFC 9116 machine-readable twin of SECURITY.md. `Contact`, `Policy`, `Canonical`, `Expires: 2027-07-01`. Verified present in `dist/` after build.

### First CSP Report-Only analysis (#497 collector)
Full write-up in `worker-csp/docs/csp-report-analysis-2026-07-03.md`. Workers Logs held **3 reports** (all 2026-06-30, one real iOS-Firefox visitor), and because the Report-Only header mirrors the enforced policy, both findings are requests the **enforced** policy silently blocks in production today:

| Directive | Blocked | Fix |
|---|---|---|
| `connect-src` | `https://www.google.com/g/collect?...` (gtag ad-signal beacon) | added `https://www.google.com` to connect-src |
| `img-src` (×2) | `https://stats.g.doubleclick.net/g/collect?...` (gtag pixel fallback) | widened img-src to `https://*.g.doubleclick.net` (matches connect-src) |

No violations implicating site code (nonces, VT scripts, Pagefind, Turnstile) — the core policy is holding. Enforce-flip criteria documented: after these fixes deploy and 14 consecutive clean days, move reporting onto the enforced policy and retire the RO mirror.

### Roadmap
S37 boxes ticked; rate-limit item annotated (rule **verified absent** on the zone via API read — token lacks WAF write, dashboard application still pending).

## Not in this PR (needs Adrian)
- **worker-csp `wrangler deploy`** — manual, required to make the csp.ts fixes live
- **Rate-limit rule** — dashboard steps in `worker/docs/rate-limiting.md`
- **Meta-CSP fallback pick** (hashes / drop / origin lock)

## Verification
- `cd worker-csp && npm test` → 25/25; `npx tsc --noEmit` clean
- `npm run verify` → PASS (0 errors); internal links 58837/654 pages, 0 broken
- `npm run format:check` clean on touched files

https://claude.ai/code/session_011PhyuCQNfTyYFHE5s1wGv8