### PR TITLE
fix(worker): use GA [[ratelimits]] binding form — unsafe shape was inert

### DIFF
--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -24,9 +24,12 @@ BLUESKY_HANDLE = "adrianwedd.com"
 # Rate limiting binding (#473): 30 req/min per IP+path across /api/*.
 # A zone-level WAF rate-limiting rule would drop abuse before worker code,
 # but the Workers binding achieves the same budget without WAF-write access.
+# GA [[ratelimits]] form — the legacy [[unsafe.bindings]] shape deploys as
+# inert "Unsafe Metadata" on current wrangler and the binding never
+# materialises (verified 2026-07-03: env.API_RATE_LIMITER undefined, fail-open).
 # namespace_id is an arbitrary per-worker-unique numeric label, not a KV id.
-[[unsafe.bindings]]
+# Enforcement is per-colo and eventually consistent (bursts may overshoot).
+[[ratelimits]]
 name = "API_RATE_LIMITER"
-type = "ratelimit"
 namespace_id = "1001"
 simple = { limit = 30, period = 60 }


### PR DESCRIPTION
Follow-up to #525. The legacy `[[unsafe.bindings]] type=\"ratelimit\"` config deploys as **inert "Unsafe Metadata"** on wrangler 4.x — the binding never materialises, `env.API_RATE_LIMITER` is undefined at runtime, and the deliberately fail-open middleware silently skips. Caught by the post-deploy burst test (45 parallel GETs → 45×200, zero 429s).

Rate Limiting in Workers went GA 2025-09-19 with the first-class `[[ratelimits]]` block ([changelog](https://developers.cloudflare.com/changelog/post/2025-09-19-ratelimit-workers-ga/)); this switches to it.

**Before:** `env.API_RATE_LIMITER (ratelimit) — Unsafe Metadata`
**After (dry-run):** `env.API_RATE_LIMITER (30 requests/60s) — Rate Limit`

Config-only change; 167/167 tests still green. Will re-run the burst test after deploy (note: the GA limiter is per-colo and eventually consistent, so bursts may overshoot ~30 slightly before 429s begin).

https://claude.ai/code/session_011PhyuCQNfTyYFHE5s1wGv8