### PR TITLE
content(ub): cinematic videos for the final five essays

### DIFF
--- a/src/content/blog/memory-wars-and-data-leakage.md
+++ b/src/content/blog/memory-wars-and-data-leakage.md
@@ -5,6 +5,7 @@ date: 2026-08-01
 heroImage: '/notebook-assets/memory-wars-and-data-leakage/infographic.webp'
 tags: ['memory', 'data', 'privacy', 'identity', 'autonomy']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/memory-wars-and-data-leakage/audio.m4a'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/memory-wars-and-data-leakage/video.mp4'
 audioDuration: '19:30'
 series: 'The Ungovernable Body: Essays'
 seriesOrder: 10

--- a/src/content/blog/the-analog-insurrection.md
+++ b/src/content/blog/the-analog-insurrection.md
@@ -5,6 +5,7 @@ date: 2026-07-30
 heroImage: '/notebook-assets/the-analog-insurrection/infographic.webp'
 tags: ['analog', 'refusal', 'privacy', 'autonomy', 'technology']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-analog-insurrection/audio.m4a'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-analog-insurrection/video.mp4'
 audioDuration: '29:26'
 series: 'The Ungovernable Body: Essays'
 seriesOrder: 8

--- a/src/content/blog/the-data-pyre.md
+++ b/src/content/blog/the-data-pyre.md
@@ -5,6 +5,7 @@ date: 2026-08-02
 heroImage: '/notebook-assets/the-data-pyre/infographic.webp'
 tags: ['deletion', 'ritual', 'data', 'mortality', 'ethics']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-data-pyre/audio.m4a'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-data-pyre/video.mp4'
 audioDuration: '23:04'
 series: 'The Ungovernable Body: Essays'
 seriesOrder: 11

--- a/src/content/blog/the-hauntology-of-the-infinite-now.md
+++ b/src/content/blog/the-hauntology-of-the-infinite-now.md
@@ -5,6 +5,7 @@ date: 2026-08-03
 heroImage: '/notebook-assets/the-hauntology-of-the-infinite-now/infographic.webp'
 tags: ['hauntology', 'memory', 'time', 'technology', 'ethics']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-hauntology-of-the-infinite-now/audio.m4a'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-hauntology-of-the-infinite-now/video.mp4'
 audioDuration: '24:22'
 series: 'The Ungovernable Body: Essays'
 seriesOrder: 12

--- a/src/content/blog/the-right-to-be-forgotten.md
+++ b/src/content/blog/the-right-to-be-forgotten.md
@@ -5,6 +5,7 @@ date: 2026-07-31
 heroImage: '/notebook-assets/the-right-to-be-forgotten/infographic.webp'
 tags: ['privacy', 'deletion', 'data', 'autonomy', 'ethics']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-right-to-be-forgotten/audio.m4a'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-right-to-be-forgotten/video.mp4'
 audioDuration: '23:04'
 series: 'The Ungovernable Body: Essays'
 seriesOrder: 9


### PR DESCRIPTION
Completes the twelve-essay **Ungovernable Body** NotebookLM kit. These five essays were the only outstanding item — they were waiting on the NotebookLM video quota to reset. Quota was available, so all five cinematic video overviews are now generated and live on R2:

| Essay | Size | R2 |
|---|---|---|
| the-analog-insurrection | 69 MB | ✅ 200 |
| the-right-to-be-forgotten | 63 MB | ✅ 200 |
| memory-wars-and-data-leakage | 46 MB | ✅ 200 |
| the-data-pyre | 70 MB | ✅ 200 |
| the-hauntology-of-the-infinite-now | 64 MB | ✅ 200 |

Each generated from that essay's existing UB notebook with the branded dark-botanical `--focus` (no human figures, no stock footage — original abstract animation only). Uploaded to `cdn.adrianwedd.com`, all five verified `200` / `video/mp4` before wiring the `videoUrl` frontmatter.

**Diff is exactly five lines** — one `videoUrl` per essay, nothing else. `validate-content.js` clean.

With this, the UB twelve are **12/12 audio + 12/12 video + 12/12 infographics**.

https://claude.ai/code/session_01DgBUQzZ1dxTjU6SqPg9oMz