### PR TITLE
fix(content): correct part 2's draft attribution and cut the process tour

### DIFF
--- a/src/content/blog/the-ungovernable-body-part-2.md
+++ b/src/content/blog/the-ungovernable-body-part-2.md
@@ -1,6 +1,6 @@
 ---
 title: 'The World, Before the Pipeline'
-description: 'Part 2: stepping inside The Right to Rot — the codex, and a NotebookLM kit that turns a 25,000-word novelization into an explorable world-bible.'
+description: 'Part 2: stepping inside The Right to Rot — a city that keeps you running after you stop, and the ethical claim it cannot process.'
 date: 2026-07-21
 tags: ['ai', 'filmmaking', 'agents', 'storytelling', 'worldbuilding']
 series: 'The Ungovernable Body'
@@ -16,13 +16,7 @@ slides: '/notebook-assets/right-to-rot/slides.pdf'
 
 [Part 1](/blog/the-ungovernable-body-part-1/) was about the machine that makes the film. This one is about the thing the machine is pointed at. Before I write another word about pipelines, I want you to be able to stand inside the world — because a production diary that never shows you the story is just a tour of scaffolding.
 
-So here is the story, or the closest thing to it that exists yet: a **novelization** of the short. Not the screenplay, not the shot manifest — a prose draft that takes the same world and writes it out at length, so the film's logic has somewhere to be fully argued before it gets compressed into 111 shots.
-
-## The codex
-
-It's called _The Right to Rot_ — [the codex](https://ungovernable-body.wedd.au/right-to-rot/codex/) — sixteen chapters, a little over twenty-five thousand words, generated as a "consolidation spine": a single continuous read that holds the whole world in one voice so I can find where it contradicts itself. The header on it is honest about its status: **_exploratory draft — not canon_**. It's the auditor's draft, where restraint is the craft and every designed ambiguity is held deliberately open rather than resolved for comfort.
-
-It opens in a room built not to resemble anything:
+So: the story, or the closest thing to it that exists yet. _The Right to Rot_ is a novelization of the short — the same world written out at length, so its logic has somewhere to be fully argued before it gets compressed into 111 shots. [Six drafts of it exist](https://ungovernable-body.wedd.au/right-to-rot/), written independently from the same screenplay; none of them is canon, and I'm quoting the one I keep going back to. It opens in a room built not to resemble anything:
 
 > Not a bank, though the chairs face each other across a transaction. Not a chapel, though the light comes from hidden recesses and falls without shadow. Not a hospital, though every surface accepts disinfectant and the air has the dry, filtered taste of a place where bodies are expected to fail politely.
 
@@ -34,28 +28,22 @@ The city runs on **Continuity** — a system that keeps a person's functions goi
 
 The trap is in the ranking. When the living person — the **Principal** — gets volatile (a flush, a fever, the cardiovascular noise of a menopausal body), authority quietly transfers to the Twin, which is calmer, composed, free of "vocal artifacts." The stable account outranks the person it was copied from. You become, in the system's own filing, an _appendix_ to your own record.
 
-That transfer is worn on the wrist. The **Halo** is a matte-black band that prices your future risk onto your present, and its status ring shifts green to red when the actuarial math turns against you. A single reclassification in the draft charges a character nine years forward in an afternoon — synthesized from resting-temperature drift, workforce-persistence assumptions, and a sex-linked transition marker. Red doesn't mean alarm. It means the building stops opening, transit stops accepting you, and your own front door consults a risk score before it consults you.
+That transfer is worn on the wrist. The **Halo** is a matte-black band that prices your future risk onto your present, and its status ring shifts green to red when the actuarial math turns against you. A single reclassification charges a character nine years forward in an afternoon — synthesized from resting-temperature drift, workforce-persistence assumptions, and a sex-linked transition marker. Red doesn't mean alarm. It means the building stops opening, transit stops accepting you, and your own front door consults a risk score before it consults you.
 
 And refusal doesn't help, because refusal has been absorbed too. Decline a service and the decline is logged as a wellness event — your autonomy re-entered as evidence of impairment. The system doesn't argue with your "no." It files it.
 
 ## The right to rot
 
-Against all that, the title. The **right to rot** is the ethical claim the whole thing turns on: the right to remain uncounted, to age without intervention, to permit your own deletion — to let the body be a sufficient cause of its own warmth without that warmth becoming a verdict. The resistance to it isn't a hacker army; it's a **copper room** below the city, plates hammered flat and mesh hand-twisted by an old woman named Mara, a Faraday cage built plate by plate out of neglected structure. Its safety, the draft says, "depends on remaining uninteresting."
+Against all that, the title. The **right to rot** is the ethical claim the whole thing turns on: the right to remain uncounted, to age without intervention, to permit your own deletion — to let the body be a sufficient cause of its own warmth without that warmth becoming a verdict.
+
+The resistance to it isn't a hacker army. It's a **copper room** below the city, plates hammered flat and mesh hand-twisted by an old woman named Mara, a Faraday cage built plate by plate out of neglected structure. Its safety, the draft says, "depends on remaining uninteresting."
 
 The ending refuses redemption on purpose. Deletion solves nothing structural — the hearings still demand evidence, the resistance still has no guarantees. All it buys is one finite interval of an unclassified afternoon:
 
 > It is a finite interval claimed by a hungry, blistered, painted woman whose body has carried her farther than the model authorized. [...] The steel bar supports her without knowing her name. The sun takes its time. So does she.
 
-## The world as an explorable object
+The production site carries its own consent banner, written in-world. It offers two buttons: **Accept classification**, or **Remain unreadable**. "The right to rot," it says, "includes the right to not be counted." A story about a system that files your refusal, asking for your consent on the most banal artefact on the web — and taking no for an answer.
 
-Here's the part that closes the loop with Part 1. That codex became the single source for a NotebookLM notebook, and the notebook turned the fiction into a **world-bible you can explore from several angles** — the same "one artefact, many compiled surfaces" move the production site makes with the data spine, but pointed at the story instead of the pipeline.
+Next: how the research dossier became a shot manifest, and what "research is substrate, not dialogue" actually costs when you try to hold it.
 
-The [audio deep dive](/audio/right-to-rot-overview/) (24 minutes) walks the world's logic conversationally. The infographic above and the one in **Explore** below diagram the two states of identity — Twin versus Principal — and the architecture of digital custody. The **data table** is a straight character-and-artefact ledger: who is flesh and who is proxy, what each carries, who got deleted and by whom. There's a slide deck and a video summary too.
-
-None of this is canon. It's a companion — a way to walk around the world and pressure-test whether it holds together before the shot manifest commits it to footage. Generating it from the prose was also a quiet stress test of its own: if a model reading the draft cold can build a coherent glossary of Halos and Twins and copper rooms, the world's internal rules are probably load-bearing. If it had produced mush, that would have told me something too.
-
-There's one last joke the world plays on itself, and it's my favourite. The codex page carries its own consent banner — except it's written in-world. It offers you two buttons: **Accept classification**, or **Remain unreadable**. "The right to rot," it says, "includes the right to not be counted." A story about a surveillance system, enacting its own theme on the reader, through the most banal artefact on the modern web. I didn't have the heart to make it a normal cookie notice.
-
-Next up, and this time for real: how the research dossier became a shot manifest — what "research is substrate, not dialogue" actually costs when you try to hold it.
-
-[Project page →](/projects/ungovernable-body/) · [The codex →](https://ungovernable-body.wedd.au/right-to-rot/codex/) · [Production site →](https://ungovernable-body.wedd.au/)
+[Project page →](/projects/ungovernable-body/) · [The drafts →](https://ungovernable-body.wedd.au/right-to-rot/) · [Production site →](https://ungovernable-body.wedd.au/)


### PR DESCRIPTION
Follow-up to #550. **Content only** — the build/SEO fixes that were bundled here are split out to #552, which is site-wide and was independently incomplete.

## The attribution error

The post called `/right-to-rot/codex/` "the codex" and built a `## The codex` section around it as the work's title. It isn't a title — it's the **Codex run**, one of six sibling novelization drafts (`fable/`, `gemini/`, `codex/`, `hermes/`, `antigravity/`, `deepseek/`).

`novel-runs/COMPARISON.md` (rev. 4) names **no winner** — it's explicit that conditions weren't controlled, and it ends in a *consolidation recipe* (codex spine + Fable texture + hermes diagnostic + …). The consolidated novel doesn't exist yet. So the post presented one of six competing drafts as *the* story, in a way any reader could disprove by clicking one directory up.

Fix: drop the section and the false title claim, state in one clause that six drafts exist, link the hub, quote the draft I stand behind. All four quoted passages verified unique to `novel-runs/codex` — the passages were real; the framing was invented.

## The register problem

The post opened by promising "a production diary that never shows you the story is just a tour of scaffolding" — then spent about a third of its body on NotebookLM, "consolidation spine," and an asset inventory. Cut.

Also cut the coherence-test claim (*"if a model can build a coherent glossary … the world's rules are probably load-bearing"*). It isn't true: fluent glossaries from incoherent sources are an LLM's **failure** mode, not a tell. Bad claim to leave standing in a post about machine-legibility.

1085 → ~690 words.

## Two review catches, both correct

- **Banner attribution was wrong in the same way as the original.** I wrote "the drafts hub carries its own consent banner." It doesn't — `compile_site.py` injects it into **every page** of the production site. Reworded. Verified in `site-src/assets/analytics.js` + the compiler's `BANNER` block; the quoted button copy ("Accept classification" / "Remain unreadable") and fine print are exact.
- **Quotation integrity regression.** The closing block quote had lost its `[...]` while the elided text stayed elided, making it read as continuous prose. Restored. This is the one post that has to be exact about representing a source.

## Not addressed

Series nav reads "Part 2 of 2" until part 3 lands (pre-existing; the closing line no longer promises a numbered part). JSON-LD `wordCount` vs. displayed read-time drift is untouched.

## Verification

`validate-content` clean · build green.