### PR TITLE
ci: harden workflows — pins, permissions, lint gate, worker typecheck/audit

### DIFF
--- a/.github/workflows/content-pipeline.yml
+++ b/.github/workflows/content-pipeline.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install pyyaml requests
+          pip install pyyaml==6.0.3 requests==2.34.2
 
       - name: Determine topics
         id: topics

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,10 +14,12 @@ permissions:
   contents: read
 
 concurrency:
-  # Production deploys share the 'pages' lane and never cancel; each PR gets its
-  # own lane so a new push supersedes the old run without touching deploys.
-  group: ${{ github.event_name == 'push' && 'pages' || format('pr-{0}', github.event.pull_request.number) }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  # Production deploys (push + manual dispatch) share the 'pages' lane and never
+  # cancel; each PR gets its own lane so a new push supersedes the old run
+  # without touching deploys. (Keying on pull_request avoids dispatch runs
+  # landing in an empty 'pr-' group with cancel-in-progress.)
+  group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'pages' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -125,6 +127,10 @@ jobs:
         # worker-csp has its own dedicated job below; this only covers the
         # social-publish worker, which had no CI coverage prior to this step.
         run: cd worker && npm ci && npm test
+      - name: Type check worker
+        run: cd worker && npx tsc --noEmit
+      - name: Audit worker dependencies
+        run: cd worker && npm audit --audit-level=high --omit=dev
       # External link check is network-flaky/slow and its value is pre-deploy,
       # not pre-merge — keep it push-only so PRs stay fast and deterministic.
       # (check:links below still covers same-origin links on every PR.)
@@ -190,6 +196,8 @@ jobs:
         run: cd worker-csp && npm test
       - name: Type check worker CSP
         run: cd worker-csp && npx tsc --noEmit
+      - name: Audit worker CSP dependencies
+        run: cd worker-csp && npm audit --audit-level=high --omit=dev
 
   deploy:
     needs: [build, worker-csp]

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,11 @@ on:
   schedule:
     - cron: '0 14 * * *' # nightly ~00:00 AEST
 
+# Least privilege: every job only reads the repo (checkout + artifact upload
+# use the job token for nothing else).
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
@@ -17,12 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
       - run: npm ci
+      - run: npm run lint
       - run: npm run test:unit
 
   # Runs on every trigger: PR (this is the gate), plus nightly/dispatch so the
@@ -35,8 +41,8 @@ jobs:
       CI: 'true'
       PUBLIC_GA_MEASUREMENT_ID: G-TESTE2E0000
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -44,7 +50,7 @@ jobs:
       - run: npx playwright install --with-deps chromium
       - run: npm run build
       - run: npm run test:e2e:smoke
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: playwright-report
@@ -59,8 +65,8 @@ jobs:
       CI: 'true'
       PUBLIC_GA_MEASUREMENT_ID: G-TESTE2E0000
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -68,7 +74,7 @@ jobs:
       - run: npx playwright install --with-deps chromium
       - run: npm run build
       - run: npm run test:e2e:full
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: playwright-report-full

--- a/.github/workflows/social-token-alert.yml
+++ b/.github/workflows/social-token-alert.yml
@@ -74,11 +74,14 @@ jobs:
               echo "=== ${PLATFORM}: daysUntilExpiry=${DAYS} (expires ${EXPIRES})"
 
               TITLE="🔑 ${PLATFORM} token data-access expiring"
-              # Existing open issue for this platform, if any.
+              # Existing open issue for this platform, if any. The worker's
+              # platform names are untrusted here, so never splice them into a
+              # jq program or search string — pass the title via `jq --arg` and
+              # filter the label-scoped listing client-side instead.
               EXISTING=$(gh issue list --repo "$REPO" --state open \
-                --label token-expiry --search "in:title ${PLATFORM}" \
-                --json number,title --jq \
-                ".[] | select(.title == \"${TITLE}\") | .number" | head -n1)
+                --label token-expiry --json number,title \
+                | jq -r --arg title "$TITLE" \
+                  '.[] | select(.title == $title) | .number' | head -n1)
 
               # Non-numeric / null days → can't reason about it; skip quietly.
               case "$DAYS" in

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260612.1",
+        "@types/node": "^26.1.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.0",
         "wrangler": "^4.100.0"
@@ -1527,6 +1528,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
@@ -2428,6 +2439,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",

--- a/worker/package.json
+++ b/worker/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260612.1",
+    "@types/node": "^26.1.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.0",
     "wrangler": "^4.100.0"

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -5,7 +5,9 @@
     "moduleResolution": "bundler",
     "strict": true,
     "skipLibCheck": true,
-    "types": ["@cloudflare/workers-types"],
+    // "node" types back the `node:crypto` imports (auth.ts, cron/comments.ts);
+    // the runtime side is provided by the nodejs_compat compatibility flag.
+    "types": ["@cloudflare/workers-types", "node"],
     "paths": { "~/*": ["./src/*"] }
   },
   "include": ["src/**/*.ts"]


### PR DESCRIPTION
## What

- **e2e.yml**: top-level `permissions: contents: read` (jobs only checkout + upload artifacts); SHA-pinned every action — checkout/setup-node copied from deploy.yml's pins (v7.0.0 / v6.4.0), upload-artifact pinned to `043fb46d` (v7.0.1, latest stable, resolved via `gh api`).
- **Lint PR gate**: `npm run lint` added to the e2e.yml `unit` job (cheapest spot — deps already installed, no build). `format:check` deliberately NOT added — a repo-wide prettier pass lands separately later.
- **Worker typecheck**: `worker/` failed `npx tsc --noEmit` with TS2591 on the `node:crypto` imports (`src/auth.ts:12`, `src/cron/comments.ts:1`). worker-csp typechecks clean simply because it has no `node:` imports, so its tsconfig wasn't a template; fixed the standard way for `nodejs_compat` workers: `@types/node` devDependency + `"node"` in tsconfig `types`. Typecheck step added to deploy.yml next to the worker tests, mirroring worker-csp's.
- **deploy.yml concurrency**: `workflow_dispatch` runs previously fell into an empty `pr-` group with cancel-in-progress; they now join the `pages` group with `cancel-in-progress: false`, same as push.
- **content-pipeline.yml**: pip installs pinned (`pyyaml==6.0.3`, `requests==2.34.2` — current releases per PyPI, 2026-07-19).
- **Worker audits**: `npm audit --audit-level=high --omit=dev` added for both `worker/` and `worker-csp/` — both run clean locally (0 vulnerabilities), so both gates are green from day one.
- **social-token-alert.yml**: worker-reported platform names/titles are no longer spliced into a `gh --jq` program string or `--search` arg; the label-scoped issue list is filtered client-side with `jq --arg title`.

## Verification

- `npm run lint` — passes
- `cd worker && npx tsc --noEmit` — passes after fix
- `cd worker && npm test` — 167 passed (12 files)
- `cd worker-csp && npm test` — 25 passed (1 file)
- `worker/` + `worker-csp/` `npm audit --audit-level=high --omit=dev` — 0 vulnerabilities each
- actionlint not installed locally — not run

https://claude.ai/code/session_016tTfK4ZG4xwqGdQLs2G713