### PR TITLE
chore(deps): clear audit gate (brace-expansion 2.x, js-yaml 4.x)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7841,9 +7841,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -8851,9 +8851,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,9 @@
     "@lhci/cli": {
       "uuid": "^11.1.1"
     },
-    "@babel/core": "^7.29.6"
+    "@babel/core": "^7.29.6",
+    "brace-expansion@2": "2.1.2",
+    "js-yaml@4": "^4.3.0"
   },
   "devDependencies": {
     "@lhci/cli": "^0.15.1",


### PR DESCRIPTION
Newly-published **high** advisories flipped the `npm audit --audit-level=high --omit=dev` gate red on build-only transitive deps — blocking every PR's `build` job (including the deploy gate on main).

## Fix
Surgical `overrides` selectors:
- `brace-expansion@2` → `2.1.2` — clears GHSA-3jxr-9vmj-r5cp (2.0.0–2.1.1 DoS); leaves 1.x/5.x in the tree untouched.
- `js-yaml@4` → `^4.3.0` — clears GHSA-52cp-r559-cp3m (4.0.0–4.2.0 quadratic CPU); the nested `^3.15.0` pins for `@lhci/utils`/`gray-matter` still win for those parents.

## Verification
- `npm audit --audit-level=high --omit=dev` → exit 0 (4 moderate remain, below threshold).
- `npm run build` → green. Only `package.json` + `package-lock.json` change.

Recurrence of the known deploy-audit-gate pattern (#471, #480).