### PR TITLE
test(unit): Sprint 38 PR B — vitest unit layer (utils, image parser, content validation)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Fast root unit tests (vitest) — no browser, no build. Runs on every trigger
+  # as part of the PR gate; parallel to smoke for quick feedback.
+  unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run test:unit
+
   # Runs on every trigger: PR (this is the gate), plus nightly/dispatch so the
   # @smoke lifecycle checks aren't skipped there. The `full` job is non-PR only,
   # so nothing runs twice on a PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ npm run lint           # ESLint
 npm run format         # Prettier (write)
 npm run format:check   # Prettier (check only)
 npm run fetch-analytics  # manual GA4 data fetch
+npm run test:unit        # root unit tests (vitest) — test/unit/*.spec.ts, no build
 npm run test:e2e         # full Playwright suite (build + preview on :4322)
 npm run test:e2e:smoke   # @smoke subset — the PR gate (<3 min, Chromium)
 npm run test:e2e:full    # nightly-only specs (search, filters, pagination, audio)
@@ -23,7 +24,9 @@ npm run test:e2e:full    # nightly-only specs (search, filters, pagination, audi
 
 Content validation: `node scripts/validate-content.js` (checks required fields, description ≤160 chars, heroImage paths).
 
-The Astro site now has a Playwright E2E suite (`e2e/`), run in CI by `.github/workflows/e2e.yml` — smoke on PRs, full nightly. It serves the production build via `astro preview` on port 4322; the build must set `PUBLIC_GA_MEASUREMENT_ID` (CI uses a dummy `G-TESTE2E0000`) for the consent spec. `worker/` and `worker-csp/` each have their own test suite (`cd worker && npm test`, `cd worker-csp && npm test`).
+The Astro site has root unit tests (vitest, `test/unit/`) covering the pure lib helpers (`slug`/`imageSlug`/`youtubeId`/`ogSafeImage`/`heroAltText` in `src/lib/utils.ts`, the `parseDimensions` header parser in `src/lib/image-dimensions.ts`) and the `validateEntry` content-schema checks (`scripts/validate-content.js`). Config in `vitest.config.ts` is scoped to `test/unit/**` so it never picks up the Playwright specs or the `worker/` suites. Run with `npm run test:unit`; CI runs it as the `unit` job in `e2e.yml` on every PR.
+
+The Astro site also has a Playwright E2E suite (`e2e/`), run in CI by `.github/workflows/e2e.yml` — smoke on PRs, full nightly. It serves the production build via `astro preview` on port 4322; the build must set `PUBLIC_GA_MEASUREMENT_ID` (CI uses a dummy `G-TESTE2E0000`) for the consent spec. `worker/` and `worker-csp/` each have their own test suite (`cd worker && npm test`, `cd worker-csp && npm test`).
 
 ## Stack
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
         "pagefind": "^1.5.0",
         "prettier": "^3.8.4",
         "prettier-plugin-astro": "^0.14.1",
-        "prettier-plugin-tailwindcss": "^0.8.0"
+        "prettier-plugin-tailwindcss": "^0.8.0",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@astrojs/check": {
@@ -3183,6 +3184,13 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
@@ -3520,6 +3528,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -3528,6 +3547,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -3792,6 +3818,119 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@volar/kit": {
       "version": "2.4.28",
@@ -4059,6 +4198,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types": {
@@ -5216,6 +5365,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -6921,6 +7080,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -11372,6 +11541,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -12789,6 +12965,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -12962,6 +13145,13 @@
         "node": ">=16"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -12971,6 +13161,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-events": {
       "version": "1.0.5",
@@ -13342,6 +13539,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyclip": {
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.14.tgz",
@@ -13374,6 +13578,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts-core": {
@@ -14162,6 +14376,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/volar-service-css": {
       "version": "0.0.70",
       "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
@@ -14491,6 +14795,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
     "fetch-analytics": "node scripts/fetch-ga4-data.mjs",
     "check:links": "node scripts/check-internal-links.mjs",
     "lint": "eslint .",
-    "format": "prettier --write 'src/**/*.{astro,ts,tsx,css,md,mdx}' 'e2e/**/*.ts' 'playwright.config.ts'",
-    "format:check": "prettier --check 'src/**/*.{astro,ts,tsx,css,md,mdx}' 'e2e/**/*.ts' 'playwright.config.ts'",
+    "format": "prettier --write 'src/**/*.{astro,ts,tsx,css,md,mdx}' 'e2e/**/*.ts' 'test/**/*.ts' 'playwright.config.ts' 'vitest.config.ts'",
+    "format:check": "prettier --check 'src/**/*.{astro,ts,tsx,css,md,mdx}' 'e2e/**/*.ts' 'test/**/*.ts' 'playwright.config.ts' 'vitest.config.ts'",
     "typecheck": "astro check",
     "validate": "node scripts/validate-content.js",
     "check": "astro check && eslint . && node scripts/validate-content.js",
     "verify": "astro check && node scripts/validate-content.js && npm run build && bash scripts/test-site.sh && npm run check:links",
+    "test:unit": "vitest run",
     "test:worker": "cd worker && npm test",
     "test:csp": "cd worker-csp && npm test && npx tsc --noEmit",
     "test:e2e": "playwright test",
@@ -59,6 +60,7 @@
     "pagefind": "^1.5.0",
     "prettier": "^3.8.4",
     "prettier-plugin-astro": "^0.14.1",
-    "prettier-plugin-tailwindcss": "^0.8.0"
+    "prettier-plugin-tailwindcss": "^0.8.0",
+    "vitest": "^4.1.9"
   }
 }

--- a/scripts/validate-content.js
+++ b/scripts/validate-content.js
@@ -11,7 +11,7 @@ const ROOT = process.cwd();
 const CONTENT_DIR = join(ROOT, 'src/content');
 const PUBLIC_DIR = join(ROOT, 'public');
 
-const COLLECTIONS = {
+export const COLLECTIONS = {
   blog: {
     required: ['title', 'description', 'date', 'tags'],
     checkDescription: true,
@@ -40,8 +40,98 @@ const COLLECTIONS = {
   },
 };
 
-let errors = 0;
-let warnings = 0;
+export const MAX_DESCRIPTION_LENGTH = 160;
+
+/**
+ * Validate a single content entry's raw markdown (frontmatter + body) against
+ * a collection's rules. Pure — does no I/O and returns collected messages
+ * rather than printing, so it can be unit-tested and reused by the CLI below.
+ *
+ * @param {string} rawContent  Full file contents (with `---` frontmatter block).
+ * @param {object} rules       One collection's entry from COLLECTIONS.
+ * @param {object} [options]
+ * @param {(publicPath: string) => boolean} [options.imageExists]  Predicate for
+ *   the soft heroImage-existence check. Omit to skip that check entirely.
+ * @returns {{ errors: string[], warnings: string[] }}
+ */
+export function validateEntry(rawContent, rules, options = {}) {
+  const { imageExists } = options;
+  const errors = [];
+  const warnings = [];
+
+  // Duplicate YAML keys — must run BEFORE matter(), because the YAML parser
+  // throws on duplicate mapping keys. Scanning the raw text first lets us emit
+  // a clean error instead of crashing on the parser's exception.
+  const fmMatch = rawContent.match(/^---\n([\s\S]*?)\n---/);
+  if (fmMatch) {
+    const keys = [...fmMatch[1].matchAll(/^([a-zA-Z_][a-zA-Z0-9_]*):/gm)].map((m) => m[1]);
+    const seen = new Set();
+    for (const key of keys) {
+      if (seen.has(key)) errors.push(`duplicate frontmatter key '${key}'`);
+      seen.add(key);
+    }
+  }
+
+  let fm;
+  try {
+    fm = matter(rawContent).data;
+  } catch (err) {
+    // Malformed YAML (including duplicate keys already reported above). Surface
+    // a clean error rather than letting the exception crash the whole run.
+    errors.push(`invalid frontmatter: ${String(err.message).split('\n')[0]}`);
+    return { errors, warnings };
+  }
+
+  // Required fields.
+  for (const field of rules.required) {
+    const val = fm[field];
+    if (val === undefined || val === null || String(val).trim() === '') {
+      errors.push(`missing required field '${field}'`);
+    }
+  }
+
+  // Audio/video media URL — must have at least one of audioUrl or videoUrl.
+  if (rules.requireMediaUrl && !fm.audioUrl && !fm.videoUrl) {
+    errors.push(`missing required field 'audioUrl' or 'videoUrl'`);
+  }
+
+  // Description length.
+  if (rules.checkDescription && fm.description && fm.description.length > MAX_DESCRIPTION_LENGTH) {
+    errors.push(
+      `description is ${fm.description.length} chars (max ${MAX_DESCRIPTION_LENGTH}): "${fm.description.slice(0, 60)}..."`,
+    );
+  }
+
+  // heroImage path existence (warn only) — skipped unless an imageExists
+  // predicate is supplied (the CLI supplies one backed by the filesystem).
+  if (
+    imageExists &&
+    fm.heroImage &&
+    typeof fm.heroImage === 'string' &&
+    fm.heroImage.startsWith('/') &&
+    !fm.heroImage.startsWith('http')
+  ) {
+    if (!imageExists(fm.heroImage)) {
+      warnings.push(`heroImage not found in public/: ${fm.heroImage}`);
+    }
+  }
+
+  // Gallery images validation.
+  if (rules.checkImages) {
+    if (!fm.images || !Array.isArray(fm.images)) {
+      errors.push(`missing or invalid 'images' array`);
+    } else if (fm.images.length === 0) {
+      warnings.push(`images array is empty`);
+    } else {
+      fm.images.forEach((img, i) => {
+        if (!img.src) errors.push(`images[${i}] missing 'src'`);
+        if (!img.alt) warnings.push(`images[${i}] missing 'alt'`);
+      });
+    }
+  }
+
+  return { errors, warnings };
+}
 
 /** Recursively find all .md/.mdx files in a directory. */
 function findMarkdownFiles(dir) {
@@ -59,84 +149,36 @@ function findMarkdownFiles(dir) {
   return results;
 }
 
-for (const [collection, rules] of Object.entries(COLLECTIONS)) {
-  const dir = join(CONTENT_DIR, collection);
-  if (!existsSync(dir)) continue;
+function main() {
+  let errors = 0;
+  let warnings = 0;
+  const imageExists = (publicPath) => existsSync(join(PUBLIC_DIR, publicPath));
 
-  for (const filePath of findMarkdownFiles(dir)) {
-    const content = readFileSync(filePath, 'utf8');
-    const { data: fm } = matter(content);
-    const label = filePath.replace(CONTENT_DIR + '/', '');
+  for (const [collection, rules] of Object.entries(COLLECTIONS)) {
+    const dir = join(CONTENT_DIR, collection);
+    if (!existsSync(dir)) continue;
 
-    // Duplicate YAML keys — gray-matter silently deduplicates, so check raw text
-    const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
-    if (fmMatch) {
-      const keys = [...fmMatch[1].matchAll(/^([a-zA-Z_][a-zA-Z0-9_]*):/gm)].map((m) => m[1]);
-      const seen = new Set();
-      for (const key of keys) {
-        if (seen.has(key)) {
-          console.error(`ERROR [${label}]: duplicate frontmatter key '${key}'`);
-          errors++;
-        }
-        seen.add(key);
-      }
-    }
+    for (const filePath of findMarkdownFiles(dir)) {
+      const content = readFileSync(filePath, 'utf8');
+      const label = filePath.replace(CONTENT_DIR + '/', '');
+      const result = validateEntry(content, rules, { imageExists });
 
-    // Required fields
-    for (const field of rules.required) {
-      const val = fm[field];
-      if (val === undefined || val === null || String(val).trim() === '') {
-        console.error(`ERROR [${label}]: missing required field '${field}'`);
+      for (const msg of result.errors) {
+        console.error(`ERROR [${label}]: ${msg}`);
         errors++;
       }
-    }
-
-    // Audio/video media URL — must have at least one of audioUrl or videoUrl
-    if (rules.requireMediaUrl && !fm.audioUrl && !fm.videoUrl) {
-      console.error(`ERROR [${label}]: missing required field 'audioUrl' or 'videoUrl'`);
-      errors++;
-    }
-
-    // Description length
-    if (rules.checkDescription && fm.description && fm.description.length > 160) {
-      console.error(
-        `ERROR [${label}]: description is ${fm.description.length} chars (max 160): "${fm.description.slice(0, 60)}..."`
-      );
-      errors++;
-    }
-
-    // heroImage path existence (warn only)
-    if (fm.heroImage && typeof fm.heroImage === 'string' && fm.heroImage.startsWith('/') && !fm.heroImage.startsWith('http')) {
-      const imgPath = join(PUBLIC_DIR, fm.heroImage);
-      if (!existsSync(imgPath)) {
-        console.warn(`WARN [${label}]: heroImage not found in public/: ${fm.heroImage}`);
+      for (const msg of result.warnings) {
+        console.warn(`WARN [${label}]: ${msg}`);
         warnings++;
-      }
-    }
-
-    // Gallery images validation
-    if (rules.checkImages) {
-      if (!fm.images || !Array.isArray(fm.images)) {
-        console.error(`ERROR [${label}]: missing or invalid 'images' array`);
-        errors++;
-      } else if (fm.images.length === 0) {
-        console.warn(`WARN [${label}]: images array is empty`);
-        warnings++;
-      } else {
-        fm.images.forEach((img, i) => {
-          if (!img.src) {
-            console.error(`ERROR [${label}]: images[${i}] missing 'src'`);
-            errors++;
-          }
-          if (!img.alt) {
-            console.warn(`WARN [${label}]: images[${i}] missing 'alt'`);
-            warnings++;
-          }
-        });
       }
     }
   }
+
+  console.log(`\nValidation complete: ${errors} error(s), ${warnings} warning(s)`);
+  if (errors > 0) process.exit(1);
 }
 
-console.log(`\nValidation complete: ${errors} error(s), ${warnings} warning(s)`);
-if (errors > 0) process.exit(1);
+// Only run the CLI when invoked directly, not when imported by tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/src/lib/image-dimensions.ts
+++ b/src/lib/image-dimensions.ts
@@ -58,7 +58,12 @@ export function getImageDimensions(publicPath: string): ImageDimensions | null {
   }
 }
 
-function parseDimensions(buf: Buffer): ImageDimensions | null {
+/**
+ * Parse pixel dimensions from an image file's leading bytes. Exported for unit
+ * testing; production callers should use {@link getImageDimensions}, which
+ * handles the file I/O and caching.
+ */
+export function parseDimensions(buf: Buffer): ImageDimensions | null {
   // PNG: signature, then 4-byte length, then "IHDR", then width/height (BE uint32).
   if (
     buf.length >= 24 &&

--- a/test/unit/image-dimensions.spec.ts
+++ b/test/unit/image-dimensions.spec.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import { parseDimensions } from '../../src/lib/image-dimensions';
+
+/** PNG: 8-byte signature, 4-byte IHDR length, "IHDR", width/height BE uint32. */
+function png(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(24);
+  buf.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  buf.writeUInt32BE(13, 8); // IHDR chunk length
+  buf.write('IHDR', 12, 'ascii');
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf;
+}
+
+/** GIF: "GIF89a", then width/height LE uint16 at offsets 6/8. */
+function gif(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(10);
+  buf.write('GIF89a', 0, 'ascii');
+  buf.writeUInt16LE(width, 6);
+  buf.writeUInt16LE(height, 8);
+  return buf;
+}
+
+/** RIFF/WEBP container wrapping a single chunk with the given fourcc + data. */
+function webp(fourcc: string, data: Buffer): Buffer {
+  const chunkSize = data.length;
+  const padded = chunkSize + (chunkSize & 1);
+  const buf = Buffer.alloc(12 + 8 + padded);
+  buf.write('RIFF', 0, 'ascii');
+  buf.writeUInt32LE(4 + 8 + padded, 4); // file size minus RIFF header
+  buf.write('WEBP', 8, 'ascii');
+  buf.write(fourcc, 12, 'ascii');
+  buf.writeUInt32LE(chunkSize, 16);
+  data.copy(buf, 20);
+  return buf;
+}
+
+/** VP8 lossy: 10-byte data, dimensions LE uint16 (14-bit) at data offsets 6/8. */
+function vp8Data(width: number, height: number): Buffer {
+  const d = Buffer.alloc(10);
+  d.writeUInt16LE(width & 0x3fff, 6);
+  d.writeUInt16LE(height & 0x3fff, 8);
+  return d;
+}
+
+/** VP8X extended: signature/flags byte, 3 reserved, then 24-bit (w-1),(h-1). */
+function vp8xData(width: number, height: number): Buffer {
+  const d = Buffer.alloc(10);
+  const w = width - 1;
+  const h = height - 1;
+  d[4] = w & 0xff;
+  d[5] = (w >> 8) & 0xff;
+  d[6] = (w >> 16) & 0xff;
+  d[7] = h & 0xff;
+  d[8] = (h >> 8) & 0xff;
+  d[9] = (h >> 16) & 0xff;
+  return d;
+}
+
+/** JPEG: SOI, an APP0 segment (skipped by length), then an SOF0 carrying dims. */
+function jpeg(width: number, height: number): Buffer {
+  const parts: number[] = [0xff, 0xd8]; // SOI
+  // APP0 segment: marker + length(16) + 4 bytes payload — must be skipped.
+  parts.push(0xff, 0xe0, 0x00, 0x06, 0x01, 0x02, 0x03, 0x04);
+  // SOF0: marker, length(0x0011), precision, height(BE16), width(BE16), ...
+  parts.push(0xff, 0xc0, 0x00, 0x11, 0x08);
+  parts.push((height >> 8) & 0xff, height & 0xff);
+  parts.push((width >> 8) & 0xff, width & 0xff);
+  parts.push(0x03, 0x01, 0x22, 0x00); // components (partial, not read)
+  return Buffer.from(parts);
+}
+
+describe('parseDimensions — PNG', () => {
+  it('reads width and height', () => {
+    expect(parseDimensions(png(1200, 630))).toEqual({ width: 1200, height: 630 });
+  });
+
+  it('rejects a valid signature with a non-IHDR first chunk', () => {
+    const buf = png(10, 10);
+    buf.write('IDAT', 12, 'ascii'); // corrupt the chunk type
+    expect(parseDimensions(buf)).toBeNull();
+  });
+});
+
+describe('parseDimensions — GIF', () => {
+  it('reads little-endian width and height', () => {
+    expect(parseDimensions(gif(640, 480))).toEqual({ width: 640, height: 480 });
+  });
+});
+
+describe('parseDimensions — WebP', () => {
+  it('reads a VP8 lossy chunk', () => {
+    expect(parseDimensions(webp('VP8 ', vp8Data(800, 600)))).toEqual({ width: 800, height: 600 });
+  });
+
+  it('reads a VP8X extended chunk', () => {
+    expect(parseDimensions(webp('VP8X', vp8xData(1536, 2752)))).toEqual({
+      width: 1536,
+      height: 2752,
+    });
+  });
+
+  it('reads a VP8L lossless chunk', () => {
+    // VP8L encodes (w-1) in 14 bits and (h-1) in the next 14 bits, LSB-first,
+    // behind a 0x2F signature byte. Build the field for 300x200.
+    const w = 300;
+    const h = 200;
+    const bits = ((h - 1) << 14) | (w - 1); // 28-bit little-endian field
+    // Pad past the parser's `buf.length >= 30` WebP guard (real VP8L chunks
+    // carry the entropy-coded stream after this 5-byte header).
+    const d = Buffer.alloc(18);
+    d[0] = 0x2f;
+    d[1] = bits & 0xff;
+    d[2] = (bits >> 8) & 0xff;
+    d[3] = (bits >> 16) & 0xff;
+    d[4] = (bits >> 24) & 0xff;
+    expect(parseDimensions(webp('VP8L', d))).toEqual({ width: 300, height: 200 });
+  });
+
+  it('rejects a VP8L chunk with a bad signature byte', () => {
+    const d = Buffer.alloc(5);
+    d[0] = 0x00; // not 0x2f
+    expect(parseDimensions(webp('VP8L', d))).toBeNull();
+  });
+
+  it('skips a leading ALPHA chunk to find VP8 dimensions', () => {
+    // Extended files can carry ALPH before the dimension-bearing chunk. Build
+    // RIFF/WEBP with ALPH(2 bytes) then VP8 (10 bytes).
+    const alph = Buffer.from([0xaa, 0xbb]);
+    const vp8 = vp8Data(320, 240);
+    const inner = Buffer.concat([
+      Buffer.from('ALPH'),
+      leU32(alph.length),
+      alph,
+      Buffer.from('VP8 '),
+      leU32(vp8.length),
+      vp8,
+    ]);
+    const buf = Buffer.concat([Buffer.from('RIFF'), leU32(4 + inner.length), Buffer.from('WEBP'), inner]);
+    expect(parseDimensions(buf)).toEqual({ width: 320, height: 240 });
+  });
+});
+
+describe('parseDimensions — JPEG', () => {
+  it('reads dimensions from SOF0, skipping the APP0 segment', () => {
+    expect(parseDimensions(jpeg(1920, 1080))).toEqual({ width: 1920, height: 1080 });
+  });
+
+  it('returns null when SOS is reached before any SOF', () => {
+    // SOI then straight to SOS (0xFFDA) — no frame header.
+    expect(parseDimensions(Buffer.from([0xff, 0xd8, 0xff, 0xda]))).toBeNull();
+  });
+});
+
+describe('parseDimensions — unknown / truncated', () => {
+  it('returns null for unrecognised bytes', () => {
+    expect(parseDimensions(Buffer.from([0x00, 0x01, 0x02, 0x03]))).toBeNull();
+  });
+
+  it('returns null for an empty buffer', () => {
+    expect(parseDimensions(Buffer.alloc(0))).toBeNull();
+  });
+
+  it('returns null for a too-short PNG', () => {
+    expect(parseDimensions(Buffer.from([0x89, 0x50, 0x4e, 0x47]))).toBeNull();
+  });
+});
+
+function leU32(n: number): Buffer {
+  const b = Buffer.alloc(4);
+  b.writeUInt32LE(n, 0);
+  return b;
+}

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { slug, imageSlug, youtubeId, ogSafeImage, heroAltText } from '../../src/lib/utils';
+
+describe('slug', () => {
+  it('passes through an id with no extension or -post suffix', () => {
+    expect(slug('my-first-article')).toBe('my-first-article');
+  });
+
+  it('strips a trailing .md / .mdx extension (Astro 5 leak)', () => {
+    expect(slug('foo.md')).toBe('foo');
+    expect(slug('foo.mdx')).toBe('foo');
+  });
+
+  it('strips the -post naming-convention suffix', () => {
+    expect(slug('agent-in-the-walls-post')).toBe('agent-in-the-walls');
+  });
+
+  it('strips -post together with an extension', () => {
+    expect(slug('agent-post.md')).toBe('agent');
+    expect(slug('agent-post.mdx')).toBe('agent');
+  });
+
+  it('only strips -post at the end, not mid-slug', () => {
+    expect(slug('post-mortem')).toBe('post-mortem');
+    expect(slug('my-post-notes')).toBe('my-post-notes');
+  });
+});
+
+describe('imageSlug', () => {
+  it('lowercases and hyphenates alt text', () => {
+    expect(imageSlug('Sunset Over Hobart')).toBe('sunset-over-hobart');
+  });
+
+  it('collapses runs of non-alphanumerics to a single hyphen', () => {
+    expect(imageSlug('A  --  B__C!!D')).toBe('a-b-c-d');
+  });
+
+  it('trims leading and trailing hyphens', () => {
+    expect(imageSlug('  !edge!  ')).toBe('edge');
+  });
+
+  it('falls back to "image" when nothing survives', () => {
+    expect(imageSlug('!!!')).toBe('image');
+    expect(imageSlug('')).toBe('image');
+  });
+});
+
+describe('youtubeId', () => {
+  it('extracts from watch?v= URLs', () => {
+    expect(youtubeId('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+  });
+
+  it('extracts from youtu.be short links', () => {
+    expect(youtubeId('https://youtu.be/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+  });
+
+  it('extracts from embed / shorts / live / v paths', () => {
+    expect(youtubeId('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+    expect(youtubeId('https://www.youtube.com/shorts/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+    expect(youtubeId('https://www.youtube.com/live/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+    expect(youtubeId('https://www.youtube.com/v/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+  });
+
+  it('handles nocookie and subdomain hosts', () => {
+    expect(youtubeId('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+    expect(youtubeId('https://music.youtube.com/watch?v=dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+  });
+
+  it('rejects malformed input and non-YouTube hosts', () => {
+    expect(youtubeId(null)).toBeNull();
+    expect(youtubeId(undefined)).toBeNull();
+    expect(youtubeId('not a url')).toBeNull();
+    expect(youtubeId('https://vimeo.com/12345')).toBeNull();
+  });
+
+  it('rejects ids that are not exactly 11 canonical chars (the XSS anchor)', () => {
+    expect(youtubeId('https://www.youtube.com/watch?v=short')).toBeNull();
+    expect(youtubeId('https://www.youtube.com/watch?v=dQw4w9WgXcQ<script>')).toBeNull();
+    expect(youtubeId('https://youtu.be/toolongvideoid123')).toBeNull();
+  });
+});
+
+describe('ogSafeImage', () => {
+  it('swaps a .webp extension to .jpg', () => {
+    expect(ogSafeImage('/og/foo.webp')).toBe('/og/foo.jpg');
+  });
+
+  it('swaps .webp before a query string or hash', () => {
+    expect(ogSafeImage('/og/foo.webp?v=2')).toBe('/og/foo.jpg?v=2');
+    expect(ogSafeImage('/og/foo.webp#frag')).toBe('/og/foo.jpg#frag');
+  });
+
+  it('is case-insensitive on the extension', () => {
+    expect(ogSafeImage('/og/foo.WEBP')).toBe('/og/foo.jpg');
+  });
+
+  it('passes non-webp paths through unchanged', () => {
+    expect(ogSafeImage('/og/foo.png')).toBe('/og/foo.png');
+    expect(ogSafeImage('/og/webp-in-name.jpg')).toBe('/og/webp-in-name.jpg');
+  });
+});
+
+describe('heroAltText', () => {
+  it('returns an authored heroAlt verbatim', () => {
+    expect(heroAltText({ heroAlt: 'A custom description', title: 'X', kind: 'article' })).toBe('A custom description');
+  });
+
+  it('describes infographic heroes for articles and projects', () => {
+    expect(heroAltText({ heroImage: '/notebook-assets/x/infographic.webp', title: 'My Post', kind: 'article' })).toBe(
+      'Infographic summarising the article: “My Post”',
+    );
+    expect(heroAltText({ heroImage: '/foo/infographic.png', title: 'My Proj', kind: 'project' })).toBe(
+      'Infographic summarising the project: “My Proj”',
+    );
+  });
+
+  it('returns empty (decorative) alt for a non-infographic hero with no authored alt', () => {
+    expect(heroAltText({ heroImage: '/photos/beach.jpg', title: 'Beach', kind: 'article' })).toBe('');
+    expect(heroAltText({ title: 'No hero', kind: 'article' })).toBe('');
+  });
+});

--- a/test/unit/validate-content.spec.ts
+++ b/test/unit/validate-content.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { validateEntry, COLLECTIONS, MAX_DESCRIPTION_LENGTH } from '../../scripts/validate-content.js';
+
+const blogRules = COLLECTIONS.blog;
+const audioRules = COLLECTIONS.audio;
+const galleryRules = COLLECTIONS.gallery;
+
+function fm(fields: Record<string, string>): string {
+  const body = Object.entries(fields)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+  return `---\n${body}\n---\n\nBody text.\n`;
+}
+
+describe('validateEntry — required fields', () => {
+  it('accepts a complete blog entry', () => {
+    const { errors } = validateEntry(
+      fm({ title: 'Hello', description: 'A post', date: '2026-01-01', tags: '[a]' }),
+      blogRules,
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it('flags each missing required field', () => {
+    const { errors } = validateEntry(fm({ title: 'Only title' }), blogRules);
+    expect(errors).toContain("missing required field 'description'");
+    expect(errors).toContain("missing required field 'date'");
+    expect(errors).toContain("missing required field 'tags'");
+  });
+
+  it('treats a blank/whitespace field as missing', () => {
+    const { errors } = validateEntry(
+      fm({ title: '   ', description: 'x', date: '2026-01-01', tags: '[a]' }),
+      blogRules,
+    );
+    expect(errors).toContain("missing required field 'title'");
+  });
+});
+
+describe('validateEntry — description length boundary', () => {
+  const base = { title: 'T', date: '2026-01-01', tags: '[a]' };
+
+  it('accepts a description at exactly the limit', () => {
+    const desc = 'x'.repeat(MAX_DESCRIPTION_LENGTH);
+    const { errors } = validateEntry(fm({ ...base, description: desc }), blogRules);
+    expect(errors).toEqual([]);
+  });
+
+  it('rejects a description one char over the limit', () => {
+    const desc = 'x'.repeat(MAX_DESCRIPTION_LENGTH + 1);
+    const { errors } = validateEntry(fm({ ...base, description: desc }), blogRules);
+    expect(errors.some((e: string) => e.startsWith('description is 161 chars'))).toBe(true);
+  });
+});
+
+describe('validateEntry — audio media URL', () => {
+  const base = { title: 'T', description: 'd', date: '2026-01-01', tags: '[a]' };
+
+  it('requires audioUrl or videoUrl', () => {
+    const { errors } = validateEntry(fm(base), audioRules);
+    expect(errors).toContain("missing required field 'audioUrl' or 'videoUrl'");
+  });
+
+  it('accepts an entry with only audioUrl', () => {
+    const { errors } = validateEntry(fm({ ...base, audioUrl: 'https://cdn/x.m4a' }), audioRules);
+    expect(errors).toEqual([]);
+  });
+});
+
+describe('validateEntry — duplicate frontmatter keys', () => {
+  it('flags a repeated key that gray-matter would silently dedupe', () => {
+    const raw = `---\ntitle: One\ndescription: d\ndate: 2026-01-01\ntags: [a]\ntitle: Two\n---\n\nBody.\n`;
+    const { errors } = validateEntry(raw, blogRules);
+    expect(errors).toContain("duplicate frontmatter key 'title'");
+  });
+});
+
+describe('validateEntry — gallery images', () => {
+  it('errors when the images array is missing', () => {
+    const { errors } = validateEntry(fm({ title: 'G', date: '2026-01-01', tags: '[a]' }), galleryRules);
+    expect(errors).toContain("missing or invalid 'images' array");
+  });
+
+  it('errors on an image missing src and warns on missing alt', () => {
+    const raw = `---\ntitle: G\ndate: 2026-01-01\ntags: [a]\nimages:\n  - alt: only alt\n---\n\nBody.\n`;
+    const { errors } = validateEntry(raw, galleryRules);
+    expect(errors).toContain("images[0] missing 'src'");
+  });
+});
+
+describe('validateEntry — heroImage existence predicate', () => {
+  const base = { title: 'T', description: 'd', date: '2026-01-01', tags: '[a]' };
+
+  it('warns when the predicate reports the image missing', () => {
+    const { warnings } = validateEntry(fm({ ...base, heroImage: '/img/missing.webp' }), blogRules, {
+      imageExists: () => false,
+    });
+    expect(warnings).toContain('heroImage not found in public/: /img/missing.webp');
+  });
+
+  it('does not warn for a remote heroImage URL', () => {
+    const { warnings } = validateEntry(fm({ ...base, heroImage: 'https://cdn/x.webp' }), blogRules, {
+      imageExists: () => false,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  it('skips the check entirely when no predicate is supplied', () => {
+    const { warnings } = validateEntry(fm({ ...base, heroImage: '/img/x.webp' }), blogRules);
+    expect(warnings).toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+// Root unit-test runner. Scoped to `test/unit/` so it never picks up the
+// Playwright specs in `e2e/` (those run under `@playwright/test`, not vitest)
+// or the worker suites (`worker/`, `worker-csp/` have their own vitest configs).
+export default defineConfig({
+  test: {
+    include: ['test/unit/**/*.spec.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Sprint 38 PR B — Unit test layer (closes the sprint)

Completes Sprint 38's third bullet: root-level unit tests. Pairs with PR A's Playwright suite. `deploy.yml` untouched.

### What's here
- **`vitest.config.ts`** — root runner (vitest `^4.1.9`, matching `worker/`), scoped to `test/unit/**` so it never picks up the `e2e/` Playwright specs or the `worker/` suites. New `test:unit` script.
- **`test/unit/utils.spec.ts`** — `slug`, `imageSlug`, the security-sensitive `youtubeId` (11-char canonical anchor / XSS guard), `ogSafeImage`, `heroAltText`.
- **`test/unit/image-dimensions.spec.ts`** — the byte-level `parseDimensions` header parser across PNG / GIF / WebP (VP8, VP8L, VP8X) / JPEG plus corrupt & truncated inputs, driven by synthesized headers (no fixture files). `parseDimensions` is now exported for testing; production still calls `getImageDimensions`.
- **`test/unit/validate-content.spec.ts`** + refactor — extracted the per-entry checks into a pure, exported `validateEntry()` (CLI runs via an `import.meta.url` guard). Tests required fields, description ≤160 boundary, audio media-URL, gallery images, heroImage existence (injected predicate).
- **`.github/workflows/e2e.yml`** — fast parallel `unit` job (no build, no browser) on every trigger.
- **CLAUDE.md** documents the suite.

### Latent bug fixed (found by a test)
The YAML parser throws on duplicate mapping keys, so `validate-content.js`'s raw-text dup-key scan — which ran *after* `matter()` — was dead code, and a duplicate key crashed the CLI with a stack trace instead of a clean error. The scan now runs *before* `matter()`, and the parse is guarded to emit a clean error. Behavior on real content is unchanged (`0 errors, 0 warnings`).

### Verification
- `npm run test:unit`: **48/48**.
- `npm run lint`: clean. `astro check`: 0 errors / 0 warnings.
- `node scripts/validate-content.js` on real content: `0 error(s), 0 warning(s)` (refactor is behavior-preserving).
- Diff kept tight: reverted an accidental repo-wide `prettier` sweep (committed files carry pre-existing prettier drift; `format:check` is not a CI gate) so `image-dimensions.ts` is a minimal 7-line diff.

https://claude.ai/code/session_01Lm2dtTcKC99rCGfqj2bw95
