### PR TITLE
fix(ci): include hidden files in the Pages artifact (unbreaks /.well-known/security.txt)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,6 +171,9 @@ jobs:
         with:
           path: dist
           retention-days: 1
+          # v5 defaults include-hidden-files to false, which silently drops
+          # dist/.well-known/ (security.txt) from the deployed artifact.
+          include-hidden-files: true
 
   worker-csp:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to #522: `security.txt` built into `dist/.well-known/` correctly (local + CI) but 404'd live. Downloading the deployed run's `github-pages` artifact showed **no `.well-known` entry in artifact.tar** — `upload-pages-artifact@v5` defaults `include-hidden-files: false` and silently drops dotted paths at upload time.

One-flag fix on the upload step. Not a validation-gate change — all deploy gates untouched.

Safety check: the only hidden path in a CI-built `dist` is `.well-known/` (`git ls-files | grep -c DS_Store` → 0; local `.DS_Store`s never reach CI), so this publishes exactly the intended file.

Verification plan: merge → deploy → `curl -s https://adrianwedd.com/.well-known/security.txt` returns the RFC 9116 file.

https://claude.ai/code/session_011PhyuCQNfTyYFHE5s1wGv8