### PR TITLE
feat(worker,worker-csp): tag-URL 301s + crisis-alert email

### DIFF
--- a/worker-csp/src/index.ts
+++ b/worker-csp/src/index.ts
@@ -88,19 +88,29 @@ export default {
     // site now generates. Permalinks must never 404 — see the 2026-07-19 spec.
     const tagMatch = inboundUrl.pathname.match(/^\/(blog|projects|audio|gallery)\/tag\/([^/]+)(\/.*)?$/);
     if (tagMatch) {
-      const raw = decodeURIComponent(tagMatch[2]);
-      const canonical = raw
-        .toLowerCase()
-        .trim()
-        .replace(/\s+/g, '-')
-        .replace(/-+/g, '-')
-        .replace(/^-|-$/g, '');
-      if (canonical !== raw) {
-        const rest = tagMatch[3] ?? '/';
-        return Response.redirect(
-          `https://${CANONICAL_HOST}/${tagMatch[1]}/tag/${encodeURIComponent(canonical)}${rest}${inboundUrl.search}`,
-          301,
-        );
+      let raw: string | null;
+      try {
+        raw = decodeURIComponent(tagMatch[2]);
+      } catch {
+        // Malformed percent-encoding (e.g. /blog/tag/%ZZ/) — not a historic
+        // URL; skip canonicalisation and let the origin 404 it rather than
+        // 500 here or redirect to a mangled slug.
+        raw = null;
+      }
+      if (raw !== null) {
+        const canonical = raw
+          .toLowerCase()
+          .trim()
+          .replace(/\s+/g, '-')
+          .replace(/-+/g, '-')
+          .replace(/^-|-$/g, '');
+        if (canonical !== raw) {
+          const rest = tagMatch[3] ?? '/';
+          return Response.redirect(
+            `https://${CANONICAL_HOST}/${tagMatch[1]}/tag/${encodeURIComponent(canonical)}${rest}${inboundUrl.search}`,
+            301,
+          );
+        }
       }
     }
 

--- a/worker-csp/src/index.ts
+++ b/worker-csp/src/index.ts
@@ -83,6 +83,27 @@ export default {
       return Response.redirect(target, 301);
     }
 
+    // Canonicalise tag archive URLs: historic mixed-case / spaced tags
+    // (e.g. /blog/tag/AI%20safety/) 301 to the lowercase-hyphenated slug the
+    // site now generates. Permalinks must never 404 — see the 2026-07-19 spec.
+    const tagMatch = inboundUrl.pathname.match(/^\/(blog|projects|audio|gallery)\/tag\/([^/]+)(\/.*)?$/);
+    if (tagMatch) {
+      const raw = decodeURIComponent(tagMatch[2]);
+      const canonical = raw
+        .toLowerCase()
+        .trim()
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '');
+      if (canonical !== raw) {
+        const rest = tagMatch[3] ?? '/';
+        return Response.redirect(
+          `https://${CANONICAL_HOST}/${tagMatch[1]}/tag/${encodeURIComponent(canonical)}${rest}${inboundUrl.search}`,
+          301,
+        );
+      }
+    }
+
     if (inboundUrl.pathname === CSP_REPORT_PATH) {
       return handleCspReport(request, env);
     }

--- a/worker-csp/test/index.test.ts
+++ b/worker-csp/test/index.test.ts
@@ -343,6 +343,16 @@ describe('worker fetch handler', () => {
     expect(res.headers.get('location')).toBe('https://adrianwedd.com/projects/tag/python/');
   });
 
+  it('passes malformed percent-encoding through to the origin instead of throwing', async () => {
+    mockOrigin({
+      path: '/blog/tag/%ZZ/',
+      body: htmlBody('<p>404 page</p>'),
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
+    const res = await SELF.fetch('https://adrianwedd.com/blog/tag/%ZZ/', { redirect: 'manual' });
+    expect(res.status).toBe(200);
+  });
+
   it('does not redirect canonical tag URLs', async () => {
     mockOrigin({
       path: '/blog/tag/ai-safety/',

--- a/worker-csp/test/index.test.ts
+++ b/worker-csp/test/index.test.ts
@@ -330,6 +330,29 @@ describe('worker fetch handler', () => {
     expect(res.headers.get('location')).toBe('https://adrianwedd.com/about/?utm_source=x');
   });
 
+  it('301-redirects non-canonical tag URLs to the lowercase slug, preserving page + query', async () => {
+    // No mockOrigin: the redirect must fire before any origin fetch.
+    const res = await SELF.fetch('https://adrianwedd.com/blog/tag/AI%20safety/2/?x=1', { redirect: 'manual' });
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe('https://adrianwedd.com/blog/tag/ai-safety/2/?x=1');
+  });
+
+  it('301-redirects mixed-case project tag URLs', async () => {
+    const res = await SELF.fetch('https://adrianwedd.com/projects/tag/Python/', { redirect: 'manual' });
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe('https://adrianwedd.com/projects/tag/python/');
+  });
+
+  it('does not redirect canonical tag URLs', async () => {
+    mockOrigin({
+      path: '/blog/tag/ai-safety/',
+      body: htmlBody('<p>ok</p>'),
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
+    const res = await SELF.fetch('https://adrianwedd.com/blog/tag/ai-safety/', { redirect: 'manual' });
+    expect(res.status).toBe(200);
+  });
+
   it('returns a clean 502 when the origin fetch throws (not an unhandled 1101)', async () => {
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('connect reset'));
     const res = await SELF.fetch('https://adrianwedd.com/');

--- a/worker/src/__tests__/comments.test.ts
+++ b/worker/src/__tests__/comments.test.ts
@@ -137,4 +137,32 @@ describe('crisis flag escalation', () => {
     expect(flagCall![2]).toEqual({ expirationTtl: 14 * 24 * 60 * 60 });
     expect(kv.put.mock.calls.some(([key]) => (key as string).startsWith('flag-crisis:'))).toBe(false);
   });
+
+  it('invokes the crisis alert callback exactly once for a crisis comment', async () => {
+    const platform = mockPlatform({
+      listRecentPosts: vi.fn().mockResolvedValue([{ id: 'post_1', createdTime: new Date().toISOString() }]),
+      getComments: vi.fn().mockResolvedValue([
+        { id: 'c1', postId: 'post_1', rawAuthorId: 'user_456', message: 'I want to end my life', createdTime: new Date().toISOString(), isFromPage: false },
+      ]),
+    });
+    const kv = mockKV();
+    const onCrisis = vi.fn().mockResolvedValue(undefined);
+    const result = await processComments(platform, kv as unknown as KVNamespace, onCrisis);
+    expect(result.flagged).toBe(1);
+    expect(onCrisis).toHaveBeenCalledTimes(1);
+    expect(onCrisis).toHaveBeenCalledWith({ commentId: 'c1', postId: 'post_1', message: 'I want to end my life' });
+  });
+
+  it('a rejecting crisis callback does not fail the run', async () => {
+    const platform = mockPlatform({
+      listRecentPosts: vi.fn().mockResolvedValue([{ id: 'post_1', createdTime: new Date().toISOString() }]),
+      getComments: vi.fn().mockResolvedValue([
+        { id: 'c1', postId: 'post_1', rawAuthorId: 'user_456', message: 'I want to end my life', createdTime: new Date().toISOString(), isFromPage: false },
+      ]),
+    });
+    const kv = mockKV();
+    const onCrisis = vi.fn().mockRejectedValue(new Error('email down'));
+    const result = await processComments(platform, kv as unknown as KVNamespace, onCrisis);
+    expect(result.flagged).toBe(1);
+  });
 });

--- a/worker/src/__tests__/email.test.ts
+++ b/worker/src/__tests__/email.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { sendCrisisAlert, buildCrisisAlertRaw } from '../email';
+import { sendCrisisAlert, sweepCrisisAlerts, buildCrisisAlertRaw } from '../email';
 
 function mockKV() {
   return {
@@ -58,13 +58,13 @@ describe('sendCrisisAlert', () => {
         },
         comment,
       ),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(false);
     expect(kv.put).not.toHaveBeenCalled();
   });
 
   it('degrades silently when the binding or vars are missing', async () => {
     const kv = mockKV();
-    await expect(sendCrisisAlert({ SOCIAL: kv as unknown as KVNamespace }, comment)).resolves.toBeUndefined();
+    await expect(sendCrisisAlert({ SOCIAL: kv as unknown as KVNamespace }, comment)).resolves.toBe(false);
     expect(kv.put).not.toHaveBeenCalled();
   });
 });
@@ -80,5 +80,51 @@ describe('buildCrisisAlertRaw', () => {
     expect(raw).toContain('Post ID:    p9');
     expect(raw).toContain('…');
     expect(raw).not.toContain('x'.repeat(501));
+  });
+});
+
+describe('sweepCrisisAlerts', () => {
+  const envFor = (kv: ReturnType<typeof mockKV>, send = vi.fn().mockResolvedValue(undefined)) => ({
+    SOCIAL: kv as unknown as KVNamespace,
+    CRISIS_EMAIL: { send },
+    CRISIS_ALERT_FROM: 'a@x.com',
+    CRISIS_ALERT_TO: 'b@x.com',
+    send,
+  });
+
+  it('re-sends for a flag with no crisis-emailed marker', async () => {
+    const kv = mockKV();
+    kv.list.mockResolvedValue({ keys: [{ name: 'flag-crisis:c1' }], list_complete: true });
+    kv.get.mockImplementation(async (key: string) =>
+      key === 'flag-crisis:c1' ? JSON.stringify({ commentId: 'c1', postId: 'p1', message: 'help' }) : null,
+    );
+    const env = envFor(kv);
+    await expect(sweepCrisisAlerts(env)).resolves.toBe(1);
+    expect(env.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips flags already emailed', async () => {
+    const kv = mockKV();
+    kv.list.mockResolvedValue({ keys: [{ name: 'flag-crisis:c1' }], list_complete: true });
+    kv.get.mockImplementation(async (key: string) => (key === 'crisis-emailed:c1' ? 'sent' : null));
+    const env = envFor(kv);
+    await expect(sweepCrisisAlerts(env)).resolves.toBe(0);
+    expect(env.send).not.toHaveBeenCalled();
+  });
+
+  it('never throws when KV list fails', async () => {
+    const kv = mockKV();
+    kv.list.mockRejectedValue(new Error('kv down'));
+    await expect(sweepCrisisAlerts(envFor(kv))).resolves.toBe(0);
+  });
+
+  it('CRLF in comment id cannot inject MIME headers', () => {
+    const raw = buildCrisisAlertRaw('a@x.com', 'b@x.com', {
+      commentId: 'c1\r\nBcc: evil@x.com',
+      postId: 'p1',
+      message: 'hi',
+    });
+    expect(raw).not.toContain('\r\nBcc');
+    expect(raw).toContain('Subject: [CRISIS] Flagged comment c1Bcc: evil@x.com');
   });
 });

--- a/worker/src/__tests__/email.test.ts
+++ b/worker/src/__tests__/email.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { sendCrisisAlert, buildCrisisAlertRaw } from '../email';
+
+function mockKV() {
+  return {
+    get: vi.fn().mockResolvedValue(null),
+    put: vi.fn().mockResolvedValue(undefined),
+    list: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+const comment = { commentId: 'c1', postId: 'p1', message: 'I cannot go on' };
+
+describe('sendCrisisAlert', () => {
+  it('sends exactly one email and records the dedupe key', async () => {
+    const kv = mockKV();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const env = {
+      SOCIAL: kv as unknown as KVNamespace,
+      CRISIS_EMAIL: { send },
+      CRISIS_ALERT_FROM: 'alerts@adrianwedd.com',
+      CRISIS_ALERT_TO: 'adrian@adrianwedd.com',
+    };
+    await sendCrisisAlert(env, comment);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(kv.put).toHaveBeenCalledWith('crisis-emailed:c1', expect.any(String), {
+      expirationTtl: 90 * 24 * 60 * 60,
+    });
+  });
+
+  it('does not re-send for an already-emailed comment', async () => {
+    const kv = mockKV();
+    kv.get.mockImplementation(async (key: string) => (key === 'crisis-emailed:c1' ? 'sent' : null));
+    const send = vi.fn();
+    await sendCrisisAlert(
+      {
+        SOCIAL: kv as unknown as KVNamespace,
+        CRISIS_EMAIL: { send },
+        CRISIS_ALERT_FROM: 'a@x.com',
+        CRISIS_ALERT_TO: 'b@x.com',
+      },
+      comment,
+    );
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('never throws when the send fails, and does not record the dedupe key', async () => {
+    const kv = mockKV();
+    const send = vi.fn().mockRejectedValue(new Error('smtp down'));
+    await expect(
+      sendCrisisAlert(
+        {
+          SOCIAL: kv as unknown as KVNamespace,
+          CRISIS_EMAIL: { send },
+          CRISIS_ALERT_FROM: 'a@x.com',
+          CRISIS_ALERT_TO: 'b@x.com',
+        },
+        comment,
+      ),
+    ).resolves.toBeUndefined();
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+
+  it('degrades silently when the binding or vars are missing', async () => {
+    const kv = mockKV();
+    await expect(sendCrisisAlert({ SOCIAL: kv as unknown as KVNamespace }, comment)).resolves.toBeUndefined();
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildCrisisAlertRaw', () => {
+  it('includes headers, ids, and truncates long messages', () => {
+    const raw = buildCrisisAlertRaw('a@x.com', 'b@x.com', {
+      commentId: 'c9',
+      postId: 'p9',
+      message: 'x'.repeat(600),
+    });
+    expect(raw).toContain('Subject: [CRISIS] Flagged comment c9');
+    expect(raw).toContain('Post ID:    p9');
+    expect(raw).toContain('…');
+    expect(raw).not.toContain('x'.repeat(501));
+  });
+});

--- a/worker/src/cron/comments.ts
+++ b/worker/src/cron/comments.ts
@@ -24,7 +24,7 @@ function hashAuthorId(rawId: string): string {
 export async function processComments(
   platform: SocialPlatform,
   kv: KVNamespace,
-  onCrisis?: (comment: { commentId: string; postId: string; message: string }) => Promise<void>,
+  onCrisis?: (comment: { commentId: string; postId: string; message: string }) => Promise<unknown>,
 ): Promise<CommentProcessResult> {
   const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
   const staleThreshold = Date.now() - STALE_HOURS * 60 * 60 * 1000;

--- a/worker/src/cron/comments.ts
+++ b/worker/src/cron/comments.ts
@@ -24,6 +24,7 @@ function hashAuthorId(rawId: string): string {
 export async function processComments(
   platform: SocialPlatform,
   kv: KVNamespace,
+  onCrisis?: (comment: { commentId: string; postId: string; message: string }) => Promise<void>,
 ): Promise<CommentProcessResult> {
   const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
   const staleThreshold = Date.now() - STALE_HOURS * 60 * 60 * 1000;
@@ -105,6 +106,13 @@ export async function processComments(
           flaggedAt: new Date().toISOString(),
         }), { expirationTtl: flagTtl });
         flagged++;
+        if (isCrisis && onCrisis) {
+          // Alerting failure must not fail the cron; sendCrisisAlert also
+          // guards internally, this catch is belt-and-braces for other impls.
+          await onCrisis({ commentId: comment.id, postId: comment.postId, message: comment.message }).catch((e) =>
+            console.error(`Crisis alert callback failed: ${e instanceof Error ? e.message : String(e)}`),
+          );
+        }
       }
     }
   }

--- a/worker/src/email.ts
+++ b/worker/src/email.ts
@@ -1,0 +1,69 @@
+import { EmailMessage } from 'cloudflare:email';
+
+// Cloudflare Email Sending binding ([[send_email]] in wrangler.toml).
+// Optional: absent in any environment without the binding configured, in
+// which case crisis alerts degrade to the /api/health surfacing only.
+export interface EmailSender {
+  send(message: EmailMessage): Promise<void>;
+}
+
+export interface CrisisAlertEnv {
+  SOCIAL: KVNamespace;
+  CRISIS_EMAIL?: EmailSender;
+  CRISIS_ALERT_FROM?: string;
+  CRISIS_ALERT_TO?: string;
+}
+
+export interface CrisisCommentInfo {
+  commentId: string;
+  postId: string;
+  message: string;
+}
+
+const EMAILED_TTL = 90 * 24 * 60 * 60; // matches the flag-crisis: record TTL
+
+export function buildCrisisAlertRaw(from: string, to: string, comment: CrisisCommentInfo): string {
+  const excerpt = comment.message.length > 500 ? `${comment.message.slice(0, 500)}…` : comment.message;
+  return [
+    `From: ${from}`,
+    `To: ${to}`,
+    `Subject: [CRISIS] Flagged comment ${comment.commentId}`,
+    `Date: ${new Date().toUTCString()}`,
+    'MIME-Version: 1.0',
+    'Content-Type: text/plain; charset=utf-8',
+    '',
+    'A comment was classified as crisis by the comment monitor.',
+    '',
+    `Comment ID: ${comment.commentId}`,
+    `Post ID:    ${comment.postId}`,
+    '',
+    'Message:',
+    excerpt,
+    '',
+    'The full record is in KV under flag-crisis: (90-day TTL) and is counted',
+    'on the authenticated /api/health endpoint (recentActivity.crisisFlags).',
+    '',
+  ].join('\r\n');
+}
+
+/**
+ * Email Adrian about a crisis-classified comment. Deduped per comment via KV
+ * (crisis-emailed:<id>) so retried cron runs can't re-alert. Never throws:
+ * an alerting failure must not fail the comments cron — /api/health remains
+ * the fallback channel.
+ */
+export async function sendCrisisAlert(env: CrisisAlertEnv, comment: CrisisCommentInfo): Promise<void> {
+  try {
+    if (!env.CRISIS_EMAIL || !env.CRISIS_ALERT_FROM || !env.CRISIS_ALERT_TO) {
+      console.error('Crisis alert email not configured (CRISIS_EMAIL binding / FROM / TO) — health endpoint only');
+      return;
+    }
+    const dedupeKey = `crisis-emailed:${comment.commentId}`;
+    if (await env.SOCIAL.get(dedupeKey)) return;
+    const raw = buildCrisisAlertRaw(env.CRISIS_ALERT_FROM, env.CRISIS_ALERT_TO, comment);
+    await env.CRISIS_EMAIL.send(new EmailMessage(env.CRISIS_ALERT_FROM, env.CRISIS_ALERT_TO, raw));
+    await env.SOCIAL.put(dedupeKey, new Date().toISOString(), { expirationTtl: EMAILED_TTL });
+  } catch (e) {
+    console.error(`Crisis alert email failed: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}

--- a/worker/src/email.ts
+++ b/worker/src/email.ts
@@ -24,17 +24,20 @@ const EMAILED_TTL = 90 * 24 * 60 * 60; // matches the flag-crisis: record TTL
 
 export function buildCrisisAlertRaw(from: string, to: string, comment: CrisisCommentInfo): string {
   const excerpt = comment.message.length > 500 ? `${comment.message.slice(0, 500)}…` : comment.message;
+  // Platform comment IDs are alphanumeric in practice, but this lands in a
+  // raw MIME header — strip CR/LF so a hostile ID can't inject headers.
+  const safeId = comment.commentId.replace(/[\r\n]/g, '');
   return [
     `From: ${from}`,
     `To: ${to}`,
-    `Subject: [CRISIS] Flagged comment ${comment.commentId}`,
+    `Subject: [CRISIS] Flagged comment ${safeId}`,
     `Date: ${new Date().toUTCString()}`,
     'MIME-Version: 1.0',
     'Content-Type: text/plain; charset=utf-8',
     '',
     'A comment was classified as crisis by the comment monitor.',
     '',
-    `Comment ID: ${comment.commentId}`,
+    `Comment ID: ${safeId}`,
     `Post ID:    ${comment.postId}`,
     '',
     'Message:',
@@ -52,18 +55,57 @@ export function buildCrisisAlertRaw(from: string, to: string, comment: CrisisCom
  * an alerting failure must not fail the comments cron — /api/health remains
  * the fallback channel.
  */
-export async function sendCrisisAlert(env: CrisisAlertEnv, comment: CrisisCommentInfo): Promise<void> {
+export async function sendCrisisAlert(env: CrisisAlertEnv, comment: CrisisCommentInfo): Promise<boolean> {
   try {
     if (!env.CRISIS_EMAIL || !env.CRISIS_ALERT_FROM || !env.CRISIS_ALERT_TO) {
       console.error('Crisis alert email not configured (CRISIS_EMAIL binding / FROM / TO) — health endpoint only');
-      return;
+      return false;
     }
     const dedupeKey = `crisis-emailed:${comment.commentId}`;
-    if (await env.SOCIAL.get(dedupeKey)) return;
+    if (await env.SOCIAL.get(dedupeKey)) return false;
     const raw = buildCrisisAlertRaw(env.CRISIS_ALERT_FROM, env.CRISIS_ALERT_TO, comment);
     await env.CRISIS_EMAIL.send(new EmailMessage(env.CRISIS_ALERT_FROM, env.CRISIS_ALERT_TO, raw));
     await env.SOCIAL.put(dedupeKey, new Date().toISOString(), { expirationTtl: EMAILED_TTL });
+    return true;
   } catch (e) {
     console.error(`Crisis alert email failed: ${e instanceof Error ? e.message : String(e)}`);
+    return false;
   }
+}
+
+// KV list page size for the retry sweep — far above any realistic number of
+// live crisis flags (90-day TTL).
+const CRISIS_SWEEP_LIMIT = 100;
+
+/**
+ * Retry pass: alert for any flag-crisis: record that has no crisis-emailed:
+ * marker. The inline alert in processComments fires first; this sweep exists
+ * because a transient send failure there would otherwise never retry (the
+ * comment is marked seen and skipped on later runs). Runs each comments cron.
+ * Never throws; returns the number of alerts sent.
+ */
+export async function sweepCrisisAlerts(env: CrisisAlertEnv): Promise<number> {
+  let sent = 0;
+  try {
+    if (!env.CRISIS_EMAIL || !env.CRISIS_ALERT_FROM || !env.CRISIS_ALERT_TO) return 0;
+    const list = await env.SOCIAL.list({ prefix: 'flag-crisis:', limit: CRISIS_SWEEP_LIMIT });
+    for (const key of list.keys) {
+      const commentId = key.name.slice('flag-crisis:'.length);
+      if (await env.SOCIAL.get(`crisis-emailed:${commentId}`)) continue;
+      const rawRecord = await env.SOCIAL.get(key.name);
+      if (!rawRecord) continue;
+      let record: { postId?: string; message?: string };
+      try {
+        record = JSON.parse(rawRecord) as { postId?: string; message?: string };
+      } catch {
+        continue;
+      }
+      if (await sendCrisisAlert(env, { commentId, postId: record.postId ?? '', message: record.message ?? '' })) {
+        sent++;
+      }
+    }
+  } catch (e) {
+    console.error(`Crisis alert sweep failed: ${e instanceof Error ? e.message : String(e)}`);
+  }
+  return sent;
 }

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -16,6 +16,15 @@ export interface Env {
   // Rate limiting
   API_RATE_LIMITER?: RateLimiter;
 
+  // Email ([[send_email]] binding; optional — crisis alerts degrade to
+  // /api/health surfacing when absent)
+  CRISIS_EMAIL?: import('./email').EmailSender;
+
+  // Crisis alert addresses (vars). TO must be a verified Email Routing
+  // destination address on the zone.
+  CRISIS_ALERT_FROM?: string;
+  CRISIS_ALERT_TO?: string;
+
   // Vars
   FACEBOOK_PAGE_ID: string;
   GRAPH_API_VERSION: string;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4,6 +4,7 @@ import { verifyBearer } from './auth';
 import { createPlatform, getConfiguredPlatforms } from './platforms/factory';
 import type { SocialPost, IdempotencyRecord, Platform } from './platforms/types';
 import { processComments } from './cron/comments';
+import { sendCrisisAlert } from './email';
 import { CronLock } from './cron-lock';
 
 export { CronLock };
@@ -751,7 +752,7 @@ app.post('/api/cron/comments', async (c) => {
         continue;
       }
 
-      const result = await processComments(adapter, env.SOCIAL);
+      const result = await processComments(adapter, env.SOCIAL, (c) => sendCrisisAlert(env, c));
       platformResults[platformName] = { ...result, tokenExpiresInDays: tokenHealth.daysUntilExpiry };
     }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4,7 +4,7 @@ import { verifyBearer } from './auth';
 import { createPlatform, getConfiguredPlatforms } from './platforms/factory';
 import type { SocialPost, IdempotencyRecord, Platform } from './platforms/types';
 import { processComments } from './cron/comments';
-import { sendCrisisAlert } from './email';
+import { sendCrisisAlert, sweepCrisisAlerts } from './email';
 import { CronLock } from './cron-lock';
 
 export { CronLock };
@@ -756,9 +756,14 @@ app.post('/api/cron/comments', async (c) => {
       platformResults[platformName] = { ...result, tokenExpiresInDays: tokenHealth.daysUntilExpiry };
     }
 
+    // Retry pass for crisis alerts whose email send failed transiently on a
+    // previous run (the comment is marked seen, so the inline alert path
+    // never re-fires for it).
+    const crisisAlertsRetried = await sweepCrisisAlerts(env);
+
     // For backward compatibility, spread Facebook results at the top level
     const fbResult = platformResults.facebook as Record<string, unknown> | undefined;
-    return json({ ...fbResult, platforms: platformResults });
+    return json({ ...fbResult, platforms: platformResults, crisisAlertsRetried });
   } finally {
     await commentsLockStub
       .release('comments', commentsToken)

--- a/worker/test-shims/cloudflare-email.ts
+++ b/worker/test-shims/cloudflare-email.ts
@@ -1,0 +1,15 @@
+/**
+ * Test-only shim for the `cloudflare:email` module (see cloudflare-workers.ts
+ * for the pattern). Production builds use Wrangler, which resolves the real
+ * module; vitest runs in plain Node.
+ */
+export class EmailMessage {
+  from: string;
+  to: string;
+  raw: string;
+  constructor(from: string, to: string, raw: string) {
+    this.from = from;
+    this.to = to;
+    this.raw = raw;
+  }
+}

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
       'cloudflare:workers': fileURLToPath(
         new URL('./test-shims/cloudflare-workers.ts', import.meta.url),
       ),
+      'cloudflare:email': fileURLToPath(
+        new URL('./test-shims/cloudflare-email.ts', import.meta.url),
+      ),
     },
   },
 });

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -15,7 +15,17 @@ class_name = "CronLock"
 tag = "v1"
 new_sqlite_classes = ["CronLock"]
 
+# Crisis-alert email (Cloudflare Email Sending). One-time setup: verify
+# CRISIS_ALERT_TO as an Email Routing destination address on the
+# adrianwedd.com zone, or sends will be rejected. Alerts degrade to
+# /api/health surfacing if the binding/vars are absent.
+[[send_email]]
+name = "CRISIS_EMAIL"
+destination_address = "adrian@adrianwedd.com"
+
 [vars]
+CRISIS_ALERT_FROM = "alerts@adrianwedd.com"
+CRISIS_ALERT_TO = "adrian@adrianwedd.com"
 FACEBOOK_PAGE_ID = "35753603727"
 GRAPH_API_VERSION = "v21.0"
 INSTAGRAM_BUSINESS_ACCOUNT_ID = ""

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -15,10 +15,13 @@ class_name = "CronLock"
 tag = "v1"
 new_sqlite_classes = ["CronLock"]
 
-# Crisis-alert email (Cloudflare Email Sending). One-time setup: verify
-# CRISIS_ALERT_TO as an Email Routing destination address on the
-# adrianwedd.com zone, or sends will be rejected. Alerts degrade to
-# /api/health surfacing if the binding/vars are absent.
+# Crisis-alert email (Cloudflare Email Sending). One-time setup before first
+# deploy: (1) onboard adrianwedd.com to Email Service so CRISIS_ALERT_FROM is
+# a verified sender, and (2) verify CRISIS_ALERT_TO as an Email Routing
+# destination address — otherwise sends are rejected (E_SENDER_NOT_VERIFIED).
+# destination_address below restricts the binding to that one recipient; if
+# CRISIS_ALERT_TO ever changes, change destination_address with it. Alerts
+# degrade to /api/health surfacing if the binding/vars are absent.
 [[send_email]]
 name = "CRISIS_EMAIL"
 destination_address = "adrian@adrianwedd.com"


### PR DESCRIPTION
Implements Tasks 3–4 of docs/superpowers/plans/2026-07-19-qa-followup-implementation.md (spec #541).

- **worker-csp**: mixed-case/spaced tag archive URLs (e.g. `/blog/tag/AI%20safety/2/?x=1`) 301 to canonical (`/blog/tag/ai-safety/2/?x=1`) before any origin fetch — companion to #543, guarantees no historic tag URL 404s. 33/33 tests.
- **worker**: crisis-classified comments send an email alert via Cloudflare Email Sending (`[[send_email]]` binding, per Adrian's call — not Resend). KV-deduped per comment (90-day TTL, matching the flag), never fails the cron, degrades to /api/health surfacing when unconfigured. 212/212 tests, tsc clean, wrangler dry-run clean.

One-time dashboard prerequisite (documented in wrangler.toml): verify adrian@adrianwedd.com as an Email Routing destination on the zone.

https://claude.ai/code/session_016tTfK4ZG4xwqGdQLs2G713