### PR TITLE
fix(seo): drop the site-name suffix from detail-page titles

### DIFF
--- a/src/components/SEOHead.astro
+++ b/src/components/SEOHead.astro
@@ -47,8 +47,7 @@ const {
 const pathname = Astro.url.pathname.endsWith('/') ? Astro.url.pathname : `${Astro.url.pathname}/`;
 const canonicalUrl = new URL(pathname, Astro.site);
 const ogImageUrl = new URL(image, Astro.site);
-const fullTitle =
-  title === 'Adrian Wedd' || !siteNameInTitle ? title : `${title} — Adrian Wedd`;
+const fullTitle = title === 'Adrian Wedd' || !siteNameInTitle ? title : `${title} — Adrian Wedd`;
 ---
 
 <meta charset="utf-8" />

--- a/src/components/SEOHead.astro
+++ b/src/components/SEOHead.astro
@@ -10,6 +10,16 @@ interface Props {
   publishedDate?: string;
   tags?: string[];
   noindex?: boolean;
+  /**
+   * Append ' — Adrian Wedd' to the <title>. Default true.
+   *
+   * Set false on content detail pages: the suffix costs 15 chars of the ~60
+   * Google renders before truncating, and it's redundant on a personal domain
+   * where og:site_name and the Person schema already carry the attribution.
+   * Index pages keep it — 'Blog' or 'Gallery' alone is ambiguous in a tab
+   * strip or a SERP.
+   */
+  siteNameInTitle?: boolean;
 }
 
 const {
@@ -23,12 +33,14 @@ const {
   publishedDate,
   tags,
   noindex,
+  siteNameInTitle = true,
 } = Astro.props;
 
 const pathname = Astro.url.pathname.endsWith('/') ? Astro.url.pathname : `${Astro.url.pathname}/`;
 const canonicalUrl = new URL(pathname, Astro.site);
 const ogImageUrl = new URL(image, Astro.site);
-const fullTitle = title === 'Adrian Wedd' ? title : `${title} — Adrian Wedd`;
+const fullTitle =
+  title === 'Adrian Wedd' || !siteNameInTitle ? title : `${title} — Adrian Wedd`;
 ---
 
 <meta charset="utf-8" />

--- a/src/components/SEOHead.astro
+++ b/src/components/SEOHead.astro
@@ -11,13 +11,21 @@ interface Props {
   tags?: string[];
   noindex?: boolean;
   /**
-   * Append ' — Adrian Wedd' to the <title>. Default true.
+   * Append ' — Adrian Wedd' to the page title. Default true.
    *
-   * Set false on content detail pages: the suffix costs 15 chars of the ~60
-   * Google renders before truncating, and it's redundant on a personal domain
-   * where og:site_name and the Person schema already carry the attribution.
-   * Index pages keep it — 'Blog' or 'Gallery' alone is ambiguous in a tab
-   * strip or a SERP.
+   * Applies to <title>, og:title and twitter:title together — they all derive
+   * from fullTitle. Dropping it from the social tags is intended: og:site_name
+   * already carries the attribution there, so the suffix is pure duplication
+   * on a card.
+   *
+   * Set false on content detail pages. The suffix is 14 characters spent on a
+   * word every visitor can already see in the domain; Google truncates title
+   * links by pixel width (no fixed character limit), so shorter titles survive
+   * intact on more screens. Attribution is not lost — og:site_name, the Person
+   * schema and the JSON-LD author/publisher nodes all remain.
+   *
+   * Index pages keep it: 'Blog' or 'Gallery' standing alone is ambiguous in a
+   * tab strip or a SERP.
    */
   siteNameInTitle?: boolean;
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -20,6 +20,8 @@ interface Props {
   publishedDate?: string;
   tags?: string[];
   noindex?: boolean;
+  /** See SEOHead — omit the ' — Adrian Wedd' title suffix on detail pages. */
+  siteNameInTitle?: boolean;
   preloadImage?: string;
   heroAnimation?: string;
 }

--- a/src/pages/audio/[...slug].astro
+++ b/src/pages/audio/[...slug].astro
@@ -47,6 +47,7 @@ const nextEpisode = currentIndex > 0 ? allEpisodes[currentIndex - 1] : null;
   description={episode.data.description}
   image={ogImage}
   type="article"
+  siteNameInTitle={false}
   publishedDate={episode.data.date.toISOString()}
   tags={episode.data.tags}
 >

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -121,6 +121,7 @@ const matchedProject = allProjects.find((p) => !p.data.draft && slug(p.id) === c
   imageHeight={ogImageHeight}
   imageAlt={(ogImage === ogTextCard ? `${post.data.title} — adrianwedd.com` : heroAlt) || undefined}
   type="article"
+  siteNameInTitle={false}
   publishedDate={post.data.date.toISOString()}
   tags={post.data.tags}
   preloadImage={typeof post.data.heroImage === 'string' ? post.data.heroImage : undefined}

--- a/src/pages/case-studies/[...slug].astro
+++ b/src/pages/case-studies/[...slug].astro
@@ -25,6 +25,7 @@ const ogImage = `/og/case-studies/${caseStudySlug}.png`;
   description={caseStudy.data.description}
   image={ogImage}
   type="article"
+  siteNameInTitle={false}
   publishedDate={caseStudy.data.date.toISOString()}
   tags={caseStudy.data.tags}
 >

--- a/src/pages/fixes/[...slug].astro
+++ b/src/pages/fixes/[...slug].astro
@@ -25,6 +25,7 @@ const ogImage = `/og/fixes/${fixSlug}.png`;
   description={fix.data.description}
   image={ogImage}
   type="article"
+  siteNameInTitle={false}
   publishedDate={fix.data.date.toISOString()}
   tags={fix.data.tags}
 >

--- a/src/pages/gallery/[...slug].astro
+++ b/src/pages/gallery/[...slug].astro
@@ -41,6 +41,7 @@ const nextGallery = currentIndex > 0 ? allGalleries[currentIndex - 1] : null;
   imageWidth={ogDimensions?.width}
   imageHeight={ogDimensions?.height}
   type="article"
+  siteNameInTitle={false}
   tags={gallery.data.tags}
 >
   <script

--- a/src/pages/gallery/[collection]/[image].astro
+++ b/src/pages/gallery/[collection]/[image].astro
@@ -76,6 +76,7 @@ const ogDimensions = getImageDimensions(ogImage);
   imageHeight={ogDimensions?.height}
   imageAlt={image.alt}
   type="article"
+  siteNameInTitle={false}
   tags={gallery.data.tags}
 >
   <script

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -119,6 +119,7 @@ const allBlogPosts = project.data.series
   imageHeight={ogImageHeight}
   imageAlt={(ogImage === ogTextCard ? `${project.data.title} — adrianwedd.com` : heroAlt) || undefined}
   type="website"
+  siteNameInTitle={false}
   tags={project.data.tags}
   preloadImage={typeof project.data.heroImage === 'string' ? project.data.heroImage : undefined}
 >


### PR DESCRIPTION
Detail pages rendered `{title} — Adrian Wedd`. The suffix is 14 characters spent on a word every visitor can already see in the domain, and Google truncates title links by pixel width — shorter titles survive intact on more screens.

Index and pagination pages keep it; "Blog" or "Gallery" alone is ambiguous in a tab strip or a SERP.

Gated on an explicit `siteNameInTitle` prop rather than the existing `type` prop: projects detail pages pass `type="website"`, so keying off `type` would both miss them and risk a later change silently altering `og:type` and the WebPage JSON-LD branch.

**Content titles are untouched** — this addresses the "73 over-length titles" item in #555 without any content edits. That number counted the rendered `<title>` including the suffix; only 8 frontmatter titles exceed 60 chars on their own, and those stay as written.

## Verification
Measured on the built artifact, not the source: all 7 detail templates emit unsuffixed titles; index, tag and pagination pages retain the suffix; homepage still `Adrian Wedd`. JSON-LD `headline`/`name` were already using the raw title, so structured data is unchanged. Unit tests (90), `astro check` and lint all pass.

## QA
codex / agy / hermes all reviewed against the built output. No correctness, schema, accessibility or missed-call-site findings from any of the three. Codex caught two inaccuracies in my doc comment (14 chars not 15; Google has no fixed character limit) — both fixed in the follow-up commit.

Refs #555.