### PR TITLE
Sprint 39: gated Worker deploy automation + nightly drift check

### DIFF
--- a/.github/workflows/worker-deploy.yml
+++ b/.github/workflows/worker-deploy.yml
@@ -1,0 +1,107 @@
+name: Worker Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'worker/**'
+      - 'worker-csp/**'
+      - 'worker-mta-sts/**'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Which worker(s) to deploy
+        type: choice
+        default: all
+        options: [all, social, csp, mta-sts]
+      mode:
+        description: deploy the target, or run a read-only drift check
+        type: choice
+        default: deploy
+        options: [deploy, drift-only]
+  schedule:
+    - cron: '0 15 * * *' # ~01:00 AEST, offset from the e2e nightly
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'deploy') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+      any: ${{ steps.select.outputs.any }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - id: select
+        env:
+          EVENT: ${{ github.event_name }}
+          BEFORE: ${{ github.event.before }}
+          DISPATCH_TARGET: ${{ github.event.inputs.target }}
+        run: node scripts/worker-targets.mjs >> "$GITHUB_OUTPUT"
+
+  deploy:
+    needs: detect
+    if: ${{ needs.detect.outputs.any == 'true' }}
+    environment: worker-production
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        worker: ${{ fromJSON(needs.detect.outputs.matrix) }}
+    concurrency:
+      group: worker-deploy-${{ matrix.worker.key }}
+      cancel-in-progress: false
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+      - name: Install pinned wrangler toolchain
+        run: |
+          npm --prefix worker ci
+          echo "WRANGLER_BIN=${GITHUB_WORKSPACE}/worker/node_modules/.bin/wrangler" >> "$GITHUB_ENV"
+      - name: Deploy, verify, rollback
+        env:
+          WORKER_KEY: ${{ matrix.worker.key }}
+          WORKER_DIR: ${{ matrix.worker.dir }}
+          WORKER_NAME: ${{ matrix.worker.name }}
+          GIT_SHA: ${{ github.sha }}
+        run: bash scripts/worker-deploy-step.sh
+
+  drift-check:
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'drift-only') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_READONLY }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+      - name: Install pinned wrangler toolchain
+        run: |
+          npm --prefix worker ci
+          echo "WRANGLER_BIN=${GITHUB_WORKSPACE}/worker/node_modules/.bin/wrangler" >> "$GITHUB_ENV"
+      - run: node scripts/worker-drift.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,9 @@ KV-based locks have a TOCTOU window between `get` and `put`; the DO closes that.
 
 **Tests:** Vitest with a per-platform mock registry (`getPlatformMocks(name)`) — each platform has independent `publishPost`/`debugAuth` mocks so multi-platform scenarios (e.g. one healthy + one expired) can be tested in a single run. `cloudflare:workers` is aliased to `worker/test-shims/cloudflare-workers.ts` for vitest.
 
-**Deploy:** `cd worker && npx wrangler deploy`. CLI posting: `scripts/fb-post.sh`. Validate locally with `npx wrangler deploy --dry-run` before pushing.
+**Deploy:** automated via `.github/workflows/worker-deploy.yml` (gated approval +
+edge verify + auto-rollback + nightly drift check). See
+`docs/runbooks/worker-deploy.md`. Manual fallback: `cd <worker> && npx wrangler deploy`.
 
 ## Key patterns
 

--- a/docs/runbooks/worker-deploy.md
+++ b/docs/runbooks/worker-deploy.md
@@ -29,6 +29,14 @@ auto-rollback, and a nightly drift check.
 - **manual** → Actions → Worker Deploy → Run workflow → choose `mode`
   (`deploy` a `target`, or `drift-only` for a read-only check).
 
+## First run: seed deployment stamps
+
+Because the three workers were last deployed manually (deployment messages lack `gitsha:` stamps), the first nightly drift check will report every worker as DRIFT / "unstamped" until each has been deployed once through CI. Seed the stamps after merge+setup by running:
+
+**Actions → Worker Deploy → Run workflow → `target: all`, `mode: deploy`** (approve each worker when prompted).
+
+After these three deployments complete, future drift reports will accurately flag real divergence.
+
 ## Limitations
 
 - Rollback targets the explicit pre-deploy version. If wrangler refuses (a

--- a/docs/runbooks/worker-deploy.md
+++ b/docs/runbooks/worker-deploy.md
@@ -1,0 +1,39 @@
+# Worker deploy runbook
+
+`.github/workflows/worker-deploy.yml` auto-deploys the three workers on merge to
+`main` (path-filtered), behind an approval gate, with edge verification,
+auto-rollback, and a nightly drift check.
+
+## One-time setup (required before first CI deploy)
+
+1. **Create `CLOUDFLARE_API_TOKEN`** — Cloudflare dashboard → My Profile → API
+   Tokens → Create Token. Permissions: **Account → Workers Scripts → Edit** and
+   **Account → Account Settings → Read**. Add **Zone → Workers Routes → Edit**
+   and **Zone → DNS → Edit** only if CI must ever (re)create the `worker-csp`
+   route or the `mta-sts` custom domain (all three already exist, so redeploys
+   don't need zone scopes).
+2. **Create `CLOUDFLARE_API_TOKEN_READONLY`** — same flow, permission
+   **Account → Workers Scripts → Read** only.
+3. **Add repo secrets** `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN_READONLY`
+   (Settings → Secrets and variables → Actions → repository secrets).
+4. **Create the `worker-production` environment** (Settings → Environments):
+   add **required reviewer = Adrian**, then add `CLOUDFLARE_API_TOKEN` as an
+   **environment** secret scoped to it.
+
+## Flow
+
+- **push to main** touching `worker*/` → `deploy` job pauses for approval →
+  approve → deploy + verify at the edge → auto-rollback on failure.
+- **nightly** → `drift-check` compares each deployed worker's stamped `gitsha:`
+  against `main` and fails red on divergence.
+- **manual** → Actions → Worker Deploy → Run workflow → choose `mode`
+  (`deploy` a `target`, or `drift-only` for a read-only check).
+
+## Limitations
+
+- Rollback targets the explicit pre-deploy version. If wrangler refuses (a
+  Durable Object migration or a changed secret can block it), the run prints
+  "MANUAL INTERVENTION REQUIRED" and leaves the failed version live — roll back
+  by hand. Only `worker/` has a Durable Object migration.
+- `/api/health` verification is a liveness probe; token health is owned by
+  `social-token-alert.yml`.

--- a/docs/superpowers/plans/2026-07-06-sprint39-worker-deploy-automation.md
+++ b/docs/superpowers/plans/2026-07-06-sprint39-worker-deploy-automation.md
@@ -4,30 +4,33 @@
 
 **Goal:** Auto-deploy the three Cloudflare Workers on merge to `main`, gated by a GitHub Environment approval, with post-deploy edge verification, auto-rollback on failure, and a nightly drift check.
 
-**Architecture:** One workflow (`.github/workflows/worker-deploy.yml`) drives three small, independently unit-tested Node scripts — a target selector, an edge-verification prober, and a drift classifier — plus one bash deploy step. Deploy jobs reference a gated `worker-production` environment (write token); the ungated nightly drift job uses a separate repo-level read-only token.
+**Architecture:** One workflow (`.github/workflows/worker-deploy.yml`) drives four small Node scripts (target selector, wrangler-deployments parser, edge-verification prober, drift classifier) plus one bash deploy step. Deploy jobs reference a gated `worker-production` environment (write token); the ungated drift job uses a separate repo-level read-only token. All wrangler invocations use a pinned binary from `worker/node_modules/`.
 
-**Tech Stack:** GitHub Actions, Node 22 (ESM `.mjs`), vitest (root `test:unit` suite), wrangler (already a worker devDep), bash.
+**Tech Stack:** GitHub Actions, Node 22 (ESM `.mjs`), vitest (root `test:unit` suite), wrangler 4 (pinned via `worker/`), bash.
 
 ## Global Constraints
 
 - **Two Cloudflare tokens.** `CLOUDFLARE_API_TOKEN` (Edit Workers) lives in the **gated** `worker-production` environment; `CLOUDFLARE_API_TOKEN_READONLY` (Read Workers) is a **repo-level** secret used only by the drift job. `CLOUDFLARE_ACCOUNT_ID` is repo-level. CI never handles the 14 platform secrets.
 - **No platform-secret exposure.** `wrangler deploy` inherits existing secrets; never add `wrangler secret put` to CI.
-- **`mta-sts` has no `package.json`** — never run `npm ci`/tests there.
+- **Pinned wrangler.** Every job that runs wrangler first runs `npm --prefix worker ci` (worker pins `wrangler@^4.100.0`) and exports `WRANGLER_BIN=<workspace>/worker/node_modules/.bin/wrangler`. Scripts read `process.env.WRANGLER_BIN ?? 'npx wrangler'` so they work locally too. Never rely on a bare `npx wrangler` in CI (unpinned download, and `worker-mta-sts/` has no `node_modules`).
+- **`mta-sts` has no `package.json`** — never run `npm ci`/tests in `worker-mta-sts/`.
 - **SHA-pin actions** per repo convention: `actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0`, `actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0`.
 - **`permissions: contents: read`** at workflow top level; nothing else.
-- **CSP nonce must be real:** regex `nonce-[A-Za-z0-9+/=]{20,}`.
+- **Lint only via `npm run lint`** (`eslint .`). Never `eslint <file>` — single-file invocation hits a broken `astro-eslint-parser` transitive and errors spuriously (an environment quirk, not a code issue).
+- **CSP verification checks the body too:** the header nonce must also appear in the HTML body (proves the worker rewrote the page, not just set a header).
 - **`/api/health` is a liveness probe only** (unauth response is `{"ok":true}`).
-- **No auto-rollback across a Durable Object migration** — detect the migration-block error and demand manual intervention.
-- Unit tests go in `test/unit/*.spec.ts` (picked up by the existing `npm run test:unit`); scripts live in `scripts/*.mjs`.
+- **Rollback targets an explicit captured version id** (never the bare default). If rollback exits non-zero, print a loud MANUAL-INTERVENTION message (a Durable Object migration or a changed secret can block it) and fail — do not silently continue.
+- Unit tests go in `test/unit/*.spec.ts` (picked up by `npm run test:unit`); scripts live in `scripts/*.mjs`.
 
 ## File structure
 
 - `scripts/worker-targets.mjs` — worker registry + `selectTargets()`; CLI emits the deploy matrix.
+- `scripts/wrangler-deployments.mjs` — `extractDeployMessage()`, `currentVersionId()`, `listDeployments()`; CLI prints the current version id or the deploy message.
 - `scripts/verify-worker.mjs` — pure assertion fns + a retrying `probe()`; CLI verifies one worker at the live edge.
-- `scripts/worker-drift.mjs` — `parseDeployedSha()` + `classifyDrift()`; CLI checks all workers and fails on drift.
-- `scripts/worker-deploy-step.sh` — install/test/deploy/verify/rollback for one worker (invoked per matrix entry).
-- `.github/workflows/worker-deploy.yml` — the workflow wiring it all together.
-- `test/unit/worker-targets.spec.ts`, `test/unit/verify-worker.spec.ts`, `test/unit/worker-drift.spec.ts` — unit tests.
+- `scripts/worker-drift.mjs` — `parseDeployedSha()` + `classifyDrift()`; CLI checks all workers, fails on drift.
+- `scripts/worker-deploy-step.sh` — capture-prev / install / test / deploy / verify / rollback for one worker.
+- `.github/workflows/worker-deploy.yml` — the workflow.
+- `test/unit/{worker-targets,wrangler-deployments,verify-worker,worker-drift}.spec.ts` — unit tests.
 - `docs/runbooks/worker-deploy.md` — token/environment setup runbook.
 - `worker-csp/README.md` — fix the stale "Not deployed" claim.
 
@@ -40,7 +43,7 @@
 - Test: `test/unit/worker-targets.spec.ts`
 
 **Interfaces:**
-- Produces: `WORKERS` (object keyed by `social`/`csp`/`mta-sts`, each `{ key, dir, name, hasPkg }`); `selectTargets({ changedFiles, dispatchTarget }) → Array<worker>`.
+- Produces: `WORKERS` (object keyed `social`/`csp`/`mta-sts`, each `{ key, dir, name, hasPkg }`); `selectTargets({ changedFiles, dispatchTarget }) → Array<worker>`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -57,27 +60,22 @@ describe('selectTargets', () => {
       'social',
     ]);
   });
-
   it('dispatch of a single worker returns just that one', () => {
     expect(selectTargets({ dispatchTarget: 'csp' })).toEqual([WORKERS.csp]);
   });
-
   it('push maps changed files to their worker dirs', () => {
-    const changed = ['worker-csp/src/index.ts', 'README.md'];
-    expect(selectTargets({ changedFiles: changed }).map((w) => w.key)).toEqual(['csp']);
+    expect(
+      selectTargets({ changedFiles: ['worker-csp/src/index.ts', 'README.md'] }).map((w) => w.key),
+    ).toEqual(['csp']);
   });
-
   it('push matches the dir prefix but not a lookalike sibling', () => {
-    // "worker-csp" must not be matched by a path under "worker/" and vice-versa
     expect(selectTargets({ changedFiles: ['worker/src/index.ts'] }).map((w) => w.key)).toEqual([
       'social',
     ]);
   });
-
   it('push with no worker changes returns nothing', () => {
     expect(selectTargets({ changedFiles: ['src/pages/index.astro'] })).toEqual([]);
   });
-
   it('mta-sts is flagged hasPkg:false', () => {
     expect(WORKERS['mta-sts'].hasPkg).toBe(false);
     expect(WORKERS.social.hasPkg).toBe(true);
@@ -94,8 +92,8 @@ Expected: FAIL — cannot resolve `../../scripts/worker-targets.mjs`.
 
 ```js
 // scripts/worker-targets.mjs
-// Registry of the three Cloudflare workers + pure target selection. Also a CLI
-// entry (guarded by import.meta.url) that emits the deploy matrix to GITHUB_OUTPUT.
+// Registry of the three Cloudflare workers + pure target selection. CLI entry
+// (guarded by import.meta.url) emits the deploy matrix to GITHUB_OUTPUT.
 import { execSync } from 'node:child_process';
 
 export const WORKERS = {
@@ -104,11 +102,6 @@ export const WORKERS = {
   'mta-sts': { key: 'mta-sts', dir: 'worker-mta-sts', name: 'adrianwedd-mta-sts', hasPkg: false },
 };
 
-/**
- * Choose which workers to act on.
- * - dispatchTarget 'all' → every worker; a specific key → just that one.
- * - otherwise (push) → workers whose dir contains a changed file.
- */
 export function selectTargets({ changedFiles = [], dispatchTarget = null } = {}) {
   if (dispatchTarget === 'all') return Object.values(WORKERS);
   if (dispatchTarget) return WORKERS[dispatchTarget] ? [WORKERS[dispatchTarget]] : [];
@@ -156,14 +149,129 @@ git commit -m "feat(worker-deploy): worker registry + target selection"
 
 ---
 
-### Task 2: Edge verification prober
+### Task 2: Wrangler deployments parser
+
+**Files:**
+- Create: `scripts/wrangler-deployments.mjs`
+- Test: `test/unit/wrangler-deployments.spec.ts`
+
+**Interfaces:**
+- Produces: `extractDeployMessage(deployments) → string`; `currentVersionId(deployments) → string|null`; `listDeployments(cwd) → Array` (I/O — runs wrangler, not unit-tested).
+- Note on shape (verified against wrangler 4 `cli.js` by both QA engines): `wrangler deployments list --json` returns up to 10 deployments **sorted ascending by `created_on`**, so the newest is `deployments.at(-1)`. The deploy message is a **deployment-level** annotation at `deployment.annotations["workers/message"]`. Each deployment has a `versions` array of `{ version_id, percentage }`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// test/unit/wrangler-deployments.spec.ts
+import { describe, it, expect } from 'vitest';
+import { extractDeployMessage, currentVersionId } from '../../scripts/wrangler-deployments.mjs';
+
+const sample = [
+  { annotations: { 'workers/message': 'gitsha:aaa' }, versions: [{ version_id: 'v-old', percentage: 100 }] },
+  {
+    annotations: { 'workers/message': 'gitsha:bbb1111111111111111111111111111111111111' },
+    versions: [
+      { version_id: 'v-new', percentage: 100 },
+      { version_id: 'v-canary', percentage: 0 },
+    ],
+  },
+];
+
+describe('extractDeployMessage', () => {
+  it('reads the newest deployment message (last element)', () => {
+    expect(extractDeployMessage(sample)).toBe('gitsha:bbb1111111111111111111111111111111111111');
+  });
+  it('returns empty string when there is no message', () => {
+    expect(extractDeployMessage([{ versions: [] }])).toBe('');
+    expect(extractDeployMessage([])).toBe('');
+  });
+});
+
+describe('currentVersionId', () => {
+  it('picks the 100%-traffic version of the newest deployment', () => {
+    expect(currentVersionId(sample)).toBe('v-new');
+  });
+  it('falls back to the last version when none is at 100%', () => {
+    expect(currentVersionId([{ versions: [{ version_id: 'a', percentage: 50 }, { version_id: 'b', percentage: 50 }] }])).toBe('b');
+  });
+  it('returns null when there are no versions', () => {
+    expect(currentVersionId([{ versions: [] }])).toBeNull();
+    expect(currentVersionId([])).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run test/unit/wrangler-deployments.spec.ts`
+Expected: FAIL — cannot resolve module.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```js
+// scripts/wrangler-deployments.mjs
+// Parse `wrangler deployments list --json`. Pure helpers + a thin I/O wrapper.
+// CLI: `node scripts/wrangler-deployments.mjs <current-version|message>` run
+// from within a worker dir; prints to stdout for capture by the deploy step.
+import { execSync } from 'node:child_process';
+
+export function extractDeployMessage(deployments) {
+  return deployments?.at?.(-1)?.annotations?.['workers/message'] ?? '';
+}
+
+export function currentVersionId(deployments) {
+  const d = deployments?.at?.(-1);
+  if (!d?.versions?.length) return null;
+  const at100 = d.versions.find((v) => v.percentage === 100);
+  return (at100 ?? d.versions.at(-1)).version_id ?? null;
+}
+
+export function listDeployments(cwd) {
+  const wrangler = process.env.WRANGLER_BIN ?? 'npx wrangler';
+  const out = execSync(`${wrangler} deployments list --json`, { cwd, encoding: 'utf8' });
+  return JSON.parse(out);
+}
+
+function main() {
+  const cmd = process.argv[2];
+  const deployments = listDeployments(process.cwd());
+  if (cmd === 'current-version') {
+    const v = currentVersionId(deployments);
+    if (!v) process.exit(1);
+    process.stdout.write(v);
+  } else if (cmd === 'message') {
+    process.stdout.write(extractDeployMessage(deployments));
+  } else {
+    process.stderr.write('usage: wrangler-deployments.mjs <current-version|message>\n');
+    process.exit(2);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run test/unit/wrangler-deployments.spec.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/wrangler-deployments.mjs test/unit/wrangler-deployments.spec.ts
+git commit -m "feat(worker-deploy): wrangler deployments parser"
+```
+
+---
+
+### Task 3: Edge verification prober
 
 **Files:**
 - Create: `scripts/verify-worker.mjs`
 - Test: `test/unit/verify-worker.spec.ts`
 
 **Interfaces:**
-- Produces: `assertSocialHealth(status, body) → {ok, reason?}`; `assertCsp(headerValue) → {ok, reason?}`; `assertMtaSts(status, body) → {ok, reason?}`; `probe(key, {attempts, delayMs}) → {ok, reason?}` (I/O, not unit-tested).
+- Produces: `assertSocialHealth(status, body) → {ok, reason?}`; `assertCsp(headerValue, body) → {ok, reason?}`; `assertMtaSts(status, body) → {ok, reason?}`; `probe(key, {attempts, delayMs}) → {ok, reason?}` (I/O, retries internally — not unit-tested).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -185,14 +293,22 @@ describe('assertSocialHealth (liveness)', () => {
 });
 
 describe('assertCsp', () => {
-  it('passes when the header carries a real >=20-char nonce', () => {
-    expect(assertCsp("script-src 'nonce-X0PqfxDjWOOHu7gxnySUAQ' 'strict-dynamic'").ok).toBe(true);
+  const nonce = 'X0PqfxDjWOOHu7gxnySUAQ';
+  it('passes when header nonce is real AND present in the body (worker rewrote HTML)', () => {
+    const header = `script-src 'nonce-${nonce}' 'strict-dynamic'`;
+    const body = `<html><script nonce="${nonce}">x()</script></html>`;
+    expect(assertCsp(header, body).ok).toBe(true);
   });
   it('fails when there is no CSP header at all', () => {
-    expect(assertCsp(null).ok).toBe(false);
+    expect(assertCsp(null, '<html></html>').ok).toBe(false);
   });
   it('fails on a degenerate empty nonce literal', () => {
-    expect(assertCsp("script-src 'nonce-' 'strict-dynamic'").ok).toBe(false);
+    expect(assertCsp("script-src 'nonce-' 'strict-dynamic'", '<html></html>').ok).toBe(false);
+  });
+  it('fails when the header has a nonce but the body was NOT rewritten', () => {
+    const header = `script-src 'nonce-${nonce}' 'strict-dynamic'`;
+    const body = '<html><script>x()</script></html>'; // no nonce in body
+    expect(assertCsp(header, body).ok).toBe(false);
   });
 });
 
@@ -233,11 +349,17 @@ export function assertSocialHealth(status, body) {
   return { ok: true };
 }
 
-const CSP_NONCE_RE = /nonce-[A-Za-z0-9+/=]{20,}/;
-export function assertCsp(headerValue) {
+const CSP_NONCE_RE = /nonce-([A-Za-z0-9+/=]{20,})/;
+export function assertCsp(headerValue, body) {
   if (!headerValue) return { ok: false, reason: 'no Content-Security-Policy response header' };
-  if (!CSP_NONCE_RE.test(headerValue)) {
-    return { ok: false, reason: 'CSP header lacks a real nonce-<base64> token' };
+  const m = CSP_NONCE_RE.exec(headerValue);
+  if (!m) return { ok: false, reason: 'CSP header lacks a real nonce-<base64> token' };
+  const nonce = m[1];
+  // The worker injects the SAME nonce into <script> tags. If the header carries
+  // a nonce but the body doesn't, the worker set a header without rewriting the
+  // HTML — a broken deploy that a header-only check would miss.
+  if (!body || !body.includes(nonce)) {
+    return { ok: false, reason: 'header nonce not found in HTML body (worker did not rewrite the page)' };
   }
   return { ok: true };
 }
@@ -255,7 +377,7 @@ const TARGETS = {
   },
   csp: {
     url: 'https://adrianwedd.com/',
-    check: async (res) => assertCsp(res.headers.get('content-security-policy')),
+    check: async (res) => assertCsp(res.headers.get('content-security-policy'), await res.text()),
   },
   'mta-sts': {
     url: 'https://mta-sts.adrianwedd.com/.well-known/mta-sts.txt',
@@ -297,12 +419,12 @@ if (import.meta.url === `file://${process.argv[1]}`) main();
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `npx vitest run test/unit/verify-worker.spec.ts`
-Expected: PASS (8 tests).
+Expected: PASS (9 tests).
 
-- [ ] **Step 5: Sanity-check the prober against the live edge (all three already deployed)**
+- [ ] **Step 5: Sanity-check against the live edge (all three already deployed)**
 
 Run: `node scripts/verify-worker.mjs csp && node scripts/verify-worker.mjs social && node scripts/verify-worker.mjs mta-sts`
-Expected: three `OK` lines (confirms the assertions match production reality before they gate a deploy).
+Expected: three `OK` lines (confirms the assertions — including the CSP body-nonce check — match production before they gate a deploy).
 
 - [ ] **Step 6: Commit**
 
@@ -313,14 +435,14 @@ git commit -m "feat(worker-deploy): edge verification prober"
 
 ---
 
-### Task 3: Drift classifier
+### Task 4: Drift classifier
 
 **Files:**
 - Create: `scripts/worker-drift.mjs`
 - Test: `test/unit/worker-drift.spec.ts`
 
 **Interfaces:**
-- Consumes: `WORKERS` from `scripts/worker-targets.mjs`.
+- Consumes: `WORKERS` (Task 1), `listDeployments`/`extractDeployMessage` (Task 2).
 - Produces: `parseDeployedSha(message) → string|null`; `classifyDrift({ sha, shaExists, isAncestor, undeployedCount }) → {drift, reason}`.
 
 - [ ] **Step 1: Write the failing test**
@@ -379,6 +501,7 @@ Expected: FAIL — cannot resolve module.
 // a CLI that queries wrangler (READ-ONLY token) and git, and fails on any drift.
 import { execSync } from 'node:child_process';
 import { WORKERS } from './worker-targets.mjs';
+import { listDeployments, extractDeployMessage } from './wrangler-deployments.mjs';
 
 export function parseDeployedSha(message) {
   const m = /gitsha:([0-9a-f]{7,40})/.exec(message ?? '');
@@ -413,28 +536,16 @@ function gitOk(cmd) {
   }
 }
 
-function deployedMessage(worker) {
-  const out = execSync('npx wrangler deployments list --json', {
-    cwd: worker.dir,
-    encoding: 'utf8',
-  });
-  const arr = JSON.parse(out);
-  const newest = arr.at(-1); // list is ascending by created_on, truncated to 10
-  return newest?.annotations?.['workers/message'] ?? '';
-}
-
 function main() {
   let drifted = 0;
   for (const worker of Object.values(WORKERS)) {
-    const sha = parseDeployedSha(deployedMessage(worker));
+    const sha = parseDeployedSha(extractDeployMessage(listDeployments(worker.dir)));
     const shaExists = sha ? gitOk(`git cat-file -e ${sha}^{commit}`) : false;
     const isAncestor = sha && shaExists ? gitOk(`git merge-base --is-ancestor ${sha} HEAD`) : false;
     const undeployedCount =
       sha && isAncestor
         ? Number(
-            execSync(`git rev-list --count ${sha}..HEAD -- ${worker.dir}`, {
-              encoding: 'utf8',
-            }).trim(),
+            execSync(`git rev-list --count ${sha}..HEAD -- ${worker.dir}`, { encoding: 'utf8' }).trim(),
           )
         : 0;
     const r = classifyDrift({ sha, shaExists, isAncestor, undeployedCount });
@@ -464,23 +575,29 @@ git commit -m "feat(worker-deploy): drift classifier"
 
 ---
 
-### Task 4: Deploy/verify/rollback bash step
+### Task 5: Deploy/verify/rollback bash step
 
 **Files:**
 - Create: `scripts/worker-deploy-step.sh`
 
 **Interfaces:**
-- Consumes env: `WORKER_KEY`, `WORKER_DIR`, `WORKER_NAME`, `GIT_SHA`, `GITHUB_WORKSPACE`. Calls `scripts/verify-worker.mjs <key>`.
+- Consumes env: `WORKER_KEY`, `WORKER_DIR`, `WORKER_NAME`, `GIT_SHA`, `GITHUB_WORKSPACE`, `WRANGLER_BIN`. Calls `scripts/wrangler-deployments.mjs current-version` and `scripts/verify-worker.mjs <key>`.
 
 - [ ] **Step 1: Write the script**
 
 ```bash
 #!/usr/bin/env bash
-# One worker's deploy lifecycle: install → test → deploy → verify → rollback.
-# Rollback defaults to the immediately-previous deployment. It refuses (and
-# demands manual action) when Cloudflare blocks rollback across a Durable
-# Object migration or a changed secret.
+# One worker's deploy lifecycle: capture-prev → install → test → deploy →
+# verify → rollback-to-explicit-version. If rollback exits non-zero (a Durable
+# Object migration or a changed secret can block it), demand manual action.
 set -euo pipefail
+
+WRANGLER="${WRANGLER_BIN:-npx wrangler}"
+
+# Capture the currently-live version BEFORE deploying, so rollback targets the
+# exact known-good version rather than wrangler's default heuristic.
+PREV_VERSION="$(cd "$WORKER_DIR" && node "${GITHUB_WORKSPACE}/scripts/wrangler-deployments.mjs" current-version || true)"
+echo "previous version for ${WORKER_NAME}: ${PREV_VERSION:-<none>}"
 
 cd "$WORKER_DIR"
 
@@ -489,11 +606,12 @@ if [ -f package.json ]; then
   case "$WORKER_KEY" in
     social) npm test ;;
     csp) npm test && npx tsc --noEmit ;;
+    *) ;; # a future worker with a package.json but no known test command
   esac
 fi
 
 echo "::group::deploy ${WORKER_NAME}"
-npx wrangler deploy --message "gitsha:${GIT_SHA}"
+"$WRANGLER" deploy --message "gitsha:${GIT_SHA}"
 echo "::endgroup::"
 
 if node "${GITHUB_WORKSPACE}/scripts/verify-worker.mjs" "$WORKER_KEY"; then
@@ -502,26 +620,28 @@ if node "${GITHUB_WORKSPACE}/scripts/verify-worker.mjs" "$WORKER_KEY"; then
 fi
 
 echo "::error::verification failed for ${WORKER_NAME} — attempting rollback"
-if npx wrangler rollback --yes --message "auto-rollback ${GIT_SHA}" 2> rollback.err; then
-  echo "rolled back ${WORKER_NAME}; re-verifying with backoff"
+if [ -z "$PREV_VERSION" ]; then
+  echo "::error::MANUAL INTERVENTION REQUIRED for ${WORKER_NAME}: no previous version captured; cannot auto-rollback. Failed version gitsha:${GIT_SHA} is live."
+  exit 1
+fi
+
+# --yes is belt-and-suspenders; in CI wrangler already auto-confirms (ci-info
+# detects CI). Rolling back to an explicit version id, not the default heuristic.
+if "$WRANGLER" rollback "$PREV_VERSION" --yes --message "auto-rollback ${GIT_SHA}"; then
+  echo "rolled ${WORKER_NAME} back to ${PREV_VERSION}; re-verifying (probe retries internally)"
   node "${GITHUB_WORKSPACE}/scripts/verify-worker.mjs" "$WORKER_KEY" \
     || echo "::error::post-rollback verify still failing for ${WORKER_NAME}"
   exit 1
 fi
 
-cat rollback.err
-if grep -qiE "migration|10220|durable object|cannot be rolled back" rollback.err; then
-  echo "::error::MANUAL INTERVENTION REQUIRED for ${WORKER_NAME}: rollback blocked (Durable Object migration or changed secret). The failed version gitsha:${GIT_SHA} is still live."
-else
-  echo "::error::rollback command itself failed for ${WORKER_NAME}"
-fi
+echo "::error::MANUAL INTERVENTION REQUIRED for ${WORKER_NAME}: rollback to ${PREV_VERSION} failed. A Durable Object migration or a changed secret can block rollback. Failed version gitsha:${GIT_SHA} is live — roll back by hand."
 exit 1
 ```
 
-- [ ] **Step 2: Make it executable + shellcheck**
+- [ ] **Step 2: Syntax-check + optional shellcheck**
 
-Run: `chmod +x scripts/worker-deploy-step.sh && shellcheck scripts/worker-deploy-step.sh`
-Expected: no warnings (if `shellcheck` is unavailable, skip — the workflow calls it via `bash`).
+Run: `bash -n scripts/worker-deploy-step.sh && chmod +x scripts/worker-deploy-step.sh`
+Expected: no output (syntax OK). If `shellcheck` is installed, also run `shellcheck scripts/worker-deploy-step.sh` and expect no warnings.
 
 - [ ] **Step 3: Commit**
 
@@ -532,13 +652,13 @@ git commit -m "feat(worker-deploy): deploy/verify/rollback step script"
 
 ---
 
-### Task 5: The workflow
+### Task 6: The workflow
 
 **Files:**
 - Create: `.github/workflows/worker-deploy.yml`
 
 **Interfaces:**
-- Consumes: `scripts/worker-targets.mjs` (matrix), `scripts/worker-deploy-step.sh`, `scripts/worker-drift.mjs`. Secrets `CLOUDFLARE_API_TOKEN` (env `worker-production`), `CLOUDFLARE_API_TOKEN_READONLY`, `CLOUDFLARE_ACCOUNT_ID`.
+- Consumes: all four scripts. Secrets `CLOUDFLARE_API_TOKEN` (env `worker-production`), `CLOUDFLARE_API_TOKEN_READONLY` (repo), `CLOUDFLARE_ACCOUNT_ID` (repo).
 
 - [ ] **Step 1: Write the workflow**
 
@@ -559,6 +679,11 @@ on:
         type: choice
         default: all
         options: [all, social, csp, mta-sts]
+      mode:
+        description: deploy the target, or run a read-only drift check
+        type: choice
+        default: deploy
+        options: [deploy, drift-only]
   schedule:
     - cron: '0 15 * * *' # ~01:00 AEST, offset from the e2e nightly
 
@@ -567,7 +692,9 @@ permissions:
 
 jobs:
   detect:
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'deploy') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       matrix: ${{ steps.select.outputs.matrix }}
       any: ${{ steps.select.outputs.any }}
@@ -587,9 +714,10 @@ jobs:
 
   deploy:
     needs: detect
-    if: ${{ github.event_name != 'schedule' && needs.detect.outputs.any == 'true' }}
+    if: ${{ needs.detect.outputs.any == 'true' }}
     environment: worker-production
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -607,6 +735,12 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+      - name: Install pinned wrangler toolchain
+        run: |
+          npm --prefix worker ci
+          echo "WRANGLER_BIN=${GITHUB_WORKSPACE}/worker/node_modules/.bin/wrangler" >> "$GITHUB_ENV"
       - name: Deploy, verify, rollback
         env:
           WORKER_KEY: ${{ matrix.worker.key }}
@@ -616,8 +750,9 @@ jobs:
         run: bash scripts/worker-deploy-step.sh
 
   drift-check:
-    if: ${{ github.event_name != 'push' }}
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'drift-only') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_READONLY }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -628,24 +763,30 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+      - name: Install pinned wrangler toolchain
+        run: |
+          npm --prefix worker ci
+          echo "WRANGLER_BIN=${GITHUB_WORKSPACE}/worker/node_modules/.bin/wrangler" >> "$GITHUB_ENV"
       - run: node scripts/worker-drift.mjs
 ```
 
 - [ ] **Step 2: Validate the workflow syntax**
 
-Run: `npx --yes @action-validator/cli .github/workflows/worker-deploy.yml || actionlint .github/workflows/worker-deploy.yml`
-Expected: no errors. (If neither validator is installed, verify YAML parses: `node -e "require('js-yaml').load(require('fs').readFileSync('.github/workflows/worker-deploy.yml','utf8'))"` — expect no throw.)
+Run: `node -e "require('js-yaml').load(require('fs').readFileSync('.github/workflows/worker-deploy.yml','utf8'))"`
+Expected: no throw. If `actionlint` is installed, also run `actionlint .github/workflows/worker-deploy.yml` and expect no errors.
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add .github/workflows/worker-deploy.yml
-git commit -m "ci(worker-deploy): add gated deploy + nightly drift workflow"
+git commit -m "ci(worker-deploy): gated deploy + nightly drift workflow"
 ```
 
 ---
 
-### Task 6: Setup runbook + README fix
+### Task 7: Setup runbook + README fix
 
 **Files:**
 - Create: `docs/runbooks/worker-deploy.md`
@@ -671,10 +812,9 @@ auto-rollback, and a nightly drift check.
    don't need zone scopes).
 2. **Create `CLOUDFLARE_API_TOKEN_READONLY`** — same flow, permission
    **Account → Workers Scripts → Read** only.
-3. **Add repo secret `CLOUDFLARE_ACCOUNT_ID`** (Settings → Secrets and variables
-   → Actions → repository secrets).
-4. **Add `CLOUDFLARE_API_TOKEN_READONLY`** as a repository secret (ungated).
-5. **Create the `worker-production` environment** (Settings → Environments):
+3. **Add repo secrets** `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN_READONLY`
+   (Settings → Secrets and variables → Actions → repository secrets).
+4. **Create the `worker-production` environment** (Settings → Environments):
    add **required reviewer = Adrian**, then add `CLOUDFLARE_API_TOKEN` as an
    **environment** secret scoped to it.
 
@@ -682,21 +822,24 @@ auto-rollback, and a nightly drift check.
 
 - **push to main** touching `worker*/` → `deploy` job pauses for approval →
   approve → deploy + verify at the edge → auto-rollback on failure.
-- **nightly / dispatch** → `drift-check` compares each deployed worker's stamped
-  `gitsha:` against `main` and fails red on divergence.
-- **manual** → Actions → Worker Deploy → Run workflow → pick `target`.
+- **nightly** → `drift-check` compares each deployed worker's stamped `gitsha:`
+  against `main` and fails red on divergence.
+- **manual** → Actions → Worker Deploy → Run workflow → choose `mode`
+  (`deploy` a `target`, or `drift-only` for a read-only check).
 
 ## Limitations
 
-- No auto-rollback across a Durable Object migration (only `worker/` has one).
-  A blocked rollback prints "MANUAL INTERVENTION REQUIRED"; roll back by hand.
+- Rollback targets the explicit pre-deploy version. If wrangler refuses (a
+  Durable Object migration or a changed secret can block it), the run prints
+  "MANUAL INTERVENTION REQUIRED" and leaves the failed version live — roll back
+  by hand. Only `worker/` has a Durable Object migration.
 - `/api/health` verification is a liveness probe; token health is owned by
   `social-token-alert.yml`.
 ```
 
 - [ ] **Step 2: Fix the stale worker-csp README**
 
-Open `worker-csp/README.md`, replace any "Not deployed" / "routes are commented out" status text with the accurate state:
+Open `worker-csp/README.md`, replace any "Not deployed" / "routes are commented out" status text with:
 
 ```markdown
 **Status:** Live. Routed on `adrianwedd.com/*` (see `wrangler.toml`). Deployed via
@@ -705,7 +848,7 @@ Open `worker-csp/README.md`, replace any "Not deployed" / "routes are commented 
 
 - [ ] **Step 3: Point CLAUDE.md at the runbook**
 
-In the CLAUDE.md Worker section, replace the manual-deploy note (`Deploy: cd worker && npx wrangler deploy`) with a line noting deploys are automated:
+In the CLAUDE.md Worker section, replace the manual-deploy note (`Deploy: cd worker && npx wrangler deploy`) with:
 
 ```markdown
 **Deploy:** automated via `.github/workflows/worker-deploy.yml` (gated approval +
@@ -716,7 +859,7 @@ edge verify + auto-rollback + nightly drift check). See
 - [ ] **Step 4: Run the full local gate**
 
 Run: `npm run test:unit && npm run lint`
-Expected: all unit tests pass (incl. the 3 new specs), lint clean.
+Expected: all unit tests pass (incl. the 4 new specs), lint clean.
 
 - [ ] **Step 5: Commit**
 
@@ -727,21 +870,23 @@ git commit -m "docs(worker-deploy): setup runbook + fix stale csp README"
 
 ---
 
-### Task 7: Post-merge live validation (blocked on Adrian's token setup)
+### Task 8: Post-merge live validation (blocked on Adrian's token setup)
 
-**Not code** — a validation checklist to run after Task 6 merges AND the one-time
+**Not code** — a validation checklist to run after Task 7 merges AND the one-time
 setup in the runbook is done. Cannot run earlier (needs the secrets + environment).
 
-- [ ] **Step 1:** Dispatch against the lowest-blast-radius worker first: Actions → Worker Deploy → Run workflow → `target: mta-sts`. Approve at the gate. Expect: deploy → `verify mta-sts: OK` → green.
+- [ ] **Step 1:** Dispatch against the lowest-blast-radius worker first: Actions → Worker Deploy → Run workflow → `mode: deploy`, `target: mta-sts`. Approve at the gate. Expect: deploy → `verify mta-sts: OK` → green.
 - [ ] **Step 2:** Repeat with `target: social`, then `target: csp`. Expect green each time; confirm the site still serves a CSP header after the csp run (`curl -sI https://adrianwedd.com/ | grep -i content-security-policy`).
-- [ ] **Step 3: Prove rollback.** Temporarily edit `scripts/verify-worker.mjs`'s mta-sts assertion to require an impossible string, push via a throwaway branch + dispatch `target: mta-sts`. Expect: verify fails → `wrangler rollback` runs → run red, prior version restored. Revert the edit.
-- [ ] **Step 4: Prove drift both ways.** Run workflow with default `target` on a day with no worker changes → drift-check green. Then merge a no-op comment change under `worker-mta-sts/` **without** approving its deploy, and dispatch again → drift-check red with "undeployed commit(s)" for mta-sts. Approve the pending deploy to clear it.
+- [ ] **Step 3: Prove rollback.** On a throwaway branch, temporarily edit `scripts/verify-worker.mjs`'s mta-sts assertion to require an impossible string; dispatch `mode: deploy`, `target: mta-sts`. Expect: verify fails → `wrangler rollback <prev>` runs → prior version restored → run red. Revert the edit.
+- [ ] **Step 4: Prove drift both ways.** Dispatch `mode: drift-only` on a day with no worker changes → drift-check green. Then merge a no-op comment change under `worker-mta-sts/` **without** approving its deploy, and dispatch `mode: drift-only` again → drift-check red with "undeployed commit(s)" for mta-sts. Approve the pending deploy to clear it.
 - [ ] **Step 5:** Update the Sprint 39 checkboxes in `docs/ROADMAP-2026-H2.md` and note completion.
 
 ---
 
 ## Self-review
 
-- **Spec coverage:** trigger+gate (Task 5 `deploy` job + environment), path filter (Task 5), per-worker conditional install/test (Tasks 4/5 via `hasPkg`+key), capture/deploy/verify/rollback with `--yes` and migration refusal (Task 4), two-token model (Tasks 5/6), verification checks incl. real-nonce CSP + honest liveness (Task 2), drift SHA classification incl. `cat-file`/ancestor/`at(-1)`/annotation path (Task 3), `permissions`/concurrency/`fetch-depth`/SHA-pins (Tasks 1–5 Global Constraints), runbook + README fix (Task 6), staged live validation incl. rollback + drift proofs (Task 7). All spec sections map to a task.
+- **Spec coverage:** trigger+gate (Task 6 `deploy` + environment), path filter (Task 6), per-worker conditional install/test with catch-all (Task 5), **explicit-version** capture/deploy/verify/rollback with honest manual-intervention on rollback failure (Tasks 2/5), two-token model (Tasks 6/7), verification incl. real-nonce + **body-rewrite** CSP check and honest liveness (Task 3), drift SHA classification incl. `cat-file`/ancestor/`at(-1)`/annotation path (Tasks 2/4), **drift-only manual mode** (Task 6), pinned-wrangler toolchain (Global Constraints + Task 6), `permissions`/per-worker-concurrency/timeouts/`cache`/`fetch-depth`/SHA-pins (Task 6), runbook + README fix (Task 7), staged live validation incl. rollback + drift proofs (Task 8). All spec sections map to a task.
+- **QA findings addressed:** rollback wrong-version (explicit `PREV_VERSION`), fictional migration grep removed (honest rollback-failure path), CSP body check, no-wrangler-in-CI (pinned toolchain + `WRANGLER_BIN`), `mta-sts` `npm ci` skip, drift-only mode, timeouts, npm cache, detect gated off schedule, bash `case` catch-all, deployment-message parsing extracted + tested, `--yes` reasoning corrected, lint-via-`npm run lint` only.
 - **Placeholder scan:** no TBD/TODO; all code blocks complete.
-- **Type consistency:** `selectTargets`/`WORKERS` shape (`key,dir,name,hasPkg`) is consistent across Tasks 1, 3, 5; `probe(key,…)` and the three `assert*` signatures match between Task 2 code and tests; `classifyDrift`/`parseDeployedSha` signatures match between Task 3 code and tests; env var names (`WORKER_KEY`/`WORKER_DIR`/`WORKER_NAME`/`GIT_SHA`) match between Task 4 script and Task 5 workflow.
+- **Type consistency:** `WORKERS` shape (`key,dir,name,hasPkg`) consistent across Tasks 1/4/6; `extractDeployMessage`/`currentVersionId`/`listDeployments` consistent across Tasks 2/4/5; `assertCsp(headerValue, body)` two-arg signature matches between Task 3 code, its tests, and the `probe` caller; `classifyDrift`/`parseDeployedSha` match Task 4 code/tests; env vars (`WORKER_KEY`/`WORKER_DIR`/`WORKER_NAME`/`GIT_SHA`/`WRANGLER_BIN`/`GITHUB_WORKSPACE`) match between Task 5 script and Task 6 workflow.
+```

--- a/docs/superpowers/plans/2026-07-06-sprint39-worker-deploy-automation.md
+++ b/docs/superpowers/plans/2026-07-06-sprint39-worker-deploy-automation.md
@@ -1,0 +1,747 @@
+# Worker Deploy Automation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-deploy the three Cloudflare Workers on merge to `main`, gated by a GitHub Environment approval, with post-deploy edge verification, auto-rollback on failure, and a nightly drift check.
+
+**Architecture:** One workflow (`.github/workflows/worker-deploy.yml`) drives three small, independently unit-tested Node scripts — a target selector, an edge-verification prober, and a drift classifier — plus one bash deploy step. Deploy jobs reference a gated `worker-production` environment (write token); the ungated nightly drift job uses a separate repo-level read-only token.
+
+**Tech Stack:** GitHub Actions, Node 22 (ESM `.mjs`), vitest (root `test:unit` suite), wrangler (already a worker devDep), bash.
+
+## Global Constraints
+
+- **Two Cloudflare tokens.** `CLOUDFLARE_API_TOKEN` (Edit Workers) lives in the **gated** `worker-production` environment; `CLOUDFLARE_API_TOKEN_READONLY` (Read Workers) is a **repo-level** secret used only by the drift job. `CLOUDFLARE_ACCOUNT_ID` is repo-level. CI never handles the 14 platform secrets.
+- **No platform-secret exposure.** `wrangler deploy` inherits existing secrets; never add `wrangler secret put` to CI.
+- **`mta-sts` has no `package.json`** — never run `npm ci`/tests there.
+- **SHA-pin actions** per repo convention: `actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0`, `actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0`.
+- **`permissions: contents: read`** at workflow top level; nothing else.
+- **CSP nonce must be real:** regex `nonce-[A-Za-z0-9+/=]{20,}`.
+- **`/api/health` is a liveness probe only** (unauth response is `{"ok":true}`).
+- **No auto-rollback across a Durable Object migration** — detect the migration-block error and demand manual intervention.
+- Unit tests go in `test/unit/*.spec.ts` (picked up by the existing `npm run test:unit`); scripts live in `scripts/*.mjs`.
+
+## File structure
+
+- `scripts/worker-targets.mjs` — worker registry + `selectTargets()`; CLI emits the deploy matrix.
+- `scripts/verify-worker.mjs` — pure assertion fns + a retrying `probe()`; CLI verifies one worker at the live edge.
+- `scripts/worker-drift.mjs` — `parseDeployedSha()` + `classifyDrift()`; CLI checks all workers and fails on drift.
+- `scripts/worker-deploy-step.sh` — install/test/deploy/verify/rollback for one worker (invoked per matrix entry).
+- `.github/workflows/worker-deploy.yml` — the workflow wiring it all together.
+- `test/unit/worker-targets.spec.ts`, `test/unit/verify-worker.spec.ts`, `test/unit/worker-drift.spec.ts` — unit tests.
+- `docs/runbooks/worker-deploy.md` — token/environment setup runbook.
+- `worker-csp/README.md` — fix the stale "Not deployed" claim.
+
+---
+
+### Task 1: Worker registry + target selection
+
+**Files:**
+- Create: `scripts/worker-targets.mjs`
+- Test: `test/unit/worker-targets.spec.ts`
+
+**Interfaces:**
+- Produces: `WORKERS` (object keyed by `social`/`csp`/`mta-sts`, each `{ key, dir, name, hasPkg }`); `selectTargets({ changedFiles, dispatchTarget }) → Array<worker>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// test/unit/worker-targets.spec.ts
+import { describe, it, expect } from 'vitest';
+import { WORKERS, selectTargets } from '../../scripts/worker-targets.mjs';
+
+describe('selectTargets', () => {
+  it('dispatch "all" returns every worker', () => {
+    expect(selectTargets({ dispatchTarget: 'all' }).map((w) => w.key).sort()).toEqual([
+      'csp',
+      'mta-sts',
+      'social',
+    ]);
+  });
+
+  it('dispatch of a single worker returns just that one', () => {
+    expect(selectTargets({ dispatchTarget: 'csp' })).toEqual([WORKERS.csp]);
+  });
+
+  it('push maps changed files to their worker dirs', () => {
+    const changed = ['worker-csp/src/index.ts', 'README.md'];
+    expect(selectTargets({ changedFiles: changed }).map((w) => w.key)).toEqual(['csp']);
+  });
+
+  it('push matches the dir prefix but not a lookalike sibling', () => {
+    // "worker-csp" must not be matched by a path under "worker/" and vice-versa
+    expect(selectTargets({ changedFiles: ['worker/src/index.ts'] }).map((w) => w.key)).toEqual([
+      'social',
+    ]);
+  });
+
+  it('push with no worker changes returns nothing', () => {
+    expect(selectTargets({ changedFiles: ['src/pages/index.astro'] })).toEqual([]);
+  });
+
+  it('mta-sts is flagged hasPkg:false', () => {
+    expect(WORKERS['mta-sts'].hasPkg).toBe(false);
+    expect(WORKERS.social.hasPkg).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run test/unit/worker-targets.spec.ts`
+Expected: FAIL — cannot resolve `../../scripts/worker-targets.mjs`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```js
+// scripts/worker-targets.mjs
+// Registry of the three Cloudflare workers + pure target selection. Also a CLI
+// entry (guarded by import.meta.url) that emits the deploy matrix to GITHUB_OUTPUT.
+import { execSync } from 'node:child_process';
+
+export const WORKERS = {
+  social: { key: 'social', dir: 'worker', name: 'adrianwedd-social', hasPkg: true },
+  csp: { key: 'csp', dir: 'worker-csp', name: 'adrianwedd-csp', hasPkg: true },
+  'mta-sts': { key: 'mta-sts', dir: 'worker-mta-sts', name: 'adrianwedd-mta-sts', hasPkg: false },
+};
+
+/**
+ * Choose which workers to act on.
+ * - dispatchTarget 'all' → every worker; a specific key → just that one.
+ * - otherwise (push) → workers whose dir contains a changed file.
+ */
+export function selectTargets({ changedFiles = [], dispatchTarget = null } = {}) {
+  if (dispatchTarget === 'all') return Object.values(WORKERS);
+  if (dispatchTarget) return WORKERS[dispatchTarget] ? [WORKERS[dispatchTarget]] : [];
+  return Object.values(WORKERS).filter((w) =>
+    changedFiles.some((f) => f === w.dir || f.startsWith(w.dir + '/')),
+  );
+}
+
+function main() {
+  const event = process.env.EVENT;
+  let changedFiles = [];
+  let dispatchTarget = null;
+  if (event === 'workflow_dispatch') dispatchTarget = process.env.DISPATCH_TARGET || 'all';
+  else if (event === 'schedule') dispatchTarget = 'all';
+  else {
+    const before = process.env.BEFORE;
+    const head = process.env.GITHUB_SHA || 'HEAD';
+    const base =
+      !before || /^0+$/.test(before)
+        ? execSync('git rev-list --max-parents=0 HEAD', { encoding: 'utf8' }).trim().split('\n').pop()
+        : before;
+    changedFiles = execSync(`git diff --name-only ${base} ${head}`, { encoding: 'utf8' })
+      .split('\n')
+      .filter(Boolean);
+  }
+  const targets = selectTargets({ changedFiles, dispatchTarget });
+  process.stdout.write(`matrix=${JSON.stringify(targets)}\n`);
+  process.stdout.write(`any=${targets.length > 0}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run test/unit/worker-targets.spec.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/worker-targets.mjs test/unit/worker-targets.spec.ts
+git commit -m "feat(worker-deploy): worker registry + target selection"
+```
+
+---
+
+### Task 2: Edge verification prober
+
+**Files:**
+- Create: `scripts/verify-worker.mjs`
+- Test: `test/unit/verify-worker.spec.ts`
+
+**Interfaces:**
+- Produces: `assertSocialHealth(status, body) → {ok, reason?}`; `assertCsp(headerValue) → {ok, reason?}`; `assertMtaSts(status, body) → {ok, reason?}`; `probe(key, {attempts, delayMs}) → {ok, reason?}` (I/O, not unit-tested).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// test/unit/verify-worker.spec.ts
+import { describe, it, expect } from 'vitest';
+import { assertSocialHealth, assertCsp, assertMtaSts } from '../../scripts/verify-worker.mjs';
+
+describe('assertSocialHealth (liveness)', () => {
+  it('passes on 200 + the unauth {"ok":true} body', () => {
+    expect(assertSocialHealth(200, '{"ok":true}').ok).toBe(true);
+  });
+  it('fails on non-200', () => {
+    expect(assertSocialHealth(503, '{"ok":true}').ok).toBe(false);
+  });
+  it('fails on non-JSON body', () => {
+    expect(assertSocialHealth(200, '<html>error</html>').ok).toBe(false);
+  });
+});
+
+describe('assertCsp', () => {
+  it('passes when the header carries a real >=20-char nonce', () => {
+    expect(assertCsp("script-src 'nonce-X0PqfxDjWOOHu7gxnySUAQ' 'strict-dynamic'").ok).toBe(true);
+  });
+  it('fails when there is no CSP header at all', () => {
+    expect(assertCsp(null).ok).toBe(false);
+  });
+  it('fails on a degenerate empty nonce literal', () => {
+    expect(assertCsp("script-src 'nonce-' 'strict-dynamic'").ok).toBe(false);
+  });
+});
+
+describe('assertMtaSts', () => {
+  it('passes on 200 + version: STSv1', () => {
+    expect(assertMtaSts(200, 'version: STSv1\nmode: enforce\n').ok).toBe(true);
+  });
+  it('fails when the body lacks the version line', () => {
+    expect(assertMtaSts(200, 'mode: enforce\n').ok).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run test/unit/verify-worker.spec.ts`
+Expected: FAIL — cannot resolve module.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```js
+// scripts/verify-worker.mjs
+// Post-deploy edge verification. Pure assertion fns + a retrying probe runner.
+// CLI: `node scripts/verify-worker.mjs <social|csp|mta-sts>` → exit 0 pass / 1 fail.
+
+export function assertSocialHealth(status, body) {
+  // Liveness/routing probe only — the unauthenticated response is {"ok":true}.
+  if (status !== 200) return { ok: false, reason: `expected 200, got ${status}` };
+  let json;
+  try {
+    json = JSON.parse(body);
+  } catch {
+    return { ok: false, reason: 'body is not valid JSON' };
+  }
+  if (typeof json !== 'object' || json === null) {
+    return { ok: false, reason: 'JSON body is not an object' };
+  }
+  return { ok: true };
+}
+
+const CSP_NONCE_RE = /nonce-[A-Za-z0-9+/=]{20,}/;
+export function assertCsp(headerValue) {
+  if (!headerValue) return { ok: false, reason: 'no Content-Security-Policy response header' };
+  if (!CSP_NONCE_RE.test(headerValue)) {
+    return { ok: false, reason: 'CSP header lacks a real nonce-<base64> token' };
+  }
+  return { ok: true };
+}
+
+export function assertMtaSts(status, body) {
+  if (status !== 200) return { ok: false, reason: `expected 200, got ${status}` };
+  if (!/version:\s*STSv1/.test(body)) return { ok: false, reason: 'body missing "version: STSv1"' };
+  return { ok: true };
+}
+
+const TARGETS = {
+  social: {
+    url: 'https://social.adrianwedd.com/api/health',
+    check: async (res) => assertSocialHealth(res.status, await res.text()),
+  },
+  csp: {
+    url: 'https://adrianwedd.com/',
+    check: async (res) => assertCsp(res.headers.get('content-security-policy')),
+  },
+  'mta-sts': {
+    url: 'https://mta-sts.adrianwedd.com/.well-known/mta-sts.txt',
+    check: async (res) => assertMtaSts(res.status, await res.text()),
+  },
+};
+
+export async function probe(key, { attempts = 5, delayMs = 10000 } = {}) {
+  const t = TARGETS[key];
+  if (!t) return { ok: false, reason: `unknown worker key: ${key}` };
+  let last = { ok: false, reason: 'no attempts made' };
+  for (let i = 1; i <= attempts; i++) {
+    try {
+      const res = await fetch(t.url, { redirect: 'manual' });
+      last = await t.check(res);
+    } catch (e) {
+      last = { ok: false, reason: `fetch error: ${e.message}` };
+    }
+    if (last.ok) return last;
+    if (i < attempts) await new Promise((r) => setTimeout(r, delayMs));
+  }
+  return last;
+}
+
+async function main() {
+  const key = process.argv[2];
+  const result = await probe(key);
+  if (result.ok) {
+    console.log(`verify ${key}: OK`);
+    process.exit(0);
+  }
+  console.error(`verify ${key}: FAIL — ${result.reason}`);
+  process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run test/unit/verify-worker.spec.ts`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Sanity-check the prober against the live edge (all three already deployed)**
+
+Run: `node scripts/verify-worker.mjs csp && node scripts/verify-worker.mjs social && node scripts/verify-worker.mjs mta-sts`
+Expected: three `OK` lines (confirms the assertions match production reality before they gate a deploy).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/verify-worker.mjs test/unit/verify-worker.spec.ts
+git commit -m "feat(worker-deploy): edge verification prober"
+```
+
+---
+
+### Task 3: Drift classifier
+
+**Files:**
+- Create: `scripts/worker-drift.mjs`
+- Test: `test/unit/worker-drift.spec.ts`
+
+**Interfaces:**
+- Consumes: `WORKERS` from `scripts/worker-targets.mjs`.
+- Produces: `parseDeployedSha(message) → string|null`; `classifyDrift({ sha, shaExists, isAncestor, undeployedCount }) → {drift, reason}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// test/unit/worker-drift.spec.ts
+import { describe, it, expect } from 'vitest';
+import { parseDeployedSha, classifyDrift } from '../../scripts/worker-drift.mjs';
+
+describe('parseDeployedSha', () => {
+  it('extracts the sha from a gitsha: message', () => {
+    expect(parseDeployedSha('gitsha:e43d57a0f1c2b3a4d5e6f7a8b9c0d1e2f3a4b5c6')).toBe(
+      'e43d57a0f1c2b3a4d5e6f7a8b9c0d1e2f3a4b5c6',
+    );
+  });
+  it('returns null for an unstamped message', () => {
+    expect(parseDeployedSha('Manual deploy')).toBeNull();
+    expect(parseDeployedSha('')).toBeNull();
+    expect(parseDeployedSha(null)).toBeNull();
+  });
+});
+
+describe('classifyDrift', () => {
+  it('unstamped → drift', () => {
+    expect(classifyDrift({ sha: null }).drift).toBe(true);
+  });
+  it('sha absent from repo → drift', () => {
+    expect(classifyDrift({ sha: 'deadbeef', shaExists: false }).drift).toBe(true);
+  });
+  it('sha not an ancestor → drift', () => {
+    expect(classifyDrift({ sha: 'abc', shaExists: true, isAncestor: false }).drift).toBe(true);
+  });
+  it('undeployed commits touch the worker → drift', () => {
+    expect(
+      classifyDrift({ sha: 'abc', shaExists: true, isAncestor: true, undeployedCount: 2 }).drift,
+    ).toBe(true);
+  });
+  it('in sync → no drift', () => {
+    const r = classifyDrift({ sha: 'abc', shaExists: true, isAncestor: true, undeployedCount: 0 });
+    expect(r.drift).toBe(false);
+    expect(r.reason).toMatch(/in sync/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run test/unit/worker-drift.spec.ts`
+Expected: FAIL — cannot resolve module.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```js
+// scripts/worker-drift.mjs
+// Drift check: is each deployed worker in sync with main? Pure classifier +
+// a CLI that queries wrangler (READ-ONLY token) and git, and fails on any drift.
+import { execSync } from 'node:child_process';
+import { WORKERS } from './worker-targets.mjs';
+
+export function parseDeployedSha(message) {
+  const m = /gitsha:([0-9a-f]{7,40})/.exec(message ?? '');
+  return m ? m[1] : null;
+}
+
+export function classifyDrift({ sha, shaExists, isAncestor, undeployedCount } = {}) {
+  if (!sha) {
+    return {
+      drift: true,
+      reason: 'unstamped (deployed out-of-band, or >10 unstamped deploys hid the stamp)',
+    };
+  }
+  if (!shaExists) {
+    return { drift: true, reason: `deployed SHA ${sha} absent from repo (force-push / other branch)` };
+  }
+  if (!isAncestor) {
+    return { drift: true, reason: `deployed SHA ${sha} not an ancestor of HEAD (history rewritten)` };
+  }
+  if (undeployedCount > 0) {
+    return { drift: true, reason: `${undeployedCount} undeployed commit(s) touch this worker` };
+  }
+  return { drift: false, reason: 'in sync' };
+}
+
+function gitOk(cmd) {
+  try {
+    execSync(cmd, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function deployedMessage(worker) {
+  const out = execSync('npx wrangler deployments list --json', {
+    cwd: worker.dir,
+    encoding: 'utf8',
+  });
+  const arr = JSON.parse(out);
+  const newest = arr.at(-1); // list is ascending by created_on, truncated to 10
+  return newest?.annotations?.['workers/message'] ?? '';
+}
+
+function main() {
+  let drifted = 0;
+  for (const worker of Object.values(WORKERS)) {
+    const sha = parseDeployedSha(deployedMessage(worker));
+    const shaExists = sha ? gitOk(`git cat-file -e ${sha}^{commit}`) : false;
+    const isAncestor = sha && shaExists ? gitOk(`git merge-base --is-ancestor ${sha} HEAD`) : false;
+    const undeployedCount =
+      sha && isAncestor
+        ? Number(
+            execSync(`git rev-list --count ${sha}..HEAD -- ${worker.dir}`, {
+              encoding: 'utf8',
+            }).trim(),
+          )
+        : 0;
+    const r = classifyDrift({ sha, shaExists, isAncestor, undeployedCount });
+    console.log(`${r.drift ? 'DRIFT' : 'ok   '}  ${worker.name}: ${r.reason}`);
+    if (r.drift) drifted++;
+  }
+  if (drifted > 0) {
+    console.error(`::error::${drifted} worker(s) drifted from main`);
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run test/unit/worker-drift.spec.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/worker-drift.mjs test/unit/worker-drift.spec.ts
+git commit -m "feat(worker-deploy): drift classifier"
+```
+
+---
+
+### Task 4: Deploy/verify/rollback bash step
+
+**Files:**
+- Create: `scripts/worker-deploy-step.sh`
+
+**Interfaces:**
+- Consumes env: `WORKER_KEY`, `WORKER_DIR`, `WORKER_NAME`, `GIT_SHA`, `GITHUB_WORKSPACE`. Calls `scripts/verify-worker.mjs <key>`.
+
+- [ ] **Step 1: Write the script**
+
+```bash
+#!/usr/bin/env bash
+# One worker's deploy lifecycle: install → test → deploy → verify → rollback.
+# Rollback defaults to the immediately-previous deployment. It refuses (and
+# demands manual action) when Cloudflare blocks rollback across a Durable
+# Object migration or a changed secret.
+set -euo pipefail
+
+cd "$WORKER_DIR"
+
+if [ -f package.json ]; then
+  npm ci
+  case "$WORKER_KEY" in
+    social) npm test ;;
+    csp) npm test && npx tsc --noEmit ;;
+  esac
+fi
+
+echo "::group::deploy ${WORKER_NAME}"
+npx wrangler deploy --message "gitsha:${GIT_SHA}"
+echo "::endgroup::"
+
+if node "${GITHUB_WORKSPACE}/scripts/verify-worker.mjs" "$WORKER_KEY"; then
+  echo "verification passed for ${WORKER_NAME}"
+  exit 0
+fi
+
+echo "::error::verification failed for ${WORKER_NAME} — attempting rollback"
+if npx wrangler rollback --yes --message "auto-rollback ${GIT_SHA}" 2> rollback.err; then
+  echo "rolled back ${WORKER_NAME}; re-verifying with backoff"
+  node "${GITHUB_WORKSPACE}/scripts/verify-worker.mjs" "$WORKER_KEY" \
+    || echo "::error::post-rollback verify still failing for ${WORKER_NAME}"
+  exit 1
+fi
+
+cat rollback.err
+if grep -qiE "migration|10220|durable object|cannot be rolled back" rollback.err; then
+  echo "::error::MANUAL INTERVENTION REQUIRED for ${WORKER_NAME}: rollback blocked (Durable Object migration or changed secret). The failed version gitsha:${GIT_SHA} is still live."
+else
+  echo "::error::rollback command itself failed for ${WORKER_NAME}"
+fi
+exit 1
+```
+
+- [ ] **Step 2: Make it executable + shellcheck**
+
+Run: `chmod +x scripts/worker-deploy-step.sh && shellcheck scripts/worker-deploy-step.sh`
+Expected: no warnings (if `shellcheck` is unavailable, skip — the workflow calls it via `bash`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/worker-deploy-step.sh
+git commit -m "feat(worker-deploy): deploy/verify/rollback step script"
+```
+
+---
+
+### Task 5: The workflow
+
+**Files:**
+- Create: `.github/workflows/worker-deploy.yml`
+
+**Interfaces:**
+- Consumes: `scripts/worker-targets.mjs` (matrix), `scripts/worker-deploy-step.sh`, `scripts/worker-drift.mjs`. Secrets `CLOUDFLARE_API_TOKEN` (env `worker-production`), `CLOUDFLARE_API_TOKEN_READONLY`, `CLOUDFLARE_ACCOUNT_ID`.
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+name: Worker Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'worker/**'
+      - 'worker-csp/**'
+      - 'worker-mta-sts/**'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Which worker(s) to deploy
+        type: choice
+        default: all
+        options: [all, social, csp, mta-sts]
+  schedule:
+    - cron: '0 15 * * *' # ~01:00 AEST, offset from the e2e nightly
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+      any: ${{ steps.select.outputs.any }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - id: select
+        env:
+          EVENT: ${{ github.event_name }}
+          BEFORE: ${{ github.event.before }}
+          DISPATCH_TARGET: ${{ github.event.inputs.target }}
+        run: node scripts/worker-targets.mjs >> "$GITHUB_OUTPUT"
+
+  deploy:
+    needs: detect
+    if: ${{ github.event_name != 'schedule' && needs.detect.outputs.any == 'true' }}
+    environment: worker-production
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        worker: ${{ fromJSON(needs.detect.outputs.matrix) }}
+    concurrency:
+      group: worker-deploy-${{ matrix.worker.key }}
+      cancel-in-progress: false
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - name: Deploy, verify, rollback
+        env:
+          WORKER_KEY: ${{ matrix.worker.key }}
+          WORKER_DIR: ${{ matrix.worker.dir }}
+          WORKER_NAME: ${{ matrix.worker.name }}
+          GIT_SHA: ${{ github.sha }}
+        run: bash scripts/worker-deploy-step.sh
+
+  drift-check:
+    if: ${{ github.event_name != 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_READONLY }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - run: node scripts/worker-drift.mjs
+```
+
+- [ ] **Step 2: Validate the workflow syntax**
+
+Run: `npx --yes @action-validator/cli .github/workflows/worker-deploy.yml || actionlint .github/workflows/worker-deploy.yml`
+Expected: no errors. (If neither validator is installed, verify YAML parses: `node -e "require('js-yaml').load(require('fs').readFileSync('.github/workflows/worker-deploy.yml','utf8'))"` — expect no throw.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/worker-deploy.yml
+git commit -m "ci(worker-deploy): add gated deploy + nightly drift workflow"
+```
+
+---
+
+### Task 6: Setup runbook + README fix
+
+**Files:**
+- Create: `docs/runbooks/worker-deploy.md`
+- Modify: `worker-csp/README.md` (correct the stale "Not deployed" status)
+- Modify: `CLAUDE.md` (point the Worker section at the new runbook)
+
+- [ ] **Step 1: Write the runbook**
+
+```markdown
+# Worker deploy runbook
+
+`.github/workflows/worker-deploy.yml` auto-deploys the three workers on merge to
+`main` (path-filtered), behind an approval gate, with edge verification,
+auto-rollback, and a nightly drift check.
+
+## One-time setup (required before first CI deploy)
+
+1. **Create `CLOUDFLARE_API_TOKEN`** — Cloudflare dashboard → My Profile → API
+   Tokens → Create Token. Permissions: **Account → Workers Scripts → Edit** and
+   **Account → Account Settings → Read**. Add **Zone → Workers Routes → Edit**
+   and **Zone → DNS → Edit** only if CI must ever (re)create the `worker-csp`
+   route or the `mta-sts` custom domain (all three already exist, so redeploys
+   don't need zone scopes).
+2. **Create `CLOUDFLARE_API_TOKEN_READONLY`** — same flow, permission
+   **Account → Workers Scripts → Read** only.
+3. **Add repo secret `CLOUDFLARE_ACCOUNT_ID`** (Settings → Secrets and variables
+   → Actions → repository secrets).
+4. **Add `CLOUDFLARE_API_TOKEN_READONLY`** as a repository secret (ungated).
+5. **Create the `worker-production` environment** (Settings → Environments):
+   add **required reviewer = Adrian**, then add `CLOUDFLARE_API_TOKEN` as an
+   **environment** secret scoped to it.
+
+## Flow
+
+- **push to main** touching `worker*/` → `deploy` job pauses for approval →
+  approve → deploy + verify at the edge → auto-rollback on failure.
+- **nightly / dispatch** → `drift-check` compares each deployed worker's stamped
+  `gitsha:` against `main` and fails red on divergence.
+- **manual** → Actions → Worker Deploy → Run workflow → pick `target`.
+
+## Limitations
+
+- No auto-rollback across a Durable Object migration (only `worker/` has one).
+  A blocked rollback prints "MANUAL INTERVENTION REQUIRED"; roll back by hand.
+- `/api/health` verification is a liveness probe; token health is owned by
+  `social-token-alert.yml`.
+```
+
+- [ ] **Step 2: Fix the stale worker-csp README**
+
+Open `worker-csp/README.md`, replace any "Not deployed" / "routes are commented out" status text with the accurate state:
+
+```markdown
+**Status:** Live. Routed on `adrianwedd.com/*` (see `wrangler.toml`). Deployed via
+`.github/workflows/worker-deploy.yml` — see `docs/runbooks/worker-deploy.md`.
+```
+
+- [ ] **Step 3: Point CLAUDE.md at the runbook**
+
+In the CLAUDE.md Worker section, replace the manual-deploy note (`Deploy: cd worker && npx wrangler deploy`) with a line noting deploys are automated:
+
+```markdown
+**Deploy:** automated via `.github/workflows/worker-deploy.yml` (gated approval +
+edge verify + auto-rollback + nightly drift check). See
+`docs/runbooks/worker-deploy.md`. Manual fallback: `cd <worker> && npx wrangler deploy`.
+```
+
+- [ ] **Step 4: Run the full local gate**
+
+Run: `npm run test:unit && npm run lint`
+Expected: all unit tests pass (incl. the 3 new specs), lint clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/runbooks/worker-deploy.md worker-csp/README.md CLAUDE.md
+git commit -m "docs(worker-deploy): setup runbook + fix stale csp README"
+```
+
+---
+
+### Task 7: Post-merge live validation (blocked on Adrian's token setup)
+
+**Not code** — a validation checklist to run after Task 6 merges AND the one-time
+setup in the runbook is done. Cannot run earlier (needs the secrets + environment).
+
+- [ ] **Step 1:** Dispatch against the lowest-blast-radius worker first: Actions → Worker Deploy → Run workflow → `target: mta-sts`. Approve at the gate. Expect: deploy → `verify mta-sts: OK` → green.
+- [ ] **Step 2:** Repeat with `target: social`, then `target: csp`. Expect green each time; confirm the site still serves a CSP header after the csp run (`curl -sI https://adrianwedd.com/ | grep -i content-security-policy`).
+- [ ] **Step 3: Prove rollback.** Temporarily edit `scripts/verify-worker.mjs`'s mta-sts assertion to require an impossible string, push via a throwaway branch + dispatch `target: mta-sts`. Expect: verify fails → `wrangler rollback` runs → run red, prior version restored. Revert the edit.
+- [ ] **Step 4: Prove drift both ways.** Run workflow with default `target` on a day with no worker changes → drift-check green. Then merge a no-op comment change under `worker-mta-sts/` **without** approving its deploy, and dispatch again → drift-check red with "undeployed commit(s)" for mta-sts. Approve the pending deploy to clear it.
+- [ ] **Step 5:** Update the Sprint 39 checkboxes in `docs/ROADMAP-2026-H2.md` and note completion.
+
+---
+
+## Self-review
+
+- **Spec coverage:** trigger+gate (Task 5 `deploy` job + environment), path filter (Task 5), per-worker conditional install/test (Tasks 4/5 via `hasPkg`+key), capture/deploy/verify/rollback with `--yes` and migration refusal (Task 4), two-token model (Tasks 5/6), verification checks incl. real-nonce CSP + honest liveness (Task 2), drift SHA classification incl. `cat-file`/ancestor/`at(-1)`/annotation path (Task 3), `permissions`/concurrency/`fetch-depth`/SHA-pins (Tasks 1–5 Global Constraints), runbook + README fix (Task 6), staged live validation incl. rollback + drift proofs (Task 7). All spec sections map to a task.
+- **Placeholder scan:** no TBD/TODO; all code blocks complete.
+- **Type consistency:** `selectTargets`/`WORKERS` shape (`key,dir,name,hasPkg`) is consistent across Tasks 1, 3, 5; `probe(key,…)` and the three `assert*` signatures match between Task 2 code and tests; `classifyDrift`/`parseDeployedSha` signatures match between Task 3 code and tests; env var names (`WORKER_KEY`/`WORKER_DIR`/`WORKER_NAME`/`GIT_SHA`) match between Task 4 script and Task 5 workflow.

--- a/docs/superpowers/plans/2026-07-06-sprint39-worker-deploy-automation.md
+++ b/docs/superpowers/plans/2026-07-06-sprint39-worker-deploy-automation.md
@@ -592,7 +592,10 @@ git commit -m "feat(worker-deploy): drift classifier"
 # Object migration or a changed secret can block it), demand manual action.
 set -euo pipefail
 
-WRANGLER="${WRANGLER_BIN:-npx wrangler}"
+# Array form so both a single-token WRANGLER_BIN path AND the two-word default
+# `npx wrangler` expand correctly (a quoted scalar would exec "npx wrangler" as
+# one binary name → command not found).
+WRANGLER=(${WRANGLER_BIN:-npx wrangler})
 
 # Capture the currently-live version BEFORE deploying, so rollback targets the
 # exact known-good version rather than wrangler's default heuristic.
@@ -611,7 +614,7 @@ if [ -f package.json ]; then
 fi
 
 echo "::group::deploy ${WORKER_NAME}"
-"$WRANGLER" deploy --message "gitsha:${GIT_SHA}"
+"${WRANGLER[@]}" deploy --message "gitsha:${GIT_SHA}"
 echo "::endgroup::"
 
 if node "${GITHUB_WORKSPACE}/scripts/verify-worker.mjs" "$WORKER_KEY"; then
@@ -627,7 +630,7 @@ fi
 
 # --yes is belt-and-suspenders; in CI wrangler already auto-confirms (ci-info
 # detects CI). Rolling back to an explicit version id, not the default heuristic.
-if "$WRANGLER" rollback "$PREV_VERSION" --yes --message "auto-rollback ${GIT_SHA}"; then
+if "${WRANGLER[@]}" rollback "$PREV_VERSION" --yes --message "auto-rollback ${GIT_SHA}"; then
   echo "rolled ${WORKER_NAME} back to ${PREV_VERSION}; re-verifying (probe retries internally)"
   node "${GITHUB_WORKSPACE}/scripts/verify-worker.mjs" "$WORKER_KEY" \
     || echo "::error::post-rollback verify still failing for ${WORKER_NAME}"

--- a/docs/superpowers/specs/2026-07-06-sprint39-worker-deploy-automation-design.md
+++ b/docs/superpowers/specs/2026-07-06-sprint39-worker-deploy-automation-design.md
@@ -52,6 +52,7 @@ on:
   workflow_dispatch:
     inputs:
       target: { type: choice, options: [all, social, csp, mta-sts] }
+      mode: { type: choice, options: [deploy, drift-only] }   # drift-only = read-only (plan-stage QA)
   schedule:
     - cron: '0 15 * * *'   # ~01:00 AEST, offset from the e2e nightly (14:00 UTC)
 
@@ -59,10 +60,7 @@ permissions:
   contents: read           # checkout only; never writes to the repo (QA M1)
 ```
 
-Concurrency is **per-job-class**, not global (QA M2), so a gated deploy waiting hours for approval never blocks the read-only nightly drift check:
-
-- Job B (deploy): `concurrency: { group: worker-deploy, cancel-in-progress: false }`
-- Job C (drift): no concurrency (read-only, independent).
+A dispatch chooses `mode`: `deploy` (deploy the `target`, gated) or `drift-only` (read-only check, no deploy) — so a manual drift check never mutates prod (plan-stage QA). Concurrency is **per-worker** on deploy (`group: worker-deploy-${{ matrix.worker.key }}`), so a CSP deploy waiting on approval doesn't block an mta-sts deploy; the drift job has no group. Every wrangler-running job first installs a **pinned** wrangler (`npm --prefix worker ci` → `WRANGLER_BIN`); a bare `npx wrangler` in CI would download an unpinned version and fails outright in `worker-mta-sts/` (no `node_modules`) — plan-stage QA.
 
 Three logical jobs:
 
@@ -100,24 +98,22 @@ Per-worker steps (all parameterized by the matrix entry):
 7. on verify failure → ROLLBACK (see rollback contract below), then exit 1
 ```
 
-**Rollback contract (revised per QA #2/C2/C3, #5/C5):**
+**Rollback contract (revised again after plan-stage QA — Codex/Hermes traced wrangler `cli.js`):**
+
+The earlier draft claimed a migration *pre-check* and a stderr grep for a migration/secret error string. Both QA engines showed that is unreliable: wrangler's rollback handler has no migration-tag comparison, code 10220 is a *changed-secret* case that CI auto-confirms internally (so it never surfaces as a fatal error), and there is no verified migration-block stderr string to grep. The honest, correct contract:
 
 ```
-- Pre-check: if this worker's wrangler.toml declares a migration tag NEWER than the
-  last-deployed tag (not merely "contains [[migrations]]" — QA L4), DO NOT auto-rollback.
-  Cloudflare disallows rollback across a Durable Object migration entirely (not "rolls
-  back code but leaves the migration" — QA #5). Print a LOUD "MANUAL INTERVENTION
-  REQUIRED" message with the failing version id and exit 1. No rollback attempt.
-- Otherwise:
+- Capture the currently-live version id BEFORE deploy (parse `deployments list --json`,
+  take the 100%-traffic version of the newest deployment). Roll back to THAT explicit id,
+  never wrangler's default heuristic (which can skip the immediate prior version — QA).
+- On verify failure:
     wrangler rollback "$prevVersionId" --yes --message "auto-rollback ${GITHUB_SHA}"
-    # --yes is REQUIRED: rollback is interactive; relying on CI=true auto-confirm is
-    # fragile (QA C2). --yes also covers the CANNOT_ROLLBACK_WITH_MODIFIED_SECRET (10220)
-    # confirmation when a secret changed between versions (QA C3) — log loudly if hit.
-  - Check the rollback command's OWN exit code. If rollback itself fails → exit 1
-    immediately; do NOT re-verify (QA C2).
-  - If rollback succeeded → re-run verify WITH THE SAME retry/backoff as step 6
-    (not a single shot — QA M4); log whether health was restored.
-  - exit 1 regardless (a rolled-back deploy is still a failed run).
+    # --yes is belt-and-suspenders; in CI wrangler already auto-confirms via ci-info.
+  - If rollback exits 0 → re-verify (the probe retries internally with backoff); exit 1.
+  - If rollback exits non-zero → print a LOUD "MANUAL INTERVENTION REQUIRED" naming a
+    Durable Object migration or a changed secret as the likely cause, leave the failed
+    version live, exit 1. We do NOT pretend to pre-detect the migration boundary.
+- If no previous version was captured → manual-intervention path (can't auto-rollback).
 ```
 
 ### Job C — `drift-check` (schedule + dispatch; ungated, read-only)
@@ -147,7 +143,7 @@ Each runs against the live edge post-deploy, with retry/backoff:
 | Worker | Verification |
 |---|---|
 | `adrianwedd-social` | `GET https://social.adrianwedd.com/api/health` → HTTP 200 + valid JSON. **This is a liveness/routing probe, not a health probe.** The unauthenticated response is exactly `{"ok":true}` (`worker/src/index.ts:715-723` returns `{ok:true}` when no `CRON_SECRET`/`PUBLISH_SECRET`/`CLI_SECRET` is supplied). It proves the worker booted and Hono routed the request; it does **not** and **cannot** (without a secret CI deliberately doesn't hold) assert upstream token health. Token expiry is owned separately by `social-token-alert.yml`. |
-| `adrianwedd-csp` | `GET https://adrianwedd.com/` → HTTP 200 **and** a `Content-Security-Policy` **response header** (not the origin's `<meta>` tag) matching `nonce-[A-Za-z0-9+/=]{20,}`. The non-empty ≥20-char base64 nonce (the worker emits 22-char nonces) proves the worker is actively generating and injecting a real nonce, not failing open to a pass-through or emitting a degenerate `nonce-` literal (QA #7/H4). |
+| `adrianwedd-csp` | `GET https://adrianwedd.com/` → HTTP 200 **and** a `Content-Security-Policy` **response header** (not the origin's `<meta>` tag) matching `nonce-([A-Za-z0-9+/=]{20,})` **and** that same nonce appears in the HTML **body**. Checking the body too proves the worker actually rewrote the page (injected the nonce into `<script>` tags), not merely set a header — a header-only check would miss a broken rewrite (plan-stage QA). |
 | `adrianwedd-mta-sts` | `GET https://mta-sts.adrianwedd.com/.well-known/mta-sts.txt` → HTTP 200 + body contains `version: STSv1`. |
 
 ## Secrets & setup (Adrian's action items)

--- a/docs/superpowers/specs/2026-07-06-sprint39-worker-deploy-automation-design.md
+++ b/docs/superpowers/specs/2026-07-06-sprint39-worker-deploy-automation-design.md
@@ -1,0 +1,193 @@
+# Sprint 39 — Worker Deploy Automation & Observability
+
+**Date:** 2026-07-06
+**Status:** Design (revised after 3-engine QA — Codex + Hermes; Agy did not return)
+**Goal:** Kill the recurring "merged but awaiting manual `wrangler deploy`" drift class permanently, while keeping the human-in-the-loop approval Adrian wants.
+
+## Problem
+
+The repo has three Cloudflare Workers, all deployed by hand (`cd <dir> && npx wrangler deploy`):
+
+| Worker | Dir | Role | Blast radius |
+|---|---|---|---|
+| `adrianwedd-social` | `worker/` | Social automation API (Hono). KV `SOCIAL`, Durable Object `CronLock`, rate-limit binding, ~14 secrets, cron endpoints. Has `GET /api/health`. Has a vitest suite + `package.json`. | Medium — a broken deploy stops social posting/comment monitoring, but the website is unaffected. |
+| `adrianwedd-csp` | `worker-csp/` | Injects per-request CSP nonces into every HTML response. **Routed on `adrianwedd.com/*`.** Has a vitest suite + `package.json`. | **Critical** — on the live site's HTML delivery path. A broken deploy mangles or blanks every page. |
+| `adrianwedd-mta-sts` | `worker-mta-sts/` | Serves the MTA-STS policy at `mta-sts.adrianwedd.com`. Custom domain. **Single bare `index.js` — no `package.json`, no deps, no test suite.** | Low — affects inbound-mail TLS policy discovery only. |
+
+There is **no deploy CI** for any of them. Every prior session's handoff carries a "worker still awaits manual `wrangler deploy`" item (HSTS, COOP/CORP, health-cap, rate-limit binding, CSP fixes were all stranded this way). Deploys are forgotten, and there is no signal when deployed code diverges from `main`.
+
+## Key enabling fact
+
+`wrangler deploy` uploads **worker code + `[vars]` from `wrangler.toml` only**. It does **not** touch secrets — those persist in Cloudflare from prior `wrangler secret put` and survive redeploys (verified against wrangler `cli.js`: version upload uses `bindings_inherit: strict`, `keepSecrets` on). Therefore CI needs only Cloudflare API credentials, **not** the 14 platform tokens. This keeps CI's blast radius to "can deploy worker code," not "holds all social credentials."
+
+## Decisions (locked with Adrian)
+
+1. **Trigger + gate:** Auto-trigger on merge to `main` (path-filtered per worker), paused behind a GitHub Environment approval with Adrian as required reviewer. Plus `workflow_dispatch`.
+2. **Verification failure:** Auto-rollback to the previous version for **all three** workers, then fail the workflow red.
+3. **Drift check:** Nightly scheduled job + manual dispatch (not per-PR).
+4. **DO-migration rollback is out of scope** — treated as a hard manual-intervention path (see limitations).
+
+## Credentials — two tokens (revised per QA #4)
+
+A GitHub Environment's protection rules gate **any** job that references it, including reads. A scheduled, ungated drift-check therefore cannot pull its token from the gated `worker-production` environment (it would sit waiting for approval). We split credentials by capability and gate:
+
+| Secret | Scope | Where it lives | Used by |
+|---|---|---|---|
+| `CLOUDFLARE_API_TOKEN` | **Edit** Cloudflare Workers Scripts (+ Account Settings: Read; + Zone: Workers Routes Edit for the `worker-csp` route and Zone: DNS Edit for the `mta-sts` custom domain — only exercised if a route/domain must be (re)created; all three already exist) | `worker-production` **environment** secret (gated) | deploy + rollback (Job B) |
+| `CLOUDFLARE_API_TOKEN_READONLY` | **Read** Workers Scripts (sufficient for `deployments list`) | **repo-level** secret (ungated) | drift-check (Job C) |
+| `CLOUDFLARE_ACCOUNT_ID` | n/a (account id) | repo-level secret (both jobs read it) | all jobs |
+
+This is also better least-privilege: the ungated, more-frequently-run drift job never holds a write-capable token.
+
+## Architecture
+
+One new workflow: **`.github/workflows/worker-deploy.yml`**.
+
+```yaml
+name: Worker Deploy
+on:
+  push:
+    branches: [main]
+    paths: [worker/**, worker-csp/**, worker-mta-sts/**]
+  workflow_dispatch:
+    inputs:
+      target: { type: choice, options: [all, social, csp, mta-sts] }
+  schedule:
+    - cron: '0 15 * * *'   # ~01:00 AEST, offset from the e2e nightly (14:00 UTC)
+
+permissions:
+  contents: read           # checkout only; never writes to the repo (QA M1)
+```
+
+Concurrency is **per-job-class**, not global (QA M2), so a gated deploy waiting hours for approval never blocks the read-only nightly drift check:
+
+- Job B (deploy): `concurrency: { group: worker-deploy, cancel-in-progress: false }`
+- Job C (drift): no concurrency (read-only, independent).
+
+Three logical jobs:
+
+### Job A — `detect` (fast, no secrets)
+
+`fetch-depth: 0` checkout (ancestry needed downstream — QA #6). Determines which workers to act on:
+
+- On `push`: diff the changed paths. Base ref = `github.event.before`, **but** guard the all-zeros first-push SHA by falling back to the repo root commit (`git rev-list --max-parents=0 HEAD`) or simply treating every worker as changed — never `HEAD^`, which doesn't exist on a 1-commit history (QA M5). (In practice `main` is long-lived so this guard is defensive only.)
+- On `workflow_dispatch`: expand `target` (`all` → all three).
+- On `schedule`: emit the full set for the drift job only (no deploy).
+
+Emits a JSON matrix. Each matrix entry carries the worker's `dir`, its Cloudflare `name`, a `hasPackageJson` flag, and a `hasTests` flag — so downstream steps don't hardcode assumptions that break on `mta-sts`.
+
+### Job B — `deploy` (matrix over changed workers; gated)
+
+`environment: worker-production` (required reviewer = Adrian). Runs on `push` / `workflow_dispatch` only, never `schedule`. `fetch-depth: 0`.
+
+Per-worker steps (all parameterized by the matrix entry):
+
+```
+1. checkout (fetch-depth: 0) + setup-node@22 (SHA-pinned per repo convention — QA L2)
+2. install ONLY if hasPackageJson:  (cd $dir && npm ci)      # mta-sts is skipped — QA #1/C1
+3. test ONLY if hasTests:
+     - worker/     → npm test              (vitest run)
+     - worker-csp/ → npm test && npx tsc --noEmit
+     - mta-sts/    → (no package.json, no tests) → skipped
+   abort before deploy if red
+4. capture prevVersionId:
+     wrangler deployments list --json  → the NEWEST is the LAST element (list is
+     sorted ascending by created_on and truncated to 10 — QA #6/H2). Read
+     `deployments.at(-1)` and its version id for the rollback target.
+5. deploy:  wrangler deploy --message "gitsha:${GITHUB_SHA}"
+6. verify (worker-specific, below) with retry/backoff for edge propagation
+   (5 attempts, 10s apart, ~50s ceiling)
+7. on verify failure → ROLLBACK (see rollback contract below), then exit 1
+```
+
+**Rollback contract (revised per QA #2/C2/C3, #5/C5):**
+
+```
+- Pre-check: if this worker's wrangler.toml declares a migration tag NEWER than the
+  last-deployed tag (not merely "contains [[migrations]]" — QA L4), DO NOT auto-rollback.
+  Cloudflare disallows rollback across a Durable Object migration entirely (not "rolls
+  back code but leaves the migration" — QA #5). Print a LOUD "MANUAL INTERVENTION
+  REQUIRED" message with the failing version id and exit 1. No rollback attempt.
+- Otherwise:
+    wrangler rollback "$prevVersionId" --yes --message "auto-rollback ${GITHUB_SHA}"
+    # --yes is REQUIRED: rollback is interactive; relying on CI=true auto-confirm is
+    # fragile (QA C2). --yes also covers the CANNOT_ROLLBACK_WITH_MODIFIED_SECRET (10220)
+    # confirmation when a secret changed between versions (QA C3) — log loudly if hit.
+  - Check the rollback command's OWN exit code. If rollback itself fails → exit 1
+    immediately; do NOT re-verify (QA C2).
+  - If rollback succeeded → re-run verify WITH THE SAME retry/backoff as step 6
+    (not a single shot — QA M4); log whether health was restored.
+  - exit 1 regardless (a rolled-back deploy is still a failed run).
+```
+
+### Job C — `drift-check` (schedule + dispatch; ungated, read-only)
+
+`fetch-depth: 0` checkout. Uses `CLOUDFLARE_API_TOKEN_READONLY`. For each worker:
+
+```
+1. deployedSha = deployments.at(-1).annotations["workers/message"], strip "gitsha:" prefix
+   (the message is a DEPLOYMENT-level annotation, not a version-level one — QA #6/H2)
+2. classify:
+   - message has no "gitsha:" → DRIFT (reason: "unstamped" — deployed out-of-band, or
+     >10 unstamped deploys pushed the stamped one off the truncated list; say so — QA H2)
+   - `git cat-file -e ${deployedSha}^{commit}` fails (SHA absent from this clone) → DRIFT
+     (reason: "deployed from outside this repo / force-push" — QA #6/H1)
+   - SHA exists but `git merge-base --is-ancestor $deployedSha HEAD` fails → DRIFT
+     (reason: "history rewritten")
+   - `git rev-list ${deployedSha}..HEAD -- <workerPath>` non-empty → DRIFT
+     (reason: "undeployed commits touch this worker")
+   - else → in sync
+3. Aggregate. If ANY worker drifted, fail the job red with a per-worker reason summary.
+```
+
+## Per-worker verification checks (revised per QA #3, #7)
+
+Each runs against the live edge post-deploy, with retry/backoff:
+
+| Worker | Verification |
+|---|---|
+| `adrianwedd-social` | `GET https://social.adrianwedd.com/api/health` → HTTP 200 + valid JSON. **This is a liveness/routing probe, not a health probe.** The unauthenticated response is exactly `{"ok":true}` (`worker/src/index.ts:715-723` returns `{ok:true}` when no `CRON_SECRET`/`PUBLISH_SECRET`/`CLI_SECRET` is supplied). It proves the worker booted and Hono routed the request; it does **not** and **cannot** (without a secret CI deliberately doesn't hold) assert upstream token health. Token expiry is owned separately by `social-token-alert.yml`. |
+| `adrianwedd-csp` | `GET https://adrianwedd.com/` → HTTP 200 **and** a `Content-Security-Policy` **response header** (not the origin's `<meta>` tag) matching `nonce-[A-Za-z0-9+/=]{20,}`. The non-empty ≥20-char base64 nonce (the worker emits 22-char nonces) proves the worker is actively generating and injecting a real nonce, not failing open to a pass-through or emitting a degenerate `nonce-` literal (QA #7/H4). |
+| `adrianwedd-mta-sts` | `GET https://mta-sts.adrianwedd.com/.well-known/mta-sts.txt` → HTTP 200 + body contains `version: STSv1`. |
+
+## Secrets & setup (Adrian's action items)
+
+Prerequisites the workflow cannot self-provision — captured as a reproducible runbook in the plan:
+
+1. Create **`CLOUDFLARE_API_TOKEN`** — Account → Workers Scripts → **Edit** (+ Account Settings → Read). Add Zone → Workers Routes → Edit and Zone → DNS → Edit **only if** a route/custom-domain will ever be (re)created by CI (all three already exist, so redeploys don't need zone scopes). Store as a **`worker-production` environment** secret.
+2. Create **`CLOUDFLARE_API_TOKEN_READONLY`** — Account → Workers Scripts → **Read**. Store as a **repo-level** secret (ungated).
+3. Add **`CLOUDFLARE_ACCOUNT_ID`** as a repo-level secret.
+4. Create the **`worker-production`** environment with **required reviewer = Adrian**.
+
+## Testing strategy
+
+CI/CD plumbing, so "tests" are staged validation:
+
+1. **Dry-run first:** each worker's deploy is validated with `wrangler deploy --dry-run` in the plan before wiring the live deploy (mta-sts dry-run confirmed working without `npm ci`).
+2. **Verification scripts independently runnable** against the current live edge, to confirm the assertions match reality before they gate a deploy.
+3. **First real exercise via `workflow_dispatch`**, lowest blast radius first: `mta-sts` → `social` → `csp` last.
+4. **Rollback path proven deliberately:** in a dispatch against `mta-sts`, point a verification at a known-failing assertion, confirm auto-rollback fires and restores the prior version (with backoff re-verify), then revert.
+5. **Drift check proven both ways:** run on demand once in-sync (green) and once with an intentionally-undeployed worker commit on `main` (red), plus once against an unstamped deployment (expect "unstamped" reason).
+
+## Out of scope / known limitations
+
+- **Durable Object migration rollback (hard limit — QA #5).** Cloudflare **disallows rollback across a Durable Object migration**. Only `worker/` has migrations (`CronLock`, tag `v1`, already applied). A *future* deploy that adds a new migration tag and then fails verification **cannot** be auto-rolled-back; the workflow detects the new tag, refuses to attempt rollback, and demands manual intervention. New DO migrations must be introduced in their own carefully-reviewed deploy.
+- **`/api/health` is a liveness probe, not a health probe** (QA #3) — see the verification table. Asserting real token health would require CI to hold a social secret, which is explicitly avoided.
+- **No secret management in CI.** Secrets stay manual via `wrangler secret put`. CI never reads, writes, or rotates them. A secret rotated between a deploy and its rollback triggers wrangler's code-10220 path; `--yes` force-confirms it and the rolled-back code runs with current secrets (logged loudly).
+- **No staging worker.** Deploys go straight to production behind the approval gate; a preview tier is YAGNI for three small workers.
+- **`paths:` won't catch shared-file changes** (root `package.json`/`tsconfig` that a worker extends) — QA M3. Documented; use `workflow_dispatch` to force-deploy after such a change.
+- **`worker-csp/README.md` is stale** ("Not deployed" / "routes commented out") — the worker is live and routed (QA L1). The implementer should fix the README as part of this sprint.
+
+## Files touched
+
+- **New:** `.github/workflows/worker-deploy.yml`
+- **New:** verification helper(s) — social health probe, `worker-csp` CSP-header/nonce probe, `mta-sts` policy probe (a small `scripts/verify-worker.mjs` or per-step shell, decided in the plan; must be locally runnable).
+- **Docs:** token/environment runbook (repo docs + CLAUDE.md worker section); fix stale `worker-csp/README.md`.
+- **No changes** to `deploy.yml`, `e2e.yml`, or the workers' application code.
+
+## Success criteria
+
+- Merging a `worker*/` change produces an approval prompt; approving ships it; the deploy is verified at the edge.
+- A failed verification auto-rolls-back (with backoff re-verify) and turns the run red — except across a DO migration, where it refuses and demands manual action.
+- The nightly drift check fails loud with a specific reason when a deployed worker diverges from `main`, green when they match, and correctly classifies unstamped / out-of-repo SHAs.
+- Only Cloudflare API credentials live in GitHub; the ungated drift job holds a read-only token; no platform secrets are stored.

--- a/scripts/verify-worker.mjs
+++ b/scripts/verify-worker.mjs
@@ -1,0 +1,83 @@
+// Post-deploy edge verification. Pure assertion fns + a retrying probe runner.
+// CLI: `node scripts/verify-worker.mjs <social|csp|mta-sts>` → exit 0 pass / 1 fail.
+
+export function assertSocialHealth(status, body) {
+  // Liveness/routing probe only — the unauthenticated response is {"ok":true}.
+  if (status !== 200) return { ok: false, reason: `expected 200, got ${status}` };
+  let json;
+  try {
+    json = JSON.parse(body);
+  } catch {
+    return { ok: false, reason: 'body is not valid JSON' };
+  }
+  if (typeof json !== 'object' || json === null) {
+    return { ok: false, reason: 'JSON body is not an object' };
+  }
+  return { ok: true };
+}
+
+const CSP_NONCE_RE = /nonce-([A-Za-z0-9+/=]{20,})/;
+export function assertCsp(headerValue, body) {
+  if (!headerValue) return { ok: false, reason: 'no Content-Security-Policy response header' };
+  const m = CSP_NONCE_RE.exec(headerValue);
+  if (!m) return { ok: false, reason: 'CSP header lacks a real nonce-<base64> token' };
+  const nonce = m[1];
+  // The worker injects the SAME nonce into <script> tags. If the header carries
+  // a nonce but the body doesn't, the worker set a header without rewriting the
+  // HTML — a broken deploy that a header-only check would miss.
+  if (!body || !body.includes(nonce)) {
+    return { ok: false, reason: 'header nonce not found in HTML body (worker did not rewrite the page)' };
+  }
+  return { ok: true };
+}
+
+export function assertMtaSts(status, body) {
+  if (status !== 200) return { ok: false, reason: `expected 200, got ${status}` };
+  if (!/version:\s*STSv1/.test(body)) return { ok: false, reason: 'body missing "version: STSv1"' };
+  return { ok: true };
+}
+
+const TARGETS = {
+  social: {
+    url: 'https://social.adrianwedd.com/api/health',
+    check: async (res) => assertSocialHealth(res.status, await res.text()),
+  },
+  csp: {
+    url: 'https://adrianwedd.com/',
+    check: async (res) => assertCsp(res.headers.get('content-security-policy'), await res.text()),
+  },
+  'mta-sts': {
+    url: 'https://mta-sts.adrianwedd.com/.well-known/mta-sts.txt',
+    check: async (res) => assertMtaSts(res.status, await res.text()),
+  },
+};
+
+export async function probe(key, { attempts = 5, delayMs = 10000 } = {}) {
+  const t = TARGETS[key];
+  if (!t) return { ok: false, reason: `unknown worker key: ${key}` };
+  let last = { ok: false, reason: 'no attempts made' };
+  for (let i = 1; i <= attempts; i++) {
+    try {
+      const res = await fetch(t.url, { redirect: 'manual' });
+      last = await t.check(res);
+    } catch (e) {
+      last = { ok: false, reason: `fetch error: ${e.message}` };
+    }
+    if (last.ok) return last;
+    if (i < attempts) await new Promise((r) => setTimeout(r, delayMs));
+  }
+  return last;
+}
+
+async function main() {
+  const key = process.argv[2];
+  const result = await probe(key);
+  if (result.ok) {
+    console.log(`verify ${key}: OK`);
+    process.exit(0);
+  }
+  console.error(`verify ${key}: FAIL — ${result.reason}`);
+  process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/worker-deploy-step.sh
+++ b/scripts/worker-deploy-step.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# One worker's deploy lifecycle: capture-prev → install → test → deploy →
+# verify → rollback-to-explicit-version. If rollback exits non-zero (a Durable
+# Object migration or a changed secret can block it), demand manual action.
+set -euo pipefail
+
+WRANGLER="${WRANGLER_BIN:-npx wrangler}"
+
+# Capture the currently-live version BEFORE deploying, so rollback targets the
+# exact known-good version rather than wrangler's default heuristic.
+PREV_VERSION="$(cd "$WORKER_DIR" && node "${GITHUB_WORKSPACE}/scripts/wrangler-deployments.mjs" current-version || true)"
+echo "previous version for ${WORKER_NAME}: ${PREV_VERSION:-<none>}"
+
+cd "$WORKER_DIR"
+
+if [ -f package.json ]; then
+  npm ci
+  case "$WORKER_KEY" in
+    social) npm test ;;
+    csp) npm test && npx tsc --noEmit ;;
+    *) ;; # a future worker with a package.json but no known test command
+  esac
+fi
+
+echo "::group::deploy ${WORKER_NAME}"
+"$WRANGLER" deploy --message "gitsha:${GIT_SHA}"
+echo "::endgroup::"
+
+if node "${GITHUB_WORKSPACE}/scripts/verify-worker.mjs" "$WORKER_KEY"; then
+  echo "verification passed for ${WORKER_NAME}"
+  exit 0
+fi
+
+echo "::error::verification failed for ${WORKER_NAME} — attempting rollback"
+if [ -z "$PREV_VERSION" ]; then
+  echo "::error::MANUAL INTERVENTION REQUIRED for ${WORKER_NAME}: no previous version captured; cannot auto-rollback. Failed version gitsha:${GIT_SHA} is live."
+  exit 1
+fi
+
+# --yes is belt-and-suspenders; in CI wrangler already auto-confirms (ci-info
+# detects CI). Rolling back to an explicit version id, not the default heuristic.
+if "$WRANGLER" rollback "$PREV_VERSION" --yes --message "auto-rollback ${GIT_SHA}"; then
+  echo "rolled ${WORKER_NAME} back to ${PREV_VERSION}; re-verifying (probe retries internally)"
+  node "${GITHUB_WORKSPACE}/scripts/verify-worker.mjs" "$WORKER_KEY" \
+    || echo "::error::post-rollback verify still failing for ${WORKER_NAME}"
+  exit 1
+fi
+
+echo "::error::MANUAL INTERVENTION REQUIRED for ${WORKER_NAME}: rollback to ${PREV_VERSION} failed. A Durable Object migration or a changed secret can block rollback. Failed version gitsha:${GIT_SHA} is live — roll back by hand."
+exit 1

--- a/scripts/worker-deploy-step.sh
+++ b/scripts/worker-deploy-step.sh
@@ -4,7 +4,7 @@
 # Object migration or a changed secret can block it), demand manual action.
 set -euo pipefail
 
-WRANGLER="${WRANGLER_BIN:-npx wrangler}"
+WRANGLER=(${WRANGLER_BIN:-npx wrangler})
 
 # Capture the currently-live version BEFORE deploying, so rollback targets the
 # exact known-good version rather than wrangler's default heuristic.
@@ -23,7 +23,7 @@ if [ -f package.json ]; then
 fi
 
 echo "::group::deploy ${WORKER_NAME}"
-"$WRANGLER" deploy --message "gitsha:${GIT_SHA}"
+"${WRANGLER[@]}" deploy --message "gitsha:${GIT_SHA}"
 echo "::endgroup::"
 
 if node "${GITHUB_WORKSPACE}/scripts/verify-worker.mjs" "$WORKER_KEY"; then
@@ -39,7 +39,7 @@ fi
 
 # --yes is belt-and-suspenders; in CI wrangler already auto-confirms (ci-info
 # detects CI). Rolling back to an explicit version id, not the default heuristic.
-if "$WRANGLER" rollback "$PREV_VERSION" --yes --message "auto-rollback ${GIT_SHA}"; then
+if "${WRANGLER[@]}" rollback "$PREV_VERSION" --yes --message "auto-rollback ${GIT_SHA}"; then
   echo "rolled ${WORKER_NAME} back to ${PREV_VERSION}; re-verifying (probe retries internally)"
   node "${GITHUB_WORKSPACE}/scripts/verify-worker.mjs" "$WORKER_KEY" \
     || echo "::error::post-rollback verify still failing for ${WORKER_NAME}"

--- a/scripts/worker-drift.mjs
+++ b/scripts/worker-drift.mjs
@@ -1,0 +1,62 @@
+// Drift check: is each deployed worker in sync with main? Pure classifier +
+// a CLI that queries wrangler (READ-ONLY token) and git, and fails on any drift.
+import { execSync } from 'node:child_process';
+import { WORKERS } from './worker-targets.mjs';
+import { listDeployments, extractDeployMessage } from './wrangler-deployments.mjs';
+
+export function parseDeployedSha(message) {
+  const m = /gitsha:([0-9a-f]{7,40})/.exec(message ?? '');
+  return m ? m[1] : null;
+}
+
+export function classifyDrift({ sha, shaExists, isAncestor, undeployedCount } = {}) {
+  if (!sha) {
+    return {
+      drift: true,
+      reason: 'unstamped (deployed out-of-band, or >10 unstamped deploys hid the stamp)',
+    };
+  }
+  if (!shaExists) {
+    return { drift: true, reason: `deployed SHA ${sha} absent from repo (force-push / other branch)` };
+  }
+  if (!isAncestor) {
+    return { drift: true, reason: `deployed SHA ${sha} not an ancestor of HEAD (history rewritten)` };
+  }
+  if (undeployedCount > 0) {
+    return { drift: true, reason: `${undeployedCount} undeployed commit(s) touch this worker` };
+  }
+  return { drift: false, reason: 'in sync' };
+}
+
+function gitOk(cmd) {
+  try {
+    execSync(cmd, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function main() {
+  let drifted = 0;
+  for (const worker of Object.values(WORKERS)) {
+    const sha = parseDeployedSha(extractDeployMessage(listDeployments(worker.dir)));
+    const shaExists = sha ? gitOk(`git cat-file -e ${sha}^{commit}`) : false;
+    const isAncestor = sha && shaExists ? gitOk(`git merge-base --is-ancestor ${sha} HEAD`) : false;
+    const undeployedCount =
+      sha && isAncestor
+        ? Number(
+            execSync(`git rev-list --count ${sha}..HEAD -- ${worker.dir}`, { encoding: 'utf8' }).trim(),
+          )
+        : 0;
+    const r = classifyDrift({ sha, shaExists, isAncestor, undeployedCount });
+    console.log(`${r.drift ? 'DRIFT' : 'ok   '}  ${worker.name}: ${r.reason}`);
+    if (r.drift) drifted++;
+  }
+  if (drifted > 0) {
+    console.error(`::error::${drifted} worker(s) drifted from main`);
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/worker-targets.mjs
+++ b/scripts/worker-targets.mjs
@@ -1,0 +1,41 @@
+// Registry of the three Cloudflare workers + pure target selection. CLI entry
+// (guarded by import.meta.url) emits the deploy matrix to GITHUB_OUTPUT.
+import { execSync } from 'node:child_process';
+
+export const WORKERS = {
+  social: { key: 'social', dir: 'worker', name: 'adrianwedd-social', hasPkg: true },
+  csp: { key: 'csp', dir: 'worker-csp', name: 'adrianwedd-csp', hasPkg: true },
+  'mta-sts': { key: 'mta-sts', dir: 'worker-mta-sts', name: 'adrianwedd-mta-sts', hasPkg: false },
+};
+
+export function selectTargets({ changedFiles = [], dispatchTarget = null } = {}) {
+  if (dispatchTarget === 'all') return Object.values(WORKERS);
+  if (dispatchTarget) return WORKERS[dispatchTarget] ? [WORKERS[dispatchTarget]] : [];
+  return Object.values(WORKERS).filter((w) =>
+    changedFiles.some((f) => f === w.dir || f.startsWith(w.dir + '/')),
+  );
+}
+
+function main() {
+  const event = process.env.EVENT;
+  let changedFiles = [];
+  let dispatchTarget = null;
+  if (event === 'workflow_dispatch') dispatchTarget = process.env.DISPATCH_TARGET || 'all';
+  else if (event === 'schedule') dispatchTarget = 'all';
+  else {
+    const before = process.env.BEFORE;
+    const head = process.env.GITHUB_SHA || 'HEAD';
+    const base =
+      !before || /^0+$/.test(before)
+        ? execSync('git rev-list --max-parents=0 HEAD', { encoding: 'utf8' }).trim().split('\n').pop()
+        : before;
+    changedFiles = execSync(`git diff --name-only ${base} ${head}`, { encoding: 'utf8' })
+      .split('\n')
+      .filter(Boolean);
+  }
+  const targets = selectTargets({ changedFiles, dispatchTarget });
+  process.stdout.write(`matrix=${JSON.stringify(targets)}\n`);
+  process.stdout.write(`any=${targets.length > 0}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/worker-targets.mjs
+++ b/scripts/worker-targets.mjs
@@ -8,6 +8,9 @@ export const WORKERS = {
   'mta-sts': { key: 'mta-sts', dir: 'worker-mta-sts', name: 'adrianwedd-mta-sts', hasPkg: false },
 };
 
+/**
+ * @param {{ changedFiles?: string[], dispatchTarget?: string | null }} [opts]
+ */
 export function selectTargets({ changedFiles = [], dispatchTarget = null } = {}) {
   if (dispatchTarget === 'all') return Object.values(WORKERS);
   if (dispatchTarget) return WORKERS[dispatchTarget] ? [WORKERS[dispatchTarget]] : [];

--- a/scripts/wrangler-deployments.mjs
+++ b/scripts/wrangler-deployments.mjs
@@ -1,0 +1,38 @@
+// Parse `wrangler deployments list --json`. Pure helpers + a thin I/O wrapper.
+// CLI: `node scripts/wrangler-deployments.mjs <current-version|message>` run
+// from within a worker dir; prints to stdout for capture by the deploy step.
+import { execSync } from 'node:child_process';
+
+export function extractDeployMessage(deployments) {
+  return deployments?.at?.(-1)?.annotations?.['workers/message'] ?? '';
+}
+
+export function currentVersionId(deployments) {
+  const d = deployments?.at?.(-1);
+  if (!d?.versions?.length) return null;
+  const at100 = d.versions.find((v) => v.percentage === 100);
+  return (at100 ?? d.versions.at(-1)).version_id ?? null;
+}
+
+export function listDeployments(cwd) {
+  const wrangler = process.env.WRANGLER_BIN ?? 'npx wrangler';
+  const out = execSync(`${wrangler} deployments list --json`, { cwd, encoding: 'utf8' });
+  return JSON.parse(out);
+}
+
+function main() {
+  const cmd = process.argv[2];
+  const deployments = listDeployments(process.cwd());
+  if (cmd === 'current-version') {
+    const v = currentVersionId(deployments);
+    if (!v) process.exit(1);
+    process.stdout.write(v);
+  } else if (cmd === 'message') {
+    process.stdout.write(extractDeployMessage(deployments));
+  } else {
+    process.stderr.write('usage: wrangler-deployments.mjs <current-version|message>\n');
+    process.exit(2);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/test/unit/verify-worker.spec.ts
+++ b/test/unit/verify-worker.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { assertSocialHealth, assertCsp, assertMtaSts } from '../../scripts/verify-worker.mjs';
+
+describe('assertSocialHealth (liveness)', () => {
+  it('passes on 200 + the unauth {"ok":true} body', () => {
+    expect(assertSocialHealth(200, '{"ok":true}').ok).toBe(true);
+  });
+  it('fails on non-200', () => {
+    expect(assertSocialHealth(503, '{"ok":true}').ok).toBe(false);
+  });
+  it('fails on non-JSON body', () => {
+    expect(assertSocialHealth(200, '<html>error</html>').ok).toBe(false);
+  });
+});
+
+describe('assertCsp', () => {
+  const nonce = 'X0PqfxDjWOOHu7gxnySUAQ';
+  it('passes when header nonce is real AND present in the body (worker rewrote HTML)', () => {
+    const header = `script-src 'nonce-${nonce}' 'strict-dynamic'`;
+    const body = `<html><script nonce="${nonce}">x()</script></html>`;
+    expect(assertCsp(header, body).ok).toBe(true);
+  });
+  it('fails when there is no CSP header at all', () => {
+    expect(assertCsp(null, '<html></html>').ok).toBe(false);
+  });
+  it('fails on a degenerate empty nonce literal', () => {
+    expect(assertCsp("script-src 'nonce-' 'strict-dynamic'", '<html></html>').ok).toBe(false);
+  });
+  it('fails when the header has a nonce but the body was NOT rewritten', () => {
+    const header = `script-src 'nonce-${nonce}' 'strict-dynamic'`;
+    const body = '<html><script>x()</script></html>'; // no nonce in body
+    expect(assertCsp(header, body).ok).toBe(false);
+  });
+});
+
+describe('assertMtaSts', () => {
+  it('passes on 200 + version: STSv1', () => {
+    expect(assertMtaSts(200, 'version: STSv1\nmode: enforce\n').ok).toBe(true);
+  });
+  it('fails when the body lacks the version line', () => {
+    expect(assertMtaSts(200, 'mode: enforce\n').ok).toBe(false);
+  });
+});

--- a/test/unit/worker-drift.spec.ts
+++ b/test/unit/worker-drift.spec.ts
@@ -25,9 +25,7 @@ describe('classifyDrift', () => {
     expect(classifyDrift({ sha: 'abc', shaExists: true, isAncestor: false }).drift).toBe(true);
   });
   it('undeployed commits touch the worker → drift', () => {
-    expect(
-      classifyDrift({ sha: 'abc', shaExists: true, isAncestor: true, undeployedCount: 2 }).drift,
-    ).toBe(true);
+    expect(classifyDrift({ sha: 'abc', shaExists: true, isAncestor: true, undeployedCount: 2 }).drift).toBe(true);
   });
   it('in sync → no drift', () => {
     const r = classifyDrift({ sha: 'abc', shaExists: true, isAncestor: true, undeployedCount: 0 });

--- a/test/unit/worker-drift.spec.ts
+++ b/test/unit/worker-drift.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { parseDeployedSha, classifyDrift } from '../../scripts/worker-drift.mjs';
+
+describe('parseDeployedSha', () => {
+  it('extracts the sha from a gitsha: message', () => {
+    expect(parseDeployedSha('gitsha:e43d57a0f1c2b3a4d5e6f7a8b9c0d1e2f3a4b5c6')).toBe(
+      'e43d57a0f1c2b3a4d5e6f7a8b9c0d1e2f3a4b5c6',
+    );
+  });
+  it('returns null for an unstamped message', () => {
+    expect(parseDeployedSha('Manual deploy')).toBeNull();
+    expect(parseDeployedSha('')).toBeNull();
+    expect(parseDeployedSha(null)).toBeNull();
+  });
+});
+
+describe('classifyDrift', () => {
+  it('unstamped → drift', () => {
+    expect(classifyDrift({ sha: null }).drift).toBe(true);
+  });
+  it('sha absent from repo → drift', () => {
+    expect(classifyDrift({ sha: 'deadbeef', shaExists: false }).drift).toBe(true);
+  });
+  it('sha not an ancestor → drift', () => {
+    expect(classifyDrift({ sha: 'abc', shaExists: true, isAncestor: false }).drift).toBe(true);
+  });
+  it('undeployed commits touch the worker → drift', () => {
+    expect(
+      classifyDrift({ sha: 'abc', shaExists: true, isAncestor: true, undeployedCount: 2 }).drift,
+    ).toBe(true);
+  });
+  it('in sync → no drift', () => {
+    const r = classifyDrift({ sha: 'abc', shaExists: true, isAncestor: true, undeployedCount: 0 });
+    expect(r.drift).toBe(false);
+    expect(r.reason).toMatch(/in sync/);
+  });
+});

--- a/test/unit/worker-targets.spec.ts
+++ b/test/unit/worker-targets.spec.ts
@@ -3,24 +3,22 @@ import { WORKERS, selectTargets } from '../../scripts/worker-targets.mjs';
 
 describe('selectTargets', () => {
   it('dispatch "all" returns every worker', () => {
-    expect(selectTargets({ dispatchTarget: 'all' }).map((w) => w.key).sort()).toEqual([
-      'csp',
-      'mta-sts',
-      'social',
-    ]);
+    expect(
+      selectTargets({ dispatchTarget: 'all' })
+        .map((w) => w.key)
+        .sort(),
+    ).toEqual(['csp', 'mta-sts', 'social']);
   });
   it('dispatch of a single worker returns just that one', () => {
     expect(selectTargets({ dispatchTarget: 'csp' })).toEqual([WORKERS.csp]);
   });
   it('push maps changed files to their worker dirs', () => {
-    expect(
-      selectTargets({ changedFiles: ['worker-csp/src/index.ts', 'README.md'] }).map((w) => w.key),
-    ).toEqual(['csp']);
+    expect(selectTargets({ changedFiles: ['worker-csp/src/index.ts', 'README.md'] }).map((w) => w.key)).toEqual([
+      'csp',
+    ]);
   });
   it('push matches the dir prefix but not a lookalike sibling', () => {
-    expect(selectTargets({ changedFiles: ['worker/src/index.ts'] }).map((w) => w.key)).toEqual([
-      'social',
-    ]);
+    expect(selectTargets({ changedFiles: ['worker/src/index.ts'] }).map((w) => w.key)).toEqual(['social']);
   });
   it('push with no worker changes returns nothing', () => {
     expect(selectTargets({ changedFiles: ['src/pages/index.astro'] })).toEqual([]);

--- a/test/unit/worker-targets.spec.ts
+++ b/test/unit/worker-targets.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { WORKERS, selectTargets } from '../../scripts/worker-targets.mjs';
+
+describe('selectTargets', () => {
+  it('dispatch "all" returns every worker', () => {
+    expect(selectTargets({ dispatchTarget: 'all' }).map((w) => w.key).sort()).toEqual([
+      'csp',
+      'mta-sts',
+      'social',
+    ]);
+  });
+  it('dispatch of a single worker returns just that one', () => {
+    expect(selectTargets({ dispatchTarget: 'csp' })).toEqual([WORKERS.csp]);
+  });
+  it('push maps changed files to their worker dirs', () => {
+    expect(
+      selectTargets({ changedFiles: ['worker-csp/src/index.ts', 'README.md'] }).map((w) => w.key),
+    ).toEqual(['csp']);
+  });
+  it('push matches the dir prefix but not a lookalike sibling', () => {
+    expect(selectTargets({ changedFiles: ['worker/src/index.ts'] }).map((w) => w.key)).toEqual([
+      'social',
+    ]);
+  });
+  it('push with no worker changes returns nothing', () => {
+    expect(selectTargets({ changedFiles: ['src/pages/index.astro'] })).toEqual([]);
+  });
+  it('mta-sts is flagged hasPkg:false', () => {
+    expect(WORKERS['mta-sts'].hasPkg).toBe(false);
+    expect(WORKERS.social.hasPkg).toBe(true);
+  });
+});

--- a/test/unit/wrangler-deployments.spec.ts
+++ b/test/unit/wrangler-deployments.spec.ts
@@ -27,7 +27,16 @@ describe('currentVersionId', () => {
     expect(currentVersionId(sample)).toBe('v-new');
   });
   it('falls back to the last version when none is at 100%', () => {
-    expect(currentVersionId([{ versions: [{ version_id: 'a', percentage: 50 }, { version_id: 'b', percentage: 50 }] }])).toBe('b');
+    expect(
+      currentVersionId([
+        {
+          versions: [
+            { version_id: 'a', percentage: 50 },
+            { version_id: 'b', percentage: 50 },
+          ],
+        },
+      ]),
+    ).toBe('b');
   });
   it('returns null when there are no versions', () => {
     expect(currentVersionId([{ versions: [] }])).toBeNull();

--- a/test/unit/wrangler-deployments.spec.ts
+++ b/test/unit/wrangler-deployments.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { extractDeployMessage, currentVersionId } from '../../scripts/wrangler-deployments.mjs';
+
+const sample = [
+  { annotations: { 'workers/message': 'gitsha:aaa' }, versions: [{ version_id: 'v-old', percentage: 100 }] },
+  {
+    annotations: { 'workers/message': 'gitsha:bbb1111111111111111111111111111111111111' },
+    versions: [
+      { version_id: 'v-new', percentage: 100 },
+      { version_id: 'v-canary', percentage: 0 },
+    ],
+  },
+];
+
+describe('extractDeployMessage', () => {
+  it('reads the newest deployment message (last element)', () => {
+    expect(extractDeployMessage(sample)).toBe('gitsha:bbb1111111111111111111111111111111111111');
+  });
+  it('returns empty string when there is no message', () => {
+    expect(extractDeployMessage([{ versions: [] }])).toBe('');
+    expect(extractDeployMessage([])).toBe('');
+  });
+});
+
+describe('currentVersionId', () => {
+  it('picks the 100%-traffic version of the newest deployment', () => {
+    expect(currentVersionId(sample)).toBe('v-new');
+  });
+  it('falls back to the last version when none is at 100%', () => {
+    expect(currentVersionId([{ versions: [{ version_id: 'a', percentage: 50 }, { version_id: 'b', percentage: 50 }] }])).toBe('b');
+  });
+  it('returns null when there are no versions', () => {
+    expect(currentVersionId([{ versions: [] }])).toBeNull();
+    expect(currentVersionId([])).toBeNull();
+  });
+});

--- a/worker-csp/README.md
+++ b/worker-csp/README.md
@@ -17,7 +17,7 @@ Nonces at the edge sidestep both problems: the worker generates a fresh random n
 
 1. Review `src/csp.ts` — make sure every external origin currently used by the site is in the policy. Missing one will block its scripts/images/connects.
 2. `cd worker-csp && npm install && npm test` — all green.
-3. `npx wrangler deploy --dry-run`, then `npx wrangler deploy`.
+3. Deploy via `.github/workflows/worker-deploy.yml` (`docs/runbooks/worker-deploy.md`); `npx wrangler deploy --dry-run` remains useful for local validation.
 4. Watch the `/__csp-report` Report-Only stream (`wrangler tail`) for new violations after any policy change.
 
 Note: the build-time meta CSP in `src/components/SEOHead.astro` is retained as a risk-accepted fallback for worker-bypass paths (see Why this exists) — keep its host lists in sync with `src/csp.ts`.

--- a/worker-csp/README.md
+++ b/worker-csp/README.md
@@ -10,7 +10,8 @@ Nonces at the edge sidestep both problems: the worker generates a fresh random n
 
 ## Status
 
-**Deployed and live.** Bound to `adrianwedd.com/*` (and `www.adrianwedd.com/*`, which it 301s to the apex) via the routes in `wrangler.toml`, with `STRICT_DYNAMIC=1`. Deploys are manual: `cd worker-csp && npx wrangler deploy`.
+**Deployed and live.** Bound to `adrianwedd.com/*` (and `www.adrianwedd.com/*`, which it 301s to the apex) via the routes in `wrangler.toml`, with `STRICT_DYNAMIC=1`. Deployed via
+`.github/workflows/worker-deploy.yml` — see `docs/runbooks/worker-deploy.md`.
 
 ## Deploy checklist
 


### PR DESCRIPTION
## Summary
- Adds `worker-deploy.yml`: gated deploy workflow (approval + edge verify + auto-rollback) plus a nightly drift check, replacing manual `wrangler deploy`
- New scripts: worker registry/target selection, wrangler-deployments parser, edge verification prober, drift classifier, and the deploy/verify/rollback step script wired together in CI
- Docs: setup runbook (`docs/runbooks/worker-deploy.md`), CLAUDE.md pointer, worker-csp README reconciliation
- 4 new unit spec files (75/75 tests passing), lint clean

## Notes
- This workflow only triggers on push-to-main/workflow_dispatch, so it **cannot run on this PR** — the PR gate is the `unit` job (new script specs). Live end-to-end proof (Task 8) happens post-merge, after Cloudflare tokens + the `worker-production` environment are configured.
- One Critical bug (WRANGLER needing to be an array so default `npx wrangler` word-splits correctly) was caught during implementation review and fixed in 8fb8196.
- Full branch reviewed clean end-to-end; ready to merge.

## Test plan
- [x] `npm run test:unit` — 75/75 passing
- [x] `npm run lint` — clean
- [ ] Post-merge: configure Cloudflare tokens + `worker-production` environment, verify first live gated deploy + nightly drift run

https://claude.ai/code/session_018rxRox1MDhhYAxnpjp3XMZ