### PR TITLE
fix(feed): harden enclosure sizing (QA round 2)

### DIFF
--- a/src/lib/enclosure-size.ts
+++ b/src/lib/enclosure-size.ts
@@ -1,6 +1,22 @@
 import { statSync } from 'node:fs';
 import { join } from 'node:path';
 
+/** Per-attempt ceiling. A stalled socket must not hold the build open. */
+const HEAD_TIMEOUT_MS = 10_000;
+const MAX_ATTEMPTS = 3;
+
+/** Thrown for a definitive answer that won't improve on retry (4xx, bad header). */
+class PermanentEnclosureError extends Error {}
+
+/**
+ * In-process memo, keyed by URL.
+ *
+ * /audio/feed.xml and /audio/podcast.xml are the same show, so a build resolves
+ * the same ~93 URLs twice. Caching the *promise* (not the value) also collapses
+ * the two feeds' concurrent requests for a URL into one in-flight HEAD.
+ */
+const cache = new Map<string, Promise<number>>();
+
 /**
  * Byte size for an RSS enclosure, from the CDN (HEAD) or the local file.
  *
@@ -12,35 +28,85 @@ import { join } from 'node:path';
  * single transient CDN blip during a build issuing 200+ HEADs would ship a
  * broken enclosure with nothing in the logs. It now retries, then throws — a
  * feed that can't state its own sizes should fail the build, not deploy quietly.
+ *
+ * The tradeoff that buys: a deploy now depends on CDN availability at build
+ * time. That is the intended direction (a wrong feed outlives a failed build),
+ * but it is a real dependency — if it ever bites, the fix is a committed cache
+ * of last-known-good sizes to fall back on, not a return to silent zeros.
  */
-export async function getFileSize(url: string): Promise<number> {
-  if (!url.startsWith('http')) {
-    const filePath = join(process.cwd(), 'public', url);
-    try {
-      return statSync(filePath).size;
-    } catch (err) {
-      throw new Error(`Enclosure missing on disk: ${url} (looked in ${filePath})`, { cause: err });
-    }
-  }
+export function getFileSize(url: string): Promise<number> {
+  const hit = cache.get(url);
+  if (hit) return hit;
+  const pending = resolveSize(url);
+  cache.set(url, pending);
+  // Don't memoise failures: a transient outage shouldn't poison the rest of
+  // the build, and an unhandled rejection here would crash the process.
+  pending.catch(() => cache.delete(url));
+  return pending;
+}
+
+/** Test seam — the memo is process-lifetime otherwise. */
+export function clearEnclosureSizeCache(): void {
+  cache.clear();
+}
+
+async function resolveSize(url: string): Promise<number> {
+  if (!url.startsWith('http')) return localSize(url);
 
   let lastError: unknown;
-  for (let attempt = 1; attempt <= 3; attempt++) {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     try {
-      const res = await fetch(url, { method: 'HEAD' });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const len = res.headers.get('content-length');
-      // A 200 with no content-length is still unusable: don't paper over it
-      // with a 0, which is indistinguishable from a real measurement.
-      if (!len) throw new Error('200 response carried no content-length header');
-      const size = Number.parseInt(len, 10);
-      if (!Number.isFinite(size) || size <= 0) throw new Error(`implausible content-length: ${len}`);
-      return size;
+      return await headSize(url);
     } catch (err) {
       lastError = err;
-      if (attempt < 3) await new Promise((r) => setTimeout(r, 250 * attempt));
+      // A 404 or a malformed header is the server's final answer. Retrying it
+      // just spends ~750ms per broken enclosure to be told the same thing.
+      if (err instanceof PermanentEnclosureError) break;
+      if (attempt < MAX_ATTEMPTS) await new Promise((r) => setTimeout(r, 250 * attempt));
     }
   }
-  throw new Error(`Could not determine enclosure size for ${url} after 3 attempts: ${String(lastError)}`, {
+  throw new Error(`Could not determine enclosure size for ${url}: ${String(lastError)}`, {
     cause: lastError,
   });
+}
+
+async function headSize(url: string): Promise<number> {
+  const res = await fetch(url, { method: 'HEAD', signal: AbortSignal.timeout(HEAD_TIMEOUT_MS) });
+  // 5xx may be transient; 4xx will not be.
+  if (!res.ok) {
+    const msg = `HTTP ${res.status}`;
+    throw res.status >= 500 ? new Error(msg) : new PermanentEnclosureError(msg);
+  }
+  const len = res.headers.get('content-length');
+  // A 200 with no content-length is still unusable: don't paper over it with a
+  // 0, which is indistinguishable from a real measurement.
+  if (!len) throw new PermanentEnclosureError('200 response carried no content-length header');
+  return parseLength(len);
+}
+
+/**
+ * Strict on purpose. `Number.parseInt` would read '42bytes' as 42, '1.5' as 1
+ * and '12e3' as 12 — each a plausible-looking wrong answer written into a feed.
+ */
+function parseLength(raw: string): number {
+  const len = raw.trim();
+  if (!/^\d+$/.test(len)) throw new PermanentEnclosureError(`malformed content-length: ${raw}`);
+  const size = Number(len);
+  if (!Number.isSafeInteger(size) || size <= 0) {
+    throw new PermanentEnclosureError(`implausible content-length: ${raw}`);
+  }
+  return size;
+}
+
+function localSize(url: string): number {
+  const filePath = join(process.cwd(), 'public', url);
+  let size: number;
+  try {
+    size = statSync(filePath).size;
+  } catch (err) {
+    throw new Error(`Enclosure missing on disk: ${url} (looked in ${filePath})`, { cause: err });
+  }
+  // A real but empty file would otherwise sail through as a legitimate 0.
+  if (size <= 0) throw new Error(`Enclosure is empty on disk: ${url} (${filePath})`);
+  return size;
 }

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -132,8 +132,13 @@ const matchedProject = allProjects.find((p) => !p.data.draft && slug(p.id) === c
     set:html={JSON.stringify({
       '@context': 'https://schema.org',
       '@type': 'Article',
+      // Identified so other nodes on this page (the FAQPage below) can point at
+      // the article itself. Without an @id the only addressable node is the
+      // WebPage named by mainEntityOfPage, which is a different entity.
+      '@id': `${new URL(Astro.url.pathname, Astro.site).href}#article`,
       headline: post.data.title,
       description: post.data.description,
+      inLanguage: 'en-AU',
       url: new URL(Astro.url.pathname, Astro.site).href,
       image: new URL(ogImage, Astro.site).href,
       datePublished: post.data.date.toISOString(),
@@ -191,19 +196,20 @@ const matchedProject = allProjects.find((p) => !p.data.draft && slug(p.id) === c
         set:html={JSON.stringify({
           '@context': 'https://schema.org',
           '@type': 'FAQPage',
-          // Kept deliberately after Google retired FAQ rich results (7 May 2026,
-          // docs removed 15 June 2026): it earns nothing in Google SERPs now but
-          // is still valid schema.org, still read by Bing, and is the cleanest
-          // machine-readable Q&A signal for answer engines and LLM crawlers.
+          // Kept deliberately after Google retired FAQ rich results in May 2026:
+          // it earns nothing in Google SERPs now, but is still valid schema.org,
+          // still read by Bing, and is the cleanest machine-readable Q&A signal
+          // for answer engines and LLM crawlers.
           //
-          // Identified and bound to the article rather than floating free — an
-          // unlinked FAQPage node on a URL that also declares an Article reads
-          // as two competing claims about the same page. The #faq fragment lets
-          // a consumer merge them instead of guessing.
+          // Identified and bound to the Article rather than floating free — an
+          // unlinked FAQPage on a URL that also declares an Article reads as two
+          // competing claims about the same page. isPartOf targets the Article's
+          // #article @id specifically; pointing it at the bare page URL would
+          // resolve to the WebPage from mainEntityOfPage, a different entity.
           '@id': `${new URL(Astro.url.pathname, Astro.site).href}#faq`,
           url: new URL(Astro.url.pathname, Astro.site).href,
           inLanguage: 'en-AU',
-          isPartOf: { '@id': new URL(Astro.url.pathname, Astro.site).href },
+          isPartOf: { '@id': `${new URL(Astro.url.pathname, Astro.site).href}#article` },
           mainEntity: post.data.faq.map((item, i) => ({
             '@type': 'Question',
             '@id': `${new URL(Astro.url.pathname, Astro.site).href}#faq-${i + 1}`,

--- a/src/pages/gallery/rss.xml.ts
+++ b/src/pages/gallery/rss.xml.ts
@@ -1,34 +1,8 @@
 import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 import { slug } from '../../lib/utils';
-import { statSync } from 'node:fs';
-import { join } from 'node:path';
+import { getFileSize } from '../../lib/enclosure-size';
 import type { APIContext } from 'astro';
-
-/**
- * Byte size for a cover-image enclosure. Throws rather than returning 0: a
- * zero-length enclosure is a silently wrong feed, and failing the build is the
- * only way that gets noticed. See the fuller note in lib/podcast-feed.ts.
- *
- * Gallery covers are all local today. A remote one would need the async HEAD
- * path from podcast-feed.ts, so it throws here instead of quietly emitting 0.
- */
-function getFileSize(path: string): number {
-  if (path.startsWith('http')) {
-    throw new Error(
-      `Remote gallery coverImage not supported: ${path}. Enclosure length needs a ` +
-        `HEAD request — reuse getFileSize() from lib/podcast-feed.ts if covers move to the CDN.`,
-    );
-  }
-  const filePath = join(process.cwd(), 'public', path);
-  try {
-    return statSync(filePath).size;
-  } catch (err) {
-    throw new Error(`Gallery coverImage missing on disk: ${path} (looked in ${filePath})`, {
-      cause: err,
-    });
-  }
-}
 
 function getMimeType(path: string): string {
   const ext = path.split('.').pop()?.toLowerCase();
@@ -49,21 +23,28 @@ export async function GET(context: APIContext) {
     title: 'Adrian Wedd — Gallery',
     description: 'Visual thinking—process documentation, experiments, and patterns.',
     site: context.site!.toString(),
-    items: collections.map((collection) => ({
-      title: collection.data.title,
-      pubDate: collection.data.date,
-      description: collection.data.description || `Gallery: ${collection.data.title}`,
-      link: `/gallery/${slug(collection.id)}/`,
-      categories: collection.data.tags,
-      ...(collection.data.coverImage
-        ? {
-            enclosure: {
-              url: `${site}${collection.data.coverImage}`,
-              type: getMimeType(collection.data.coverImage),
-              length: getFileSize(collection.data.coverImage),
-            },
-          }
-        : {}),
-    })),
+    // Sizes resolve before rss() because enclosure/@length must be a number,
+    // and getFileSize is async for the CDN case. Shared with the podcast feeds
+    // so a cover image that ever moves to the CDN just works.
+    items: await Promise.all(
+      collections.map(async (collection) => ({
+        title: collection.data.title,
+        pubDate: collection.data.date,
+        description: collection.data.description || `Gallery: ${collection.data.title}`,
+        link: `/gallery/${slug(collection.id)}/`,
+        categories: collection.data.tags,
+        ...(collection.data.coverImage
+          ? {
+              enclosure: {
+                url: collection.data.coverImage.startsWith('http')
+                  ? collection.data.coverImage
+                  : `${site}${collection.data.coverImage}`,
+                type: getMimeType(collection.data.coverImage),
+                length: await getFileSize(collection.data.coverImage),
+              },
+            }
+          : {}),
+      })),
+    ),
   });
 }

--- a/test/unit/enclosure-size.spec.ts
+++ b/test/unit/enclosure-size.spec.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { getFileSize } from '../../src/lib/enclosure-size';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getFileSize, clearEnclosureSizeCache } from '../../src/lib/enclosure-size';
 
 /**
  * These all guard one property: an enclosure size that cannot be determined
@@ -12,28 +12,43 @@ import { getFileSize } from '../../src/lib/enclosure-size';
  * outcome; a deployed feed lying about its sizes is the expensive one.
  */
 
-const head = (headers: Record<string, string>, ok = true, status = 200) =>
-  vi.fn().mockResolvedValue({ ok, status, headers: new Headers(headers) });
+const ok = (headers: Record<string, string>) => ({
+  ok: true,
+  status: 200,
+  headers: new Headers(headers),
+});
+const status = (code: number) => ({ ok: false, status: code, headers: new Headers() });
 
+// Unique per test so the module-level memo never bleeds between cases.
+let n = 0;
+const url = () => `https://cdn.example.com/a${++n}.m4a`;
+
+beforeEach(() => clearEnclosureSizeCache());
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
 describe('getFileSize — remote enclosures', () => {
-  it('returns the content-length from a HEAD request', async () => {
-    vi.stubGlobal('fetch', head({ 'content-length': '56097519' }));
-    await expect(getFileSize('https://cdn.example.com/a.m4a')).resolves.toBe(56097519);
+  it('issues a HEAD (not a GET) and returns the content-length', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok({ 'content-length': '56097519' }));
+    vi.stubGlobal('fetch', fetchMock);
+    const u = url();
+
+    await expect(getFileSize(u)).resolves.toBe(56097519);
+    // Pin the method: a silent switch to GET would download gigabytes of audio
+    // at build time and still pass a value-only assertion.
+    expect(fetchMock).toHaveBeenCalledWith(u, expect.objectContaining({ method: 'HEAD' }));
   });
 
-  it('retries a transient failure rather than shipping a zero', async () => {
+  it('retries a transient network failure rather than shipping a zero', async () => {
     const fetchMock = vi
       .fn()
       .mockRejectedValueOnce(new Error('ECONNRESET'))
-      .mockResolvedValueOnce({ ok: true, status: 200, headers: new Headers({ 'content-length': '42' }) });
+      .mockResolvedValueOnce(ok({ 'content-length': '42' }));
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(getFileSize('https://cdn.example.com/a.m4a')).resolves.toBe(42);
+    await expect(getFileSize(url())).resolves.toBe(42);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
@@ -41,25 +56,70 @@ describe('getFileSize — remote enclosures', () => {
     const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNRESET'));
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(getFileSize('https://cdn.example.com/a.m4a')).rejects.toThrow(/after 3 attempts/);
+    await expect(getFileSize(url())).rejects.toThrow(/ECONNRESET/);
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
-  it('throws on a non-2xx response instead of returning 0', async () => {
-    vi.stubGlobal('fetch', head({}, false, 404));
-    await expect(getFileSize('https://cdn.example.com/gone.m4a')).rejects.toThrow(/404/);
+  it('retries a 5xx, which may be transient', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(status(503));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(getFileSize(url())).rejects.toThrow(/503/);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('does NOT retry a 404 — a permanent answer costs nothing to re-ask', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(status(404));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(getFileSize(url())).rejects.toThrow(/404/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('throws when a 200 carries no content-length', async () => {
     // The dangerous case: the request "succeeded", so a naive implementation
     // reads a missing header as 0 and emits it as though it were measured.
-    vi.stubGlobal('fetch', head({}));
-    await expect(getFileSize('https://cdn.example.com/a.m4a')).rejects.toThrow(/no content-length/);
+    const fetchMock = vi.fn().mockResolvedValue(ok({}));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(getFileSize(url())).rejects.toThrow(/no content-length/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it.each(['0', '-1', 'not-a-number'])('throws on implausible content-length %s', async (len) => {
-    vi.stubGlobal('fetch', head({ 'content-length': len }));
-    await expect(getFileSize('https://cdn.example.com/a.m4a')).rejects.toThrow(/implausible|no content-length/);
+  it.each(['0', '-1'])('rejects implausible content-length %s', async (len) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(ok({ 'content-length': len })));
+    await expect(getFileSize(url())).rejects.toThrow(/implausible|malformed/);
+  });
+
+  it.each(['not-a-number', '42bytes', '1.5', '12e3'])('rejects malformed content-length %s', async (len) => {
+    // parseInt would read '42bytes' as 42 and '1.5' as 1 — a plausible-looking
+    // wrong number is worse than an error, because it ships.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(ok({ 'content-length': len })));
+    await expect(getFileSize(url())).rejects.toThrow(/malformed/);
+  });
+
+  it('memoises by URL so the two feeds share one request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok({ 'content-length': '99' }));
+    vi.stubGlobal('fetch', fetchMock);
+    const u = url();
+
+    const [a, b] = await Promise.all([getFileSize(u), getFileSize(u)]);
+    expect([a, b]).toEqual([99, 99]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not memoise a failure, so one blip cannot poison later lookups', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValue(ok({ 'content-length': '7' }));
+    vi.stubGlobal('fetch', fetchMock);
+    const u = url();
+
+    await expect(getFileSize(u)).rejects.toThrow();
+    await expect(getFileSize(u)).resolves.toBe(7);
   });
 });
 
@@ -70,5 +130,18 @@ describe('getFileSize — local enclosures', () => {
 
   it('throws for a missing file, naming the path it looked in', async () => {
     await expect(getFileSize('/no/such/file.m4a')).rejects.toThrow(/missing on disk.*looked in/s);
+  });
+
+  it('throws for a real but empty file rather than reporting 0 bytes', async () => {
+    const { mkdtempSync, writeFileSync, mkdirSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const dir = mkdtempSync(join(tmpdir(), 'enc-'));
+    mkdirSync(join(dir, 'public'), { recursive: true });
+    writeFileSync(join(dir, 'public', 'empty.m4a'), '');
+    const cwd = vi.spyOn(process, 'cwd').mockReturnValue(dir);
+
+    await expect(getFileSize('/empty.m4a')).rejects.toThrow(/empty on disk/);
+    cwd.mockRestore();
   });
 });


### PR DESCRIPTION
## Provenance note — read this first

The first version of this change (`7e35420`) reached `main` inside #562, a PR about twelve blog essays, without its own review. It was in my working tree when that session staged its commit and got swept in. `git rebase` here dropped it as *"patch contents already upstream"*, confirming that's what happened.

Nothing is reverted — the code is green and wanted. **This PR is the review that change should have had**, and it carries the fixes that review produced.

## What the QA found in the code now on main

Three engines on one prompt. codex and hermes independently found the same defects; agy reported the branch as flawless and clear to merge.

| Defect | Consequence |
|---|---|
| 404 retried 3× with backoff | ~750ms per broken enclosure to be told the same thing three times |
| No per-attempt timeout | A stalled socket holds the build open indefinitely; the retry loop can never advance |
| `parseInt` on content-length | `'42bytes'` → 42, `'1.5'` → 1, `'12e3'` → 12 — plausible-looking wrong numbers that ship |
| Empty local file | Returns a legitimate-looking `0` — the exact bug this change existed to kill |
| Gallery feed | Near-duplicate implementation; its comment pointed at `getFileSize()` in `lib/podcast-feed.ts`, which no longer exists there |
| `FAQPage.isPartOf` | Pointed at the bare page URL, resolving to the WebPage from `mainEntityOfPage` — not the Article. The comment claimed it bound to the article. It didn't. |

Also: the two feeds are the same show, so a build resolved ~93 URLs twice — **206 HEAD requests**. Now memoised by URL, with the *promise* cached so concurrent lookups collapse into one in-flight request. Failures are evicted so a blip can't poison the rest of the build.

## Fixes

5xx still retries; 4xx and malformed headers fail immediately. `AbortSignal.timeout` per attempt. `/^\d+$/` plus a safe-integer check. Empty local files throw. Gallery uses the shared resolver (remote covers now work instead of throwing). The Article carries an `#article` `@id` and `isPartOf` targets it, so the prose and the graph agree; `inLanguage` hoisted onto the Article as the canonical node.

Dropped the "docs removed 15 June 2026" claim from the FAQ comment — it came from the issue, codex cites 7 July in Google's changelog, and only the retirement date matters.

## Test quality

The old 404 test asserted the message only, so it passed whether the code retried once or three times. Call counts are now pinned on every retry path. 107 unit tests; the HEAD test asserts the *method*, since a silent switch to GET would download gigabytes of audio at build time and still pass a value-only assertion.

## Verified on the built artifact

213 enclosures across three feeds, none zero. `Article#article` and `FAQPage#faq` resolve against each other. Build, lint, Prettier, `astro check` (0 errors), content validation all clean.

Refs #555.