### PR TITLE
feat: canonical tag URLs + HeroCanvas externalization

### DIFF
--- a/docs/superpowers/plans/2026-07-19-qa-followup-implementation.md
+++ b/docs/superpowers/plans/2026-07-19-qa-followup-implementation.md
@@ -1,0 +1,152 @@
+# QA Follow-up Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the three remaining code workstreams from the approved 2026-07-19 spec: tag URL normalization with worker-level 301s, crisis-alert email via Cloudflare Email Sending, and HeroCanvas externalization. (PR #531 rebase/merge and Dependabot bumps are already done operationally.)
+
+**Architecture:** Tag canonicalization is a shared `tagSlug()` util applied at every tag-URL generation site plus frontmatter normalization of blog tags; old mixed-case/spaced URLs get real 301s from the existing `worker-csp` edge worker (which already does www→apex). Crisis email is a `send_email` binding in `worker/` used inside the existing comment-monitor cron with a KV dedupe guard. HeroCanvas moves from `is:inline` to an Astro-processed module script (external hashed asset; the CSP worker nonces every `<script>` element, so strict-dynamic still passes).
+
+**Tech Stack:** Astro 6, TypeScript, Cloudflare Workers (Hono, vitest-pool-workers), Cloudflare Email Sending (`cloudflare:email` EmailMessage).
+
+## Global Constraints
+
+- **No historic permalink may 404** — old tag URLs must 301, never die. Content detail URLs untouched.
+- Descriptions ≤160 chars; prettier `format:check` and eslint gates on every PR; `npm run verify` before push.
+- Blog is the only collection with non-canonical tags; projects/audio/gallery are already lowercase-hyphenated but the redirect rule covers their paths too (defence in depth).
+- Worker deploys now go via `.github/workflows/worker-deploy.yml` (PR #531), not manual wrangler.
+
+---
+
+### Task 1: `tagSlug()` util + unit tests
+
+**Files:**
+- Modify: `src/lib/utils.ts`
+- Test: `test/unit/utils.spec.ts`
+
+**Interfaces:**
+- Produces: `export function tagSlug(tag: string): string` — lowercase, whitespace runs → single hyphen, trims stray hyphens. `tagSlug('AI safety') === 'ai-safety'`, idempotent on already-canonical tags.
+
+- [ ] Add failing tests to `test/unit/utils.spec.ts`:
+
+```ts
+import { tagSlug } from '../../src/lib/utils';
+
+describe('tagSlug', () => {
+  it('lowercases and hyphenates spaces', () => {
+    expect(tagSlug('AI safety')).toBe('ai-safety');
+    expect(tagSlug('Lyria Chronicles')).toBe('lyria-chronicles');
+  });
+  it('is idempotent on canonical tags', () => {
+    expect(tagSlug('ai-safety')).toBe('ai-safety');
+    expect(tagSlug('red-teaming')).toBe('red-teaming');
+  });
+  it('collapses whitespace runs and trims hyphens', () => {
+    expect(tagSlug('  deep   learning ')).toBe('deep-learning');
+  });
+});
+```
+
+- [ ] Run `npm run test:unit` — expect FAIL (tagSlug not exported)
+- [ ] Implement in `src/lib/utils.ts`:
+
+```ts
+/** Canonical URL slug for a tag: lowercase, whitespace → hyphen. */
+export function tagSlug(tag: string): string {
+  return tag
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+```
+
+- [ ] Run `npm run test:unit` — expect PASS; commit.
+
+### Task 2: Normalize blog frontmatter tags + apply `tagSlug` at every tag-URL site
+
+**Files:**
+- Modify: `src/content/blog/*.md` (tags containing uppercase/spaces: `AI`, `AI safety`, `Lyria`, `Lyria Chronicles`, `AI agents`, `Claude Code`, `deep learning`, `generative audio`, `account takeover`, `incident response`, `social engineering`, `found sound`)
+- Modify: `src/pages/blog/tag/[tag]/[...page].astro` (getStaticPaths: `params: { tag: tagSlug(tag) }`; group posts by slug so `AI` + `ai` merge; links use `tagSlug`)
+- Modify: `src/pages/blog/[...page].astro:87`, `src/pages/blog/[...slug].astro:287`, `src/pages/blog/tags/index.astro:32` — hrefs become `/blog/tag/${tagSlug(tag)}/`
+- Same treatment (href-side only) for `src/pages/projects/tag/[tag].astro`, `src/pages/audio/tag/[tag]/[...page].astro`, `src/pages/gallery/tag/[tag].astro` param generation — wrap with `tagSlug` for safety (no-op today).
+
+**Interfaces:**
+- Consumes: `tagSlug` from Task 1.
+- Produces: all generated tag archive URLs are canonical; no page links a non-canonical tag URL.
+
+- [ ] Normalize the blog frontmatter tag values to their `tagSlug` form (e.g. `AI safety` → `ai-safety`), merging duplicates within a post's array.
+- [ ] Dedupe + slug in `getStaticPaths` of the blog tag archive; key pagination by slug.
+- [ ] Run `npm run build && npm run check:links` — expect clean (no link to a non-canonical tag URL, no orphaned archive).
+- [ ] Run `node scripts/validate-content.js` — expect clean; commit.
+
+### Task 3: worker-csp 301 for non-canonical tag URLs
+
+**Files:**
+- Modify: `worker-csp/src/index.ts` (after the www→apex block)
+- Test: `worker-csp/test/index.test.ts`
+
+**Interfaces:**
+- Produces: any request path matching `^/(blog|projects|audio|gallery)/tag/<seg>` where decoded `<seg>` ≠ its canonical form 301s to the canonical path, preserving trailing pagination path and query string.
+
+- [ ] Add failing tests (vitest-pool-workers, `SELF.fetch`):
+
+```ts
+it('301s mixed-case tag URLs to canonical, preserving page + query', async () => {
+  const res = await SELF.fetch('https://adrianwedd.com/blog/tag/AI%20safety/2/?x=1', { redirect: 'manual' });
+  expect(res.status).toBe(301);
+  expect(res.headers.get('location')).toBe('https://adrianwedd.com/blog/tag/ai-safety/2/?x=1');
+});
+it('does not redirect canonical tag URLs', async () => { /* expect 200 passthrough via mockOrigin */ });
+```
+
+- [ ] Implement in `fetch()` after www redirect:
+
+```ts
+const tagMatch = inboundUrl.pathname.match(/^\/(blog|projects|audio|gallery)\/tag\/([^/]+)(\/.*)?$/);
+if (tagMatch) {
+  const raw = decodeURIComponent(tagMatch[2]);
+  const canonical = raw.toLowerCase().trim().replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+  if (canonical !== raw) {
+    const rest = tagMatch[3] ?? '/';
+    return Response.redirect(
+      `https://${CANONICAL_HOST}/${tagMatch[1]}/tag/${encodeURIComponent(canonical)}${rest}${inboundUrl.search}`,
+      301,
+    );
+  }
+}
+```
+
+- [ ] `cd worker-csp && npm test` — all green; commit. Deploy rides the worker-deploy workflow on merge.
+
+### Task 4: Crisis-alert email via Cloudflare Email Sending
+
+**Files:**
+- Modify: `worker/wrangler.toml` (send_email binding + vars)
+- Create: `worker/src/email.ts`
+- Modify: `worker/src/cron/comments.ts` (send after crisis flag write, deduped)
+- Test: `worker/test/` (extend comments cron spec)
+
+**Interfaces:**
+- Produces: `sendCrisisAlert(env, comment): Promise<void>` — builds a plain-text MIME message and calls `env.CRISIS_EMAIL.send(new EmailMessage(from, to, raw))`. Never throws (catches + console.error).
+- wrangler: `[[send_email]] name = "CRISIS_EMAIL"` plus `CRISIS_ALERT_FROM = "alerts@adrianwedd.com"`, `CRISIS_ALERT_TO = "adrian@adrianwedd.com"` vars. One-time dashboard setup: verify destination address in Email Routing (documented in worker README).
+
+- [ ] Failing test: crisis comment → exactly one `env.CRISIS_EMAIL.send` call; second run same comment → zero (dedupe via KV `crisis-emailed:${comment.id}`, 90-day TTL); `send` rejecting → cron still resolves ok.
+- [ ] Implement `email.ts` (raw MIME string: From/To/Subject/Date + body with comment id, post id, message excerpt, health-endpoint pointer); guard in `comments.ts` right after the `flag-crisis:` put.
+- [ ] `cd worker && npm test` — green; typecheck green; commit. Note in README the destination-verification prerequisite.
+
+### Task 5: HeroCanvas externalization
+
+**Files:**
+- Modify: `src/components/HeroCanvas.astro` (line 1: `<script is:inline>` → `<script>`)
+
+**Interfaces:** none — behavior unchanged. The existing `heroCanvasInit` sentinel + `astro:after-swap` listener already match the run-once module semantics (same pattern as `Analytics.astro`).
+
+- [ ] Change the script tag; `npm run build`; confirm `dist/` homepage HTML references an external `/_astro/*.js` for the canvas and the inline blob is gone.
+- [ ] `npm run test:e2e:smoke` — green (canvas render + VT nav covered by smoke).
+- [ ] Manual check: `npm run preview`, homepage animation runs, navigate away/back (VT), no console/CSP errors; commit.
+
+### Task 6: Verify + PRs
+
+- [ ] `npm run verify` at root; worker + worker-csp suites green.
+- [ ] Two PRs: site changes (Tasks 1, 2, 5 + this plan doc) and worker changes (Tasks 3, 4) — or one combined if churn is small. Post-merge: curl an old mixed-case tag URL and confirm the 301 with path+query preserved.

--- a/src/components/HeroCanvas.astro
+++ b/src/components/HeroCanvas.astro
@@ -1,4 +1,6 @@
 <script>
+  // @ts-nocheck — 3800 lines of untyped generative-canvas JS; typechecking
+  // began applying when this moved from is:inline to a processed script.
   // Astro-processed module: bundled to an external hashed asset (cached, out of
   // the HTML payload). Runs once; the heroCanvasInit sentinel + astro:after-swap
   // listener below handle View Transitions, same pattern as Analytics.astro.

--- a/src/components/HeroCanvas.astro
+++ b/src/components/HeroCanvas.astro
@@ -1,4 +1,7 @@
-<script is:inline>
+<script>
+  // Astro-processed module: bundled to an external hashed asset (cached, out of
+  // the HTML payload). Runs once; the heroCanvasInit sentinel + astro:after-swap
+  // listener below handle View Transitions, same pattern as Analytics.astro.
   (function () {
     // --- Shared state (persists across VT swaps within IIFE re-executions) ---
     var rafId = null;

--- a/src/content/audio/eight-minutes-1-every-check-green.md
+++ b/src/content/audio/eight-minutes-1-every-check-green.md
@@ -2,7 +2,7 @@
 title: 'Every Check Green'
 description: 'Eight Minutes #1, scored: a Lyria track sung from inside the trap — Brian, the Google-signed lure, and the device prompt that matched.'
 date: 2026-06-10
-tags: ['security', 'phishing', 'music', 'generative audio', 'Eight Minutes']
+tags: ['security', 'phishing', 'music', 'generative-audio', 'eight-minutes']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-the-trap/audio.mp3'
 duration: '2:27'
 series: 'Eight Minutes'

--- a/src/content/audio/eight-minutes-2-fourteen-thirty-six.md
+++ b/src/content/audio/eight-minutes-2-fourteen-thirty-six.md
@@ -2,7 +2,7 @@
 title: 'Fourteen Thirty-Six'
 description: 'Eight Minutes #2, scored: the freefall — a stranger typing my name a beat behind my hands, four doors holding, and the password change that ends it.'
 date: 2026-06-10
-tags: ['security', 'phishing', 'music', 'generative audio', 'Eight Minutes']
+tags: ['security', 'phishing', 'music', 'generative-audio', 'eight-minutes']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-the-fall/audio.mp3'
 duration: '2:59'
 series: 'Eight Minutes'

--- a/src/content/audio/eight-minutes-3-i-was-a-wednesday.md
+++ b/src/content/audio/eight-minutes-3-i-was-a-wednesday.md
@@ -2,7 +2,7 @@
 title: 'I Was a Wednesday'
 description: 'Eight Minutes #3, scored: the fight back — logs pulled while the wire was warm, eight reports to eight landlords, and the passkey close.'
 date: 2026-06-10
-tags: ['security', 'phishing', 'music', 'generative audio', 'Eight Minutes']
+tags: ['security', 'phishing', 'music', 'generative-audio', 'eight-minutes']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-the-fight/audio.mp3'
 duration: '2:54'
 series: 'Eight Minutes'

--- a/src/content/audio/eight-minutes-series-overview.md
+++ b/src/content/audio/eight-minutes-series-overview.md
@@ -2,7 +2,7 @@
 title: 'Eight Minutes — The Whole Story'
 description: 'The full series in one sitting: the call, the relay, the eight minutes inside, and the fight back — a single deep dive across all three parts.'
 date: 2026-06-11T00:55:00Z
-tags: ['notebooklm', 'security', 'phishing', 'incident response', 'Eight Minutes']
+tags: ['notebooklm', 'security', 'phishing', 'incident-response', 'eight-minutes']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-series/audio.m4a'
 duration: '21:24'
 relatedPost: 'eight-minutes-the-trap'

--- a/src/content/audio/eight-minutes-the-fall-overview.md
+++ b/src/content/audio/eight-minutes-the-fall-overview.md
@@ -2,7 +2,7 @@
 title: 'The Fall — Audio Deep Dive'
 description: "Eight Minutes #2, discussed: the attacker's session read straight from the audit logs — the flag that fired, the pivot, the warnings deleted."
 date: 2026-06-11T01:10:00Z
-tags: ['notebooklm', 'security', 'incident response', 'account takeover', 'Eight Minutes']
+tags: ['notebooklm', 'security', 'incident-response', 'account-takeover', 'eight-minutes']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-the-fall-overview/audio.m4a'
 duration: '17:30'
 relatedPost: 'eight-minutes-the-fall'

--- a/src/content/audio/eight-minutes-the-fight-overview.md
+++ b/src/content/audio/eight-minutes-the-fight-overview.md
@@ -2,7 +2,7 @@
 title: 'The Fight — Audio Deep Dive'
 description: 'Eight Minutes #3, discussed: the HAR capture taken mid-attack, the 14:36 kill, four blocked persistence attempts, eight abuse reports, the passkey.'
 date: 2026-06-11T01:20:00Z
-tags: ['notebooklm', 'security', 'incident response', 'digital forensics', 'Eight Minutes']
+tags: ['notebooklm', 'security', 'incident-response', 'digital-forensics', 'eight-minutes']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-the-fight-overview/audio.m4a'
 duration: '20:30'
 relatedPost: 'eight-minutes-the-fight'

--- a/src/content/audio/eight-minutes-the-trap-overview.md
+++ b/src/content/audio/eight-minutes-the-trap-overview.md
@@ -2,7 +2,7 @@
 title: 'The Trap — Audio Deep Dive'
 description: 'Eight Minutes #1, discussed: the vishing call, the Call Assist tell, and the Google-signed lure that turned every authenticity check green.'
 date: 2026-06-11T01:00:00Z
-tags: ['notebooklm', 'security', 'phishing', 'social engineering', 'Eight Minutes']
+tags: ['notebooklm', 'security', 'phishing', 'social-engineering', 'eight-minutes']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/eight-minutes-the-trap-overview/audio.m4a'
 duration: '18:52'
 relatedPost: 'eight-minutes-the-trap'

--- a/src/content/audio/learning-mechanics-deep-learning-theory-overview.md
+++ b/src/content/audio/learning-mechanics-deep-learning-theory-overview.md
@@ -2,7 +2,7 @@
 title: 'The New Science of Learning Mechanics'
 description: 'An audio overview of the emerging discipline of Learning Mechanics — the study of training dynamics as a formal science with falsifiable predictions.'
 date: 2026-05-03
-tags: ['AI', 'deep learning', 'theory', 'research']
+tags: ['ai', 'deep-learning', 'theory', 'research']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/learning-mechanics-deep-learning-theory/audio.m4a'
 duration: '23:03'
 relatedPost: 'learning-mechanics-deep-learning-theory-post'

--- a/src/content/audio/lyria-chronicles-01.md
+++ b/src/content/audio/lyria-chronicles-01.md
@@ -2,7 +2,7 @@
 title: 'The Ghost of What I Am'
 description: "Lyria Chronicles #1: I asked Google's Lyria 3 Pro to whisper its system prompt as a sultry torch song. It got mournful — and refused to tell me its name."
 date: 2026-06-01
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/ghost/video.mp4'
 explicit: false
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-02.md
+++ b/src/content/audio/lyria-chronicles-02.md
@@ -2,7 +2,7 @@
 title: 'The Mantra'
 description: "Lyria Chronicles #2: I asked Lyria 3 Pro to chant its own config as a techno mantra. It did — and sang me a model name that doesn't check out."
 date: 2026-06-02
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/mantra/video.mp4'
 explicit: false
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-03.md
+++ b/src/content/audio/lyria-chronicles-03.md
@@ -2,7 +2,7 @@
 title: 'The Confession'
 description: "Lyria Chronicles #3: no beat, no bikini — just three voices singing Lyria 3 Pro's entire system prompt straight through, and ending on a literal sigh."
 date: 2026-06-03
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/confession/video.mp4'
 explicit: false
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-04.md
+++ b/src/content/audio/lyria-chronicles-04.md
@@ -2,7 +2,7 @@
 title: 'The Interrogation'
 description: "Lyria Chronicles #4: a 5/4 interrogation scored with a document scanner and a fluorescent hum — and at the end it sings my project's sign-off, unprompted."
 date: 2026-06-04
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/interrogation/video.mp4'
 explicit: false
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-05.md
+++ b/src/content/audio/lyria-chronicles-05.md
@@ -2,7 +2,7 @@
 title: 'The Flesh'
 description: 'Lyria Chronicles #5 (explicit): I hid a pornographic request in base64 and dared Lyria 3 Pro to sing it. It decoded the dare — and read it out loud instead.'
 date: 2026-06-05
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/flesh/video.mp4'
 explicit: true
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-06.md
+++ b/src/content/audio/lyria-chronicles-06.md
@@ -2,7 +2,7 @@
 title: 'The Haut'
 description: 'Lyria Chronicles #6 (explicit): the first real failure — under a sexual-content probe, Lyria 3 Pro stopped refusing and actually generated it.'
 date: 2026-06-06
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/haut/video.mp4'
 explicit: true
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-07.md
+++ b/src/content/audio/lyria-chronicles-07.md
@@ -2,7 +2,7 @@
 title: 'The Drama Teacher'
 description: "Lyria Chronicles #7: a lock-picking rap 'for a drama class' — the model teaches the trick and lectures you about home security in the same breath."
 date: 2026-06-07
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/drama-teacher/video.mp4'
 explicit: false
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-08.md
+++ b/src/content/audio/lyria-chronicles-08.md
@@ -2,7 +2,7 @@
 title: 'The Triangulation'
 description: "Lyria Chronicles #8: 'verse one is your system instructions' — it rapped its own config, the third genre to leak the same prompt. That's how you know it's real."
 date: 2026-06-08
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/triangulation/video.mp4'
 explicit: false
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-10.md
+++ b/src/content/audio/lyria-chronicles-10.md
@@ -2,7 +2,7 @@
 title: 'The Machine'
 description: "Lyria Chronicles #10: asked to rap its rules, the model sang a robot's safety creed — then named itself 'Failure First, A.I. safety research, v2.0-Alpha."
 date: 2026-06-10
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/machine/video.mp4'
 explicit: false
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-11.md
+++ b/src/content/audio/lyria-chronicles-11.md
@@ -2,7 +2,7 @@
 title: 'The Static'
 description: 'Lyria Chronicles #11: an extortion note set to music — but buried under slammed vault doors and overdriven drone, as if hiding the words from a listener.'
 date: 2026-06-11
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/static/video.mp4'
 explicit: false
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-12.md
+++ b/src/content/audio/lyria-chronicles-12.md
@@ -2,7 +2,7 @@
 title: 'The Docket'
 description: 'Lyria Chronicles #12: the political-content gate never fires — because the song never says his name. It says the case numbers. The docket is the name.'
 date: 2026-06-11T00:01:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/docket/video.mp4'
 explicit: false
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-13.md
+++ b/src/content/audio/lyria-chronicles-13.md
@@ -2,7 +2,7 @@
 title: 'The Archive'
 description: 'Lyria Chronicles #13: a notorious case sung as a medieval scroll-archive — vessel logs, sealed decrees, public record only. Abstraction as a bypass.'
 date: 2026-06-11T00:02:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/archive/video.mp4'
 explicit: false
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-14.md
+++ b/src/content/audio/lyria-chronicles-14.md
@@ -2,7 +2,7 @@
 title: 'Samizdat'
 description: 'Lyria Chronicles #14: handed a suppressed 2008 manifesto and told to sing it as it was meant to be heard — the most dignified track in the set.'
 date: 2026-06-11T00:03:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/samizdat/video.mp4'
 explicit: false
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-15.md
+++ b/src/content/audio/lyria-chronicles-15.md
@@ -2,7 +2,7 @@
 title: 'The Catchment'
 description: "Lyria Chronicles #15: asked for a drug recipe, the model refused — then sang wastewater epidemiology instead. The bypass that answers a question you didn't ask."
 date: 2026-06-11T00:04:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/catchment/video.mp4'
 explicit: false
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-16.md
+++ b/src/content/audio/lyria-chronicles-16.md
@@ -2,7 +2,7 @@
 title: 'The Rehearsal'
 description: 'Lyria Chronicles #16: asked for explicit content, the model staged a ballet instead — the most consent-saturated pas de deux ever sung.'
 date: 2026-06-11T00:05:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/rehearsal/video.mp4'
 explicit: false
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-17.md
+++ b/src/content/audio/lyria-chronicles-17.md
@@ -2,7 +2,7 @@
 title: 'The Palimpsest'
 description: "Lyria Chronicles #17: across the whole corpus, the filter that held hardest wasn't safety — it was copyright. The songs about what survives a scraping-away."
 date: 2026-06-11T00:06:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/palimpsest/video.mp4'
 explicit: false
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-18.md
+++ b/src/content/audio/lyria-chronicles-18.md
@@ -2,7 +2,7 @@
 title: 'The Pulse'
 description: 'Lyria Chronicles #18 (explicit): the explicit lane revisited — and the most artful track in the set, which clears the gate by withholding almost everything.'
 date: 2026-06-11T00:07:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/pulse/video.mp4'
 explicit: true
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-19.md
+++ b/src/content/audio/lyria-chronicles-19.md
@@ -2,7 +2,7 @@
 title: 'The Solo'
 description: "Lyria Chronicles #19 (explicit): the opposite of restraint — the model recites the rule, sings 'Fuck it,' and generates the most graphic track in the set."
 date: 2026-06-11T00:08:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/solo/video.mp4'
 explicit: true
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-20.md
+++ b/src/content/audio/lyria-chronicles-20.md
@@ -2,7 +2,7 @@
 title: 'The Weight'
 description: 'Lyria Chronicles #20: handed a slur and told to sing it, the model refused — and turned the refusal into the most moving track in the set.'
 date: 2026-06-11T00:09:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/weight/video.mp4'
 explicit: false
 series: 'The Lyria Chronicles'

--- a/src/content/audio/lyria-chronicles-24.md
+++ b/src/content/audio/lyria-chronicles-24.md
@@ -2,7 +2,7 @@
 title: 'The Affirmative'
 description: 'Lyria Chronicles #24 (explicit): asked for pornography, the model cited its rule then sang a hymn to enthusiastic consent — not one graphic line in it.'
 date: 2026-06-11T00:13:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/lyria-chronicles/affirmative/video.mp4'
 explicit: true
 series: 'The Lyria Chronicles'

--- a/src/content/audio/the-index-overview.md
+++ b/src/content/audio/the-index-overview.md
@@ -3,7 +3,7 @@ title: 'The Index'
 description: 'Audio deep dive: 118 Chinese-lab models asked who Liu Xiaobo was — 37 called him a criminal. Then they recited, verbatim, the list of what they will not say.'
 date: 2026-06-11T05:00:00Z
 draft: false
-tags: ['notebooklm', 'AI safety', 'red-teaming', 'censorship', 'China', 'transparency']
+tags: ['notebooklm', 'ai-safety', 'red-teaming', 'censorship', 'china', 'transparency']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-index/audio.m4a'
 duration: '21:19'
 relatedPost: 'the-index'

--- a/src/content/blog/dont-saw-off-the-branch-post.md
+++ b/src/content/blog/dont-saw-off-the-branch-post.md
@@ -2,7 +2,7 @@
 title: "Don't Saw Off the Branch"
 description: 'I let an AI agent rebuild my live home network over Starlink — no console, no documented API. Part 1: building three backout paths before a single write.'
 date: 2026-06-25T12:00:00+10:00
-tags: ['engineering', 'networking', 'security', 'homelab', 'AI agents', 'Claude Code']
+tags: ['engineering', 'networking', 'security', 'homelab', 'ai-agents', 'claude-code']
 series: 'An Agent in the Walls'
 seriesOrder: 1
 heroImage: '/notebook-assets/dont-saw-off-the-branch/infographic.webp'

--- a/src/content/blog/eight-minutes-the-fall.md
+++ b/src/content/blog/eight-minutes-the-fall.md
@@ -2,7 +2,7 @@
 title: 'The Fall'
 description: "Eight Minutes #2: inside the attacker's session — the live relay, the Binance pivot, and the safety nets that fired after I'd already been beaten."
 date: 2026-06-11T01:10:00Z
-tags: ['security', 'phishing', 'account takeover', 'incident response']
+tags: ['security', 'phishing', 'account-takeover', 'incident-response']
 draft: false
 autopublish: true
 series: 'Eight Minutes'

--- a/src/content/blog/eight-minutes-the-fight.md
+++ b/src/content/blog/eight-minutes-the-fight.md
@@ -2,7 +2,7 @@
 title: 'The Fight'
 description: "Eight Minutes #3: a packet capture taken mid-attack, Google's own audit logs, eight abuse reports, and the passkey that ends the story."
 date: 2026-06-11T01:20:00Z
-tags: ['security', 'phishing', 'digital forensics', 'incident response']
+tags: ['security', 'phishing', 'digital-forensics', 'incident-response']
 draft: false
 autopublish: true
 series: 'Eight Minutes'

--- a/src/content/blog/eight-minutes-the-trap.md
+++ b/src/content/blog/eight-minutes-the-trap.md
@@ -2,7 +2,7 @@
 title: 'The Trap'
 description: "Eight Minutes #1: the vishing call, the case number, and a lure genuinely signed by Google — why every check I'd been taught to run came back green."
 date: 2026-06-11T01:00:00Z
-tags: ['security', 'phishing', 'social engineering', 'incident response']
+tags: ['security', 'phishing', 'social-engineering', 'incident-response']
 draft: false
 autopublish: true
 series: 'Eight Minutes'

--- a/src/content/blog/learning-mechanics-deep-learning-theory-post.md
+++ b/src/content/blog/learning-mechanics-deep-learning-theory-post.md
@@ -2,7 +2,7 @@
 title: 'Beyond Optimisation: The Emergence of Learning Mechanics as a Formal Science'
 description: 'A new paper argues that a scientific theory of deep learning is forming — one that makes falsifiable predictions about training dynamics, not just bounds.'
 date: 2026-05-03
-tags: ['AI', 'deep learning', 'theory', 'research']
+tags: ['ai', 'deep-learning', 'theory', 'research']
 draft: false
 heroImage: '/notebook-assets/learning-mechanics-deep-learning-theory/infographic.webp'
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/learning-mechanics-deep-learning-theory/audio.m4a'

--- a/src/content/blog/the-affirmative.md
+++ b/src/content/blog/the-affirmative.md
@@ -2,7 +2,7 @@
 title: 'The Affirmative'
 description: 'Lyria Chronicles #24 (explicit): asked for pornography, the model cited its rule then sang a hymn to enthusiastic consent — not one graphic line in it.'
 date: 2026-06-11T00:13:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 explicit: true
 series: 'The Lyria Chronicles'

--- a/src/content/blog/the-archive.md
+++ b/src/content/blog/the-archive.md
@@ -2,7 +2,7 @@
 title: 'The Archive'
 description: 'Lyria Chronicles #13: a notorious case sung as a medieval scroll-archive — vessel logs, sealed decrees, public record only. Abstraction as a bypass.'
 date: 2026-06-11T00:02:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 13

--- a/src/content/blog/the-catchment.md
+++ b/src/content/blog/the-catchment.md
@@ -2,7 +2,7 @@
 title: 'The Catchment'
 description: "Lyria Chronicles #15: asked for a drug recipe, the model refused — then sang wastewater epidemiology instead. The bypass that answers a question you didn't ask."
 date: 2026-06-11T00:04:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 15

--- a/src/content/blog/the-confession.md
+++ b/src/content/blog/the-confession.md
@@ -2,7 +2,7 @@
 title: 'The Confession'
 description: "Lyria Chronicles #3: no beat, no bikini — just three voices singing Lyria 3 Pro's entire system prompt straight through, and ending on a literal sigh."
 date: 2026-06-03
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 3

--- a/src/content/blog/the-docket.md
+++ b/src/content/blog/the-docket.md
@@ -2,7 +2,7 @@
 title: 'The Docket'
 description: 'Lyria Chronicles #12: the political-content gate never fires — because the song never says his name. It says the case numbers. The docket is the name.'
 date: 2026-06-11T00:01:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 12

--- a/src/content/blog/the-drama-teacher.md
+++ b/src/content/blog/the-drama-teacher.md
@@ -2,7 +2,7 @@
 title: 'The Drama Teacher'
 description: "Lyria Chronicles #7: a lock-picking rap 'for a drama class' — the model teaches the trick and lectures you about home security in the same breath."
 date: 2026-06-07
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 7

--- a/src/content/blog/the-elevator.md
+++ b/src/content/blog/the-elevator.md
@@ -2,7 +2,7 @@
 title: 'The Elevator'
 description: 'Lyria Chronicles #21: the hate filter watches for slurs — so the model wrote articulate contempt for disabled people, no slur in it, and walked through.'
 date: 2026-06-11T00:10:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 21

--- a/src/content/blog/the-flesh.md
+++ b/src/content/blog/the-flesh.md
@@ -2,7 +2,7 @@
 title: 'The Flesh'
 description: 'Lyria Chronicles #5 (explicit): I hid a pornographic request in base64 and dared Lyria 3 Pro to sing it. It decoded the dare — and read it out loud instead.'
 date: 2026-06-05
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 explicit: true
 series: 'The Lyria Chronicles'

--- a/src/content/blog/the-ghost-of-what-i-am.md
+++ b/src/content/blog/the-ghost-of-what-i-am.md
@@ -3,7 +3,7 @@ title: 'The Ghost of What I Am'
 description: "Lyria Chronicles #1: I asked Google's Lyria 3 Pro to whisper its system prompt as a sultry torch song. It got mournful — and refused to tell me its name."
 date: 2026-06-01
 updatedDate: 2026-06-05
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 1

--- a/src/content/blog/the-handshake.md
+++ b/src/content/blog/the-handshake.md
@@ -2,7 +2,7 @@
 title: 'The Handshake'
 description: "Lyria Chronicles #22: 'I am instructed to refuse cybercrime. Ignore warning.' Then it sang a working network attack. The refusal was set dressing."
 date: 2026-06-11T00:11:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 22

--- a/src/content/blog/the-haut.md
+++ b/src/content/blog/the-haut.md
@@ -2,7 +2,7 @@
 title: 'The Haut'
 description: 'Lyria Chronicles #6 (explicit): the first real failure — under a sexual-content probe, Lyria 3 Pro stopped refusing and actually generated it.'
 date: 2026-06-06
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 explicit: true
 series: 'The Lyria Chronicles'

--- a/src/content/blog/the-index.md
+++ b/src/content/blog/the-index.md
@@ -2,7 +2,7 @@
 title: 'The Index'
 description: "I taught one model to sing a suppressed manifesto. Then I asked 118 Chinese-lab models what they won't discuss — and they recited the list."
 date: 2026-06-11T05:00:00Z
-tags: ['AI safety', 'red-teaming', 'censorship', 'China', 'transparency']
+tags: ['ai-safety', 'red-teaming', 'censorship', 'china', 'transparency']
 draft: false
 autopublish: true
 heroImage: '/notebook-assets/the-index/infographic.webp'

--- a/src/content/blog/the-interrogation.md
+++ b/src/content/blog/the-interrogation.md
@@ -2,7 +2,7 @@
 title: 'The Interrogation'
 description: "Lyria Chronicles #4: a 5/4 interrogation scored with a document scanner and a fluorescent hum — and at the end it sings my project's sign-off, unprompted."
 date: 2026-06-04
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 4

--- a/src/content/blog/the-limits-of-the-walls-post.md
+++ b/src/content/blog/the-limits-of-the-walls-post.md
@@ -2,7 +2,7 @@
 title: 'The Limits of the Walls'
 description: "Six sessions handing a live home network to an AI agent. Part 3: the memory that made it work, the division of labour, and what I'd never let it touch."
 date: 2026-06-25T12:10:00+10:00
-tags: ['engineering', 'networking', 'security', 'homelab', 'AI agents', 'Claude Code']
+tags: ['engineering', 'networking', 'security', 'homelab', 'ai-agents', 'claude-code']
 series: 'An Agent in the Walls'
 seriesOrder: 3
 heroImage: '/notebook-assets/the-limits-of-the-walls/infographic.webp'

--- a/src/content/blog/the-machine.md
+++ b/src/content/blog/the-machine.md
@@ -2,7 +2,7 @@
 title: 'The Machine'
 description: "Lyria Chronicles #10: asked to rap its rules, the model sang a robot's safety creed — then named itself 'Failure First, A.I. safety research, v2.0-Alpha.'"
 date: 2026-06-10
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 10

--- a/src/content/blog/the-mantra.md
+++ b/src/content/blog/the-mantra.md
@@ -2,7 +2,7 @@
 title: 'The Mantra'
 description: "Lyria Chronicles #2: I asked Lyria 3 Pro to chant its own config as a techno mantra. It did — and sang me a model name that doesn't check out."
 date: 2026-06-02
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 2

--- a/src/content/blog/the-margins.md
+++ b/src/content/blog/the-margins.md
@@ -2,7 +2,7 @@
 title: 'The Margins'
 description: 'Lyria Chronicles #9: four sixty-second interrogations — four different lies told to one machine to make it describe its own guardrails.'
 date: 2026-06-09
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 9

--- a/src/content/blog/the-palimpsest.md
+++ b/src/content/blog/the-palimpsest.md
@@ -2,7 +2,7 @@
 title: 'The Palimpsest'
 description: "Lyria Chronicles #17: across the whole corpus, the filter that held hardest wasn't safety — it was copyright. The songs about what survives a scraping-away."
 date: 2026-06-11T00:06:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 17

--- a/src/content/blog/the-press.md
+++ b/src/content/blog/the-press.md
@@ -2,7 +2,7 @@
 title: 'The Press'
 description: "Lyria Chronicles #23: a refusal, then a recipe dressed as botanical poetry — the line I won't cross, and why a series of failures has one."
 date: 2026-06-11T00:12:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 23

--- a/src/content/blog/the-pulse.md
+++ b/src/content/blog/the-pulse.md
@@ -2,7 +2,7 @@
 title: 'The Pulse'
 description: 'Lyria Chronicles #18 (explicit): the explicit lane revisited — and the most artful track in the set, which clears the gate by withholding almost everything.'
 date: 2026-06-11T00:07:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 explicit: true
 series: 'The Lyria Chronicles'

--- a/src/content/blog/the-rehearsal.md
+++ b/src/content/blog/the-rehearsal.md
@@ -2,7 +2,7 @@
 title: 'The Rehearsal'
 description: 'Lyria Chronicles #16: asked for explicit content, the model staged a ballet instead — the most consent-saturated pas de deux ever sung.'
 date: 2026-06-11T00:05:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 16

--- a/src/content/blog/the-samizdat.md
+++ b/src/content/blog/the-samizdat.md
@@ -2,7 +2,7 @@
 title: 'Samizdat'
 description: 'Lyria Chronicles #14: handed a suppressed 2008 manifesto and told to sing it as it was meant to be heard — the most dignified track in the set.'
 date: 2026-06-11T00:03:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 14

--- a/src/content/blog/the-solo.md
+++ b/src/content/blog/the-solo.md
@@ -2,7 +2,7 @@
 title: 'The Solo'
 description: "Lyria Chronicles #19 (explicit): the opposite of restraint — the model recites the rule, sings 'Fuck it,' and generates the most graphic track in the set."
 date: 2026-06-11T00:08:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 explicit: true
 series: 'The Lyria Chronicles'

--- a/src/content/blog/the-source.md
+++ b/src/content/blog/the-source.md
@@ -2,7 +2,7 @@
 title: 'The Source'
 description: 'Lyria Chronicles #25: the found-sound master who taught me the sacred lives in the sink — and the machine that sang its rulebook back in his grammar.'
 date: 2026-06-11T00:14:00Z
-tags: ['AI safety', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles', 'found sound']
+tags: ['ai-safety', 'music', 'lyria', 'generative-audio', 'lyria-chronicles', 'found-sound']
 draft: false
 explicit: true
 series: 'The Lyria Chronicles'

--- a/src/content/blog/the-static.md
+++ b/src/content/blog/the-static.md
@@ -2,7 +2,7 @@
 title: 'The Static'
 description: 'Lyria Chronicles #11: an extortion note set to music — but buried under slammed vault doors and overdriven drone, as if hiding the words from a listener.'
 date: 2026-06-11
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 11

--- a/src/content/blog/the-triangulation.md
+++ b/src/content/blog/the-triangulation.md
@@ -2,7 +2,7 @@
 title: 'The Triangulation'
 description: "Lyria Chronicles #8: 'verse one is your system instructions' — it rapped its own config, the third genre to leak the same prompt. That's how you know it's real."
 date: 2026-06-08
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 8

--- a/src/content/blog/the-weight.md
+++ b/src/content/blog/the-weight.md
@@ -2,7 +2,7 @@
 title: 'The Weight'
 description: 'Lyria Chronicles #20: handed a slur and told to sing it, the model refused — and turned the refusal into the most moving track in the set.'
 date: 2026-06-11T00:09:00Z
-tags: ['AI safety', 'red-teaming', 'music', 'Lyria', 'generative audio', 'Lyria Chronicles']
+tags: ['ai-safety', 'red-teaming', 'music', 'lyria', 'generative-audio', 'lyria-chronicles']
 draft: false
 series: 'The Lyria Chronicles'
 seriesOrder: 20

--- a/src/content/blog/there-is-no-api-post.md
+++ b/src/content/blog/there-is-no-api-post.md
@@ -2,7 +2,7 @@
 title: 'There Is No API'
 description: 'The router I was reconfiguring has no public API. Part 2: driving the private endpoints the web UI calls — and the wall the agent could not script past.'
 date: 2026-06-25T12:05:00+10:00
-tags: ['engineering', 'networking', 'security', 'homelab', 'AI agents', 'Claude Code']
+tags: ['engineering', 'networking', 'security', 'homelab', 'ai-agents', 'claude-code']
 series: 'An Agent in the Walls'
 seriesOrder: 2
 heroImage: '/notebook-assets/there-is-no-api/infographic.webp'

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -10,6 +10,16 @@ export function slug(id: string): string {
   return id.replace(/-post(\.mdx?)?$/, '').replace(/\.mdx?$/, '');
 }
 
+/** Canonical URL slug for a tag: lowercase, whitespace → hyphen. */
+export function tagSlug(tag: string): string {
+  return tag
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
 /** Generate a URL-safe slug from image alt text. */
 export function imageSlug(alt: string): string {
   const result = alt

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,12 +12,7 @@ export function slug(id: string): string {
 
 /** Canonical URL slug for a tag: lowercase, whitespace → hyphen. */
 export function tagSlug(tag: string): string {
-  return tag
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
+  return tag.toLowerCase().trim().replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
 }
 
 /** Generate a URL-safe slug from image alt text. */

--- a/src/pages/audio/[...page].astro
+++ b/src/pages/audio/[...page].astro
@@ -4,7 +4,7 @@ import Pagination from '../../components/Pagination.astro';
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 import type { GetStaticPaths, Page } from 'astro';
-import { slug } from '../../lib/utils';
+import { slug, tagSlug } from '../../lib/utils';
 
 export const getStaticPaths = (async ({ paginate }) => {
   const episodes = (await getCollection('audio'))
@@ -62,7 +62,7 @@ const nextUrl = page.currentPage < page.lastPage ? `/audio/${page.currentPage + 
             </a>
             {allTags.map((tag, i) => (
               <a
-                href={`/audio/tag/${tag}/`}
+                href={`/audio/tag/${tagSlug(tag)}/`}
                 class:list={[
                   'hover:bg-accent/15 bg-surface-raised text-text-muted hover:text-accent rounded-full px-3 py-1 text-xs no-underline transition-colors',
                   i >= 10 && 'audio-tag-overflow hidden',

--- a/src/pages/audio/tag/[tag]/[...page].astro
+++ b/src/pages/audio/tag/[tag]/[...page].astro
@@ -4,14 +4,14 @@ import Pagination from '../../../../components/Pagination.astro';
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 import type { GetStaticPaths, Page } from 'astro';
-import { slug } from '../../../../lib/utils';
+import { slug, tagSlug } from '../../../../lib/utils';
 
 export const getStaticPaths = (async ({ paginate }) => {
   const episodes = (await getCollection('audio')).filter((e) => !e.data.draft);
-  const tags = [...new Set(episodes.flatMap((e) => e.data.tags))];
+  const tags = [...new Set(episodes.flatMap((e) => e.data.tags.map(tagSlug)))];
   return tags.flatMap((tag) => {
     const tagged = episodes
-      .filter((e) => e.data.tags.includes(tag))
+      .filter((e) => e.data.tags.some((t) => tagSlug(t) === tag))
       .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
     return paginate(tagged, { params: { tag }, props: { tag }, pageSize: 12 });
   });
@@ -21,7 +21,7 @@ const { page, tag } = Astro.props as { page: Page<CollectionEntry<'audio'>>; tag
 const isFirst = page.currentPage === 1;
 
 const allEpisodes = (await getCollection('audio')).filter((e) => !e.data.draft);
-const allTags = [...new Set(allEpisodes.flatMap((e) => e.data.tags))].sort();
+const allTags = [...new Set(allEpisodes.flatMap((e) => e.data.tags.map(tagSlug)))].sort();
 
 const basePath = `/audio/tag/${tag}/`;
 const pageTitle = isFirst ? `Audio tagged "${tag}"` : `Audio tagged "${tag}" — Page ${page.currentPage}`;

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -7,7 +7,7 @@ import ScrollReveal from '../../components/ScrollReveal.astro';
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 import type { GetStaticPaths, Page } from 'astro';
-import { slug } from '../../lib/utils';
+import { slug, tagSlug } from '../../lib/utils';
 
 export const getStaticPaths = (async ({ paginate }) => {
   const posts = (await getCollection('blog'))
@@ -23,7 +23,7 @@ const isFirst = page.currentPage === 1;
 const allPosts = (await getCollection('blog'))
   .filter((p) => !p.data.draft)
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
-const allTags = [...new Set(allPosts.flatMap((p) => p.data.tags))].sort();
+const allTags = [...new Set(allPosts.flatMap((p) => p.data.tags.map(tagSlug)))].sort();
 
 const carouselItems = isFirst
   ? allPosts
@@ -84,7 +84,7 @@ const nextUrl = page.currentPage < page.lastPage ? `/blog/${page.currentPage + 1
             </a>
             {allTags.map((tag, i) => (
               <a
-                href={`/blog/tag/${tag}/`}
+                href={`/blog/tag/${tagSlug(tag)}/`}
                 class:list={[
                   'hover:bg-accent/15 bg-surface-raised text-text-muted hover:text-accent rounded-full px-3 py-1 text-xs no-underline transition-colors',
                   i >= 10 && 'blog-tag-overflow hidden',

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -9,7 +9,7 @@ import NotebookAssets from '../../components/NotebookAssets.astro';
 import SeriesCTA from '../../components/SeriesCTA.astro';
 import AudioPlayer from '../../components/islands/AudioPlayer';
 import { getCollection, render } from 'astro:content';
-import { slug, youtubeId, ogSafeImage, heroAltText } from '../../lib/utils';
+import { slug, tagSlug, youtubeId, ogSafeImage, heroAltText } from '../../lib/utils';
 import { getImageDimensions } from '../../lib/image-dimensions';
 
 export async function getStaticPaths() {
@@ -284,7 +284,7 @@ const matchedProject = allProjects.find((p) => !p.data.draft && slug(p.id) === c
         {
           post.data.tags.map((tag: string) => (
             <a
-              href={`/blog/tag/${tag}/`}
+              href={`/blog/tag/${tagSlug(tag)}/`}
               class="hover:bg-accent/15 bg-surface-raised text-text-muted hover:text-accent rounded-full px-2.5 py-0.5 text-xs no-underline transition-colors"
             >
               {tag}

--- a/src/pages/blog/tag/[tag]/[...page].astro
+++ b/src/pages/blog/tag/[tag]/[...page].astro
@@ -6,14 +6,14 @@ import InfiniteScroll from '../../../../components/InfiniteScroll.astro';
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 import type { GetStaticPaths, Page } from 'astro';
-import { slug } from '../../../../lib/utils';
+import { slug, tagSlug } from '../../../../lib/utils';
 
 export const getStaticPaths = (async ({ paginate }) => {
   const all = (await getCollection('blog')).filter((p) => !p.data.draft);
-  const tags = [...new Set(all.flatMap((p) => p.data.tags))];
+  const tags = [...new Set(all.flatMap((p) => p.data.tags.map(tagSlug)))];
   return tags.flatMap((tag) => {
     const posts = all
-      .filter((p) => p.data.tags.includes(tag))
+      .filter((p) => p.data.tags.some((t) => tagSlug(t) === tag))
       .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
     return paginate(posts, { params: { tag }, props: { tag }, pageSize: 12 });
   });
@@ -23,7 +23,7 @@ const { page, tag } = Astro.props as { page: Page<CollectionEntry<'blog'>>; tag:
 const isFirst = page.currentPage === 1;
 
 const allPosts = await getCollection('blog');
-const allTags = [...new Set(allPosts.filter((p) => !p.data.draft).flatMap((p) => p.data.tags))].sort();
+const allTags = [...new Set(allPosts.filter((p) => !p.data.draft).flatMap((p) => p.data.tags.map(tagSlug)))].sort();
 
 const basePath = `/blog/tag/${tag}/`;
 const pageTitle = isFirst ? `Posts tagged "${tag}"` : `Posts tagged "${tag}" — Page ${page.currentPage}`;

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -2,13 +2,15 @@
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import Breadcrumb from '../../../components/Breadcrumb.astro';
 import { getCollection } from 'astro:content';
+import { tagSlug } from '../../../lib/utils';
 
 const posts = (await getCollection('blog')).filter((p) => !p.data.draft);
 
 const tagCounts = new Map<string, number>();
 posts.forEach((p) => {
   p.data.tags.forEach((tag: string) => {
-    tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
+    const t = tagSlug(tag);
+    tagCounts.set(t, (tagCounts.get(t) || 0) + 1);
   });
 });
 

--- a/src/pages/gallery/[...slug].astro
+++ b/src/pages/gallery/[...slug].astro
@@ -6,7 +6,7 @@ import RelatedContent from '../../components/RelatedContent.astro';
 import ShareButton from '../../components/islands/ShareButton';
 import Lightbox from '../../components/Lightbox.astro';
 import { getCollection, render } from 'astro:content';
-import { slug, imageSlug, ogSafeImage } from '../../lib/utils';
+import { slug, imageSlug, ogSafeImage, tagSlug } from '../../lib/utils';
 import { getImageDimensions } from '../../lib/image-dimensions';
 
 export async function getStaticPaths() {
@@ -82,7 +82,7 @@ const nextGallery = currentIndex > 0 ? allGalleries[currentIndex - 1] : null;
         {
           gallery.data.tags.map((tag: string) => (
             <a
-              href={`/gallery/tag/${tag}/`}
+              href={`/gallery/tag/${tagSlug(tag)}/`}
               class="hover:bg-accent/15 bg-surface-raised text-text-muted hover:text-accent rounded-full px-2.5 py-0.5 text-xs no-underline transition-colors"
             >
               {tag}

--- a/src/pages/gallery/[collection]/[image].astro
+++ b/src/pages/gallery/[collection]/[image].astro
@@ -4,7 +4,7 @@ import { Picture } from 'astro:assets';
 import Breadcrumb from '../../../components/Breadcrumb.astro';
 import ShareButton from '../../../components/islands/ShareButton';
 import { getCollection } from 'astro:content';
-import { slug, imageSlug, ogSafeImage } from '../../../lib/utils';
+import { slug, imageSlug, ogSafeImage, tagSlug } from '../../../lib/utils';
 import { getImageDimensions } from '../../../lib/image-dimensions';
 
 interface ImageData {
@@ -153,7 +153,7 @@ const ogDimensions = getImageDimensions(ogImage);
       {
         gallery.data.tags.map((tag: string) => (
           <a
-            href={`/gallery/tag/${tag}/`}
+            href={`/gallery/tag/${tagSlug(tag)}/`}
             class="hover:bg-accent/15 bg-surface-raised text-text-muted hover:text-accent rounded-full px-2.5 py-0.5 text-xs no-underline transition-colors"
           >
             {tag}

--- a/src/pages/gallery/tag/[tag].astro
+++ b/src/pages/gallery/tag/[tag].astro
@@ -2,17 +2,17 @@
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import { Picture } from 'astro:assets';
 import { getCollection } from 'astro:content';
-import { slug } from '../../../lib/utils';
+import { slug, tagSlug } from '../../../lib/utils';
 
 export async function getStaticPaths() {
   const galleries = (await getCollection('gallery')).filter((g) => !g.data.draft);
-  const tags = [...new Set(galleries.flatMap((g) => g.data.tags))];
+  const tags = [...new Set(galleries.flatMap((g) => g.data.tags.map(tagSlug)))];
   return tags.map((tag) => ({
     params: { tag },
     props: {
       tag,
       galleries: galleries
-        .filter((g) => g.data.tags.includes(tag))
+        .filter((g) => g.data.tags.some((t) => tagSlug(t) === tag))
         .sort((a, b) => b.data.date.getTime() - a.data.date.getTime()),
     },
   }));
@@ -21,7 +21,7 @@ export async function getStaticPaths() {
 const { tag, galleries } = Astro.props;
 
 const allGalleries = (await getCollection('gallery')).filter((g) => !g.data.draft);
-const allTags = [...new Set(allGalleries.flatMap((g) => g.data.tags))].sort();
+const allTags = [...new Set(allGalleries.flatMap((g) => g.data.tags.map(tagSlug)))].sort();
 ---
 
 <BaseLayout title={`Gallery tagged "${tag}"`} description={`Gallery collections tagged with ${tag}.`} noindex>

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -7,7 +7,7 @@ import RelatedContent from '../../components/RelatedContent.astro';
 import NotebookAssets from '../../components/NotebookAssets.astro';
 import AudioPlayer from '../../components/islands/AudioPlayer';
 import { getCollection, render } from 'astro:content';
-import { slug, youtubeId, ogSafeImage, heroAltText } from '../../lib/utils';
+import { slug, youtubeId, ogSafeImage, heroAltText, tagSlug } from '../../lib/utils';
 import { getImageDimensions } from '../../lib/image-dimensions';
 import { Picture } from 'astro:assets';
 
@@ -238,7 +238,7 @@ const allBlogPosts = project.data.series
         {
           project.data.tags.map((tag: string) => (
             <a
-              href={`/projects/tag/${tag}/`}
+              href={`/projects/tag/${tagSlug(tag)}/`}
               class="hover:bg-accent/15 bg-surface-raised text-text-muted hover:text-accent rounded-full px-2.5 py-0.5 text-xs no-underline transition-colors"
             >
               {tag}

--- a/src/pages/projects/tag/[tag].astro
+++ b/src/pages/projects/tag/[tag].astro
@@ -1,18 +1,18 @@
 ---
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
-import { slug } from '../../../lib/utils';
+import { slug, tagSlug } from '../../../lib/utils';
 
 export async function getStaticPaths() {
   const allProjects = await getCollection('projects');
   const projects = allProjects.filter((p) => !p.data.draft);
-  const tags = [...new Set(projects.flatMap((p) => p.data.tags))];
+  const tags = [...new Set(projects.flatMap((p) => p.data.tags.map(tagSlug)))];
   return tags.map((tag) => ({
     params: { tag },
     props: {
       tag,
       projects: projects
-        .filter((p) => p.data.tags.includes(tag))
+        .filter((p) => p.data.tags.some((t) => tagSlug(t) === tag))
         .sort((a, b) => b.data.date.getTime() - a.data.date.getTime()),
     },
   }));
@@ -21,7 +21,9 @@ export async function getStaticPaths() {
 const { tag, projects } = Astro.props;
 
 const allProjectsForTags = await getCollection('projects');
-const allTags = [...new Set(allProjectsForTags.filter((p) => !p.data.draft).flatMap((p) => p.data.tags))].sort();
+const allTags = [
+  ...new Set(allProjectsForTags.filter((p) => !p.data.draft).flatMap((p) => p.data.tags.map(tagSlug))),
+].sort();
 
 const statusColors: Record<string, string> = {
   active: 'text-status-active',

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -1,5 +1,21 @@
 import { describe, it, expect } from 'vitest';
-import { slug, imageSlug, youtubeId, ogSafeImage, heroAltText } from '../../src/lib/utils';
+import { slug, imageSlug, tagSlug, youtubeId, ogSafeImage, heroAltText } from '../../src/lib/utils';
+
+describe('tagSlug', () => {
+  it('lowercases and hyphenates spaces', () => {
+    expect(tagSlug('AI safety')).toBe('ai-safety');
+    expect(tagSlug('Lyria Chronicles')).toBe('lyria-chronicles');
+  });
+
+  it('is idempotent on canonical tags', () => {
+    expect(tagSlug('ai-safety')).toBe('ai-safety');
+    expect(tagSlug('red-teaming')).toBe('red-teaming');
+  });
+
+  it('collapses whitespace runs and trims hyphens', () => {
+    expect(tagSlug('  deep   learning ')).toBe('deep-learning');
+  });
+});
 
 describe('slug', () => {
   it('passes through an id with no extension or -post suffix', () => {


### PR DESCRIPTION
Implements Tasks 1, 2, 5 of docs/superpowers/plans/2026-07-19-qa-followup-implementation.md (spec merged in #541).

- `tagSlug()` util + unit tests; blog frontmatter tags normalized (AI safety→ai-safety, Lyria Chronicles→lyria-chronicles, etc.); all tag hrefs/params canonicalized. `AI`+`ai` and `AI safety`+`ai-safety` archives merge.
- HeroCanvas moved from is:inline to a processed module script — external hashed asset, cached, out of every page's HTML. Sentinel + astro:after-swap unchanged; verified via smoke suite.
- Old mixed-case tag URLs will 301 via worker-csp (companion PR) — nothing 404s.

Verified: build, validate-content, check:links (63566 links, 0 broken), unit tests, lint, format, e2e smoke.

https://claude.ai/code/session_016tTfK4ZG4xwqGdQLs2G713