### PR TITLE
content(ub): backdate the twelve essays + one-per-hour social blast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,14 @@
         "@astrojs/check": "^0.9.9",
         "@astrojs/mdx": "^6.0.1",
         "@astrojs/preact": "^5.1.4",
-        "@astrojs/rss": "^4.0.18",
+        "@astrojs/rss": "^4.0.19",
         "@astrojs/sitemap": "^3.7.3",
         "@google-analytics/data": "^6.1.0",
         "@tailwindcss/vite": "^4.3.0",
         "astro": "^6.4.2",
         "preact": "^10.29.2",
         "satori": "^0.26.0",
-        "sharp": "0.35.1",
+        "sharp": "^0.35.3",
         "tailwindcss": "^4.3.0",
         "typescript": ">=5.0.0 <6.0.0"
       },
@@ -211,9 +211,9 @@
       }
     },
     "node_modules/@astrojs/rss": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
-      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.19.tgz",
+      "integrity": "sha512-e+z5wYeYtffQdHQO8c2tkSd2JEBdAuRXJV4ZEU5IxkYeE6e39woDd7nw1PH1Kk2tEYNCYuKdylnnbhGmt61awA==",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^5.5.7",
@@ -647,9 +647,9 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
-      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1354,9 +1354,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.1.tgz",
-      "integrity": "sha512-T15JRWOubQ3f5+GxnWeIvo47u5qV0M9HBgJhT+f2gE1e9e6OhR6K73Re52Hm80qWcu1DNb3GweKmpr/MnuP2Ow==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -1372,13 +1372,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.3.0"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.1.tgz",
-      "integrity": "sha512-t1CPD0cr7XCHjwUj6tQ5MC0pCi866I+gUW6zbUX4aFPnKd1DFBtk0M+gWcjX8VeEzgfCNiSiNTVFZ6b7kvdbnQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -1394,20 +1394,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.3.0"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.1.tgz",
-      "integrity": "sha512-MBSQXqNPThW9EcZ905H6N4sEdX5EwZEYzGx5EBq9ncDCGJALMiY1xPFJxNdzuB1iBjLOpIfxajM6YxdvwmQSLA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.1"
+        "@img/sharp-wasm32": "0.35.3"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1417,9 +1417,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.0.tgz",
-      "integrity": "sha512-EKbmBKtyTH+GPFDRw2TgK2oV6hyxxlJVIar4hoTYSNmIwipgMFdxPQqR392GmfdsPGWga0mCFN1cCKjRb9cljw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -1433,9 +1433,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.0.tgz",
-      "integrity": "sha512-Pl2OmOvrJ42adUllESxBsG54PfXLo1OYg9i3c5/5Ln/qJ0gZuTM9YMhQJPIbXqwidLRc/c2zuHt4RsrymmNv7A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -1449,11 +1449,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.0.tgz",
-      "integrity": "sha512-A8UpHoUDW4DwnXoV6+q3C1s7QLRAHtPDEjWuNZjwHMyoCNZnm0GeNN8ls9f/bsEYTRQRW96C/n34XJQHJ2fT7A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1465,11 +1468,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.0.tgz",
-      "integrity": "sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1481,11 +1487,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.0.tgz",
-      "integrity": "sha512-WOpkVxAjFd369iaIzEgNRreFD+gWdUMIGD5zplhNKNeqS6mm5dac3q2AFyCBmzYoAdouzZvRBgxy4z8QHZb4/A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1497,11 +1506,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.0.tgz",
-      "integrity": "sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1513,11 +1525,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.0.tgz",
-      "integrity": "sha512-9APy+nFWhHS+kzLgWZfLcyrUd7YqnAQVa4BPOo4xkoHpdoktOAPG4cEr9+Jpl0TtqfVmcMJimNL5qNTyyOHZNA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1529,11 +1544,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.0.tgz",
-      "integrity": "sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1545,11 +1563,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.0.tgz",
-      "integrity": "sha512-cC1wkC0Mlucd0KSiGrLkJnB/ZqPvZCntc/Lk7ZnYO5ZSbF2euNek4Xvxafojq+wN1q/W0eprdpUIjUr/EV2PBg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1561,11 +1582,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.0.tgz",
-      "integrity": "sha512-LiYMhUZicB1QG//+RvmYZpXJO8fYRENfp+MZUCnG9aw+AKvGAy9gPaCnuwsPcBFs8EV66M0NNxj9VHcNklE8zw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1577,12 +1601,15 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.1.tgz",
-      "integrity": "sha512-jygmR02PpCYypt7xB7nst1vqjZp/BpRA/Kf9nK7qRponJ/KrLPaZWEG4G15z1d2FZ6XqI+T0350ha3RSnKx24A==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1595,15 +1622,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.3.0"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.1.tgz",
-      "integrity": "sha512-ErCRyGU7LeoaFBZ0xW8hhLlXzhAg80sc4vxePB86qvtEvW1jEhhmbiNBP4oEzZfPMnu6HwHXfzD2W2kBU+RnCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1617,16 +1647,19 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.3.0"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.1.tgz",
-      "integrity": "sha512-LUWZ2+r2UoLCd8j0RLCwQ4gL6w47+Y7igxtVnPIDXOOEjV86LpBkAHq5VpJeg+GHbw0KN/JWlPJOdZjyZnFqFQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1639,16 +1672,19 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.3.0"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.1.tgz",
-      "integrity": "sha512-i7x6J3mwF4JgT0sM4V4WlAWdJ0bucPtA9rzO1bTji1n5qgBq/W5nn87RvOQPleuuxahNoLdTngByD8/vDDLArw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1661,16 +1697,19 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.3.0"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.1.tgz",
-      "integrity": "sha512-0zSaTUjTF0kIWTSYxD4EG/nvCU4jez53+3RdURtoY3HvbXtIQ98W90JnrGz/oLRFuEnfIy9+7xeq883euc0ZWw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1683,15 +1722,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.3.0"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.1.tgz",
-      "integrity": "sha512-NbJD4mWdeyrNQKluO/tR/wBDOelcowSVGNBWxI0e3ZtlXc6F/UOVKDj1MLD4zl3oHTuvKW3s+MA9N54YTldAYw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1705,16 +1747,19 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.3.0"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.1.tgz",
-      "integrity": "sha512-VoW2sQCWI+0YIKQEmWJ8vzaQjTg9wIyfkFpvEfAS2h43X6iHu7GTk1hhOgB4IpSzCHe8UwQZIcx7b81VTaOrJA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1727,15 +1772,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.0"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.1.tgz",
-      "integrity": "sha512-LjBoSd/c5JU0/K5MwzDMlgsSRP2bPn98JQGFFQAOLQ0bU/1z4ekxUdSKY9BmlwSh/cA+OrvpgsWqfZyYfVHBRw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1749,17 +1797,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.0"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.1.tgz",
-      "integrity": "sha512-PCQUoQdZyE8tp3HpbevuihfUmgSP4qWI0FGEPWoeXqaS+cUrFfemabHQiebUmUmlUhCuNnQMxGrQ+CPqK4hnxg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.11.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1769,16 +1817,16 @@
       }
     },
     "node_modules/@img/sharp-webcontainers-wasm32": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.1.tgz",
-      "integrity": "sha512-xU2ml2bU2OPxYVvW2A6ae4M1g5QKyhKG06P4FAt+YEaFQQO0919Qx+XxIZEUuWTMoDViLpMws2/dQwoe/VcA6A==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.1"
+        "@img/sharp-wasm32": "0.35.3"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1788,9 +1836,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.1.tgz",
-      "integrity": "sha512-IkmHwuFhYpd3bTsN5SAahjwhiAcyXPooBt8vEUgxY3T0IP70sSJ0nU1xiPzZY8AH/OB1XpV3j8aZSVSOSfTbdA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -1807,9 +1855,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.1.tgz",
-      "integrity": "sha512-wQahqCi9MD8Yxzg4gVM4fNrZxh+r6vD55PyIg+WJPaM5ZRUyF35iQpwJCuma3r6viU9/8Pxlc+XHV+woVa6nCQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -1826,9 +1874,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.1.tgz",
-      "integrity": "sha512-WzBtkYtZHATLPe8XRharxZXxQ9cdLrQWHiwxt+BJ5rBsisQrKeeV86ErxPSVhcG6xCEuNhs0SqLpWr7XDa2k6w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -4404,462 +4452,6 @@
       "integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
       "license": "MIT"
     },
-    "node_modules/astro/node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/astro/node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
     "node_modules/astro/node_modules/jsonc-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
@@ -4876,51 +4468,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/astro/node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/astrojs-compiler-sync": {
@@ -7294,9 +6841,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -12797,14 +12344,14 @@
       "license": "ISC"
     },
     "node_modules/sharp": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.1.tgz",
-      "integrity": "sha512-lW979AMi+ESidzMv/Lnv+F9bknzLyxLqFI05Sm433vOeRcltgxQmXpnfOOFIAlKtwXU/ksupm2srQoFCkR214g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.8.4"
+        "semver": "^7.8.5"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -12813,37 +12360,42 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.35.1",
-        "@img/sharp-darwin-x64": "0.35.1",
-        "@img/sharp-freebsd-wasm32": "0.35.1",
-        "@img/sharp-libvips-darwin-arm64": "1.3.0",
-        "@img/sharp-libvips-darwin-x64": "1.3.0",
-        "@img/sharp-libvips-linux-arm": "1.3.0",
-        "@img/sharp-libvips-linux-arm64": "1.3.0",
-        "@img/sharp-libvips-linux-ppc64": "1.3.0",
-        "@img/sharp-libvips-linux-riscv64": "1.3.0",
-        "@img/sharp-libvips-linux-s390x": "1.3.0",
-        "@img/sharp-libvips-linux-x64": "1.3.0",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.0",
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.0",
-        "@img/sharp-linux-arm": "0.35.1",
-        "@img/sharp-linux-arm64": "0.35.1",
-        "@img/sharp-linux-ppc64": "0.35.1",
-        "@img/sharp-linux-riscv64": "0.35.1",
-        "@img/sharp-linux-s390x": "0.35.1",
-        "@img/sharp-linux-x64": "0.35.1",
-        "@img/sharp-linuxmusl-arm64": "0.35.1",
-        "@img/sharp-linuxmusl-x64": "0.35.1",
-        "@img/sharp-webcontainers-wasm32": "0.35.1",
-        "@img/sharp-win32-arm64": "0.35.1",
-        "@img/sharp-win32-ia32": "0.35.1",
-        "@img/sharp-win32-x64": "0.35.1"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -13400,9 +12952,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "@astrojs/check": "^0.9.9",
     "@astrojs/mdx": "^6.0.1",
     "@astrojs/preact": "^5.1.4",
-    "@astrojs/rss": "^4.0.18",
+    "@astrojs/rss": "^4.0.19",
     "@astrojs/sitemap": "^3.7.3",
     "@google-analytics/data": "^6.1.0",
     "@tailwindcss/vite": "^4.3.0",
     "astro": "^6.4.2",
     "preact": "^10.29.2",
     "satori": "^0.26.0",
-    "sharp": "0.35.1",
+    "sharp": "^0.35.3",
     "tailwindcss": "^4.3.0",
     "typescript": ">=5.0.0 <6.0.0"
   },
@@ -48,6 +48,9 @@
     "protobufjs": "^7.6.4",
     "vite": "^7.3.5",
     "tmp": "^0.2.6",
+    "sharp": "^0.35.3",
+    "svgo": "^4.0.2",
+    "fast-uri": "^3.1.4",
     "@lhci/utils": {
       "js-yaml": "^3.15.0"
     },

--- a/social/facebook-posts.json
+++ b/social/facebook-posts.json
@@ -36,8 +36,8 @@
       "type": "text",
       "message": "The Glass Cage\n\nThe demand that you be readable is the demand that you be governable. On legibility, the trap of visibility, and why opacity is the freedom left.\n\nhttps://adrianwedd.com/blog/the-glass-cage/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-glass-cage/infographic.jpg",
-      "scheduledAt": "2026-07-23T09:00:00+10:00",
-      "scheduledAtEpoch": 1784761200000
+      "scheduledAt": "2026-07-22T01:00:00.000Z",
+      "scheduledAtEpoch": 1784682000000
     },
     {
       "id": "drip-bluesky-the-glass-cage",
@@ -45,8 +45,8 @@
       "type": "text",
       "message": "The Glass Cage\n\nThe demand that you be readable is the demand that you be governable. On legibility, the trap of visibility, and why opacity is the freedom left.\n\nhttps://adrianwedd.com/blog/the-glass-cage/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-glass-cage/infographic.jpg",
-      "scheduledAt": "2026-07-23T09:00:00+10:00",
-      "scheduledAtEpoch": 1784761200000
+      "scheduledAt": "2026-07-22T01:00:00.000Z",
+      "scheduledAtEpoch": 1784682000000
     },
     {
       "id": "drip-twitter-the-glass-cage",
@@ -54,8 +54,8 @@
       "type": "text",
       "message": "The Glass Cage\n\nThe demand that you be readable is the demand that you be governable. On legibility, the trap of visibility, and why opacity is the freedom left.\n\nhttps://adrianwedd.com/blog/the-glass-cage/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-glass-cage/infographic.jpg",
-      "scheduledAt": "2026-07-23T09:00:00+10:00",
-      "scheduledAtEpoch": 1784761200000
+      "scheduledAt": "2026-07-22T01:00:00.000Z",
+      "scheduledAtEpoch": 1784682000000
     },
     {
       "id": "drip-facebook-the-bio-age-trap",
@@ -63,8 +63,8 @@
       "type": "text",
       "message": "The Bio-Age Trap\n\nInsurers are swapping your birthday for a biological age score. The markers it reads are gendered, so menopause gets priced as accelerated decay.\n\nhttps://adrianwedd.com/blog/the-bio-age-trap/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-bio-age-trap/infographic.jpg",
-      "scheduledAt": "2026-07-24T09:00:00+10:00",
-      "scheduledAtEpoch": 1784847600000
+      "scheduledAt": "2026-07-22T02:00:00.000Z",
+      "scheduledAtEpoch": 1784685600000
     },
     {
       "id": "drip-bluesky-the-bio-age-trap",
@@ -72,8 +72,8 @@
       "type": "text",
       "message": "The Bio-Age Trap\n\nInsurers are swapping your birthday for a biological age score. The markers it reads are gendered, so menopause gets priced as accelerated decay.\n\nhttps://adrianwedd.com/blog/the-bio-age-trap/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-bio-age-trap/infographic.jpg",
-      "scheduledAt": "2026-07-24T09:00:00+10:00",
-      "scheduledAtEpoch": 1784847600000
+      "scheduledAt": "2026-07-22T02:00:00.000Z",
+      "scheduledAtEpoch": 1784685600000
     },
     {
       "id": "drip-twitter-the-bio-age-trap",
@@ -81,8 +81,8 @@
       "type": "text",
       "message": "The Bio-Age Trap\n\nInsurers are swapping your birthday for a biological age score. The markers it reads are gendered, so menopause gets priced as accelerated decay.\n\nhttps://adrianwedd.com/blog/the-bio-age-trap/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-bio-age-trap/infographic.jpg",
-      "scheduledAt": "2026-07-24T09:00:00+10:00",
-      "scheduledAtEpoch": 1784847600000
+      "scheduledAt": "2026-07-22T02:00:00.000Z",
+      "scheduledAtEpoch": 1784685600000
     },
     {
       "id": "drip-facebook-the-gorgon-protocol",
@@ -90,8 +90,8 @@
       "type": "text",
       "message": "The Gorgon Protocol\n\nFacial recognition fails unevenly, and hardest on the people it was never built for. That failure is a vulnerability you can put on your face.\n\nhttps://adrianwedd.com/blog/the-gorgon-protocol/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-gorgon-protocol/infographic.jpg",
-      "scheduledAt": "2026-07-25T09:00:00+10:00",
-      "scheduledAtEpoch": 1784934000000
+      "scheduledAt": "2026-07-22T03:00:00.000Z",
+      "scheduledAtEpoch": 1784689200000
     },
     {
       "id": "drip-bluesky-the-gorgon-protocol",
@@ -99,8 +99,8 @@
       "type": "text",
       "message": "The Gorgon Protocol\n\nFacial recognition fails unevenly, and hardest on the people it was never built for. That failure is a vulnerability you can put on your face.\n\nhttps://adrianwedd.com/blog/the-gorgon-protocol/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-gorgon-protocol/infographic.jpg",
-      "scheduledAt": "2026-07-25T09:00:00+10:00",
-      "scheduledAtEpoch": 1784934000000
+      "scheduledAt": "2026-07-22T03:00:00.000Z",
+      "scheduledAtEpoch": 1784689200000
     },
     {
       "id": "drip-twitter-the-gorgon-protocol",
@@ -108,8 +108,8 @@
       "type": "text",
       "message": "The Gorgon Protocol\n\nFacial recognition fails unevenly, and hardest on the people it was never built for. That failure is a vulnerability you can put on your face.\n\nhttps://adrianwedd.com/blog/the-gorgon-protocol/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-gorgon-protocol/infographic.jpg",
-      "scheduledAt": "2026-07-25T09:00:00+10:00",
-      "scheduledAtEpoch": 1784934000000
+      "scheduledAt": "2026-07-22T03:00:00.000Z",
+      "scheduledAtEpoch": 1784689200000
     },
     {
       "id": "drip-facebook-the-ghost-in-the-city",
@@ -117,8 +117,8 @@
       "type": "text",
       "message": "The Ghost in the City\n\nA city redesigned so that pausing reads as a fault condition, and what that costs the people whose bodies need to stop.\n\nhttps://adrianwedd.com/blog/the-ghost-in-the-city/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-ghost-in-the-city/infographic.jpg",
-      "scheduledAt": "2026-07-26T09:00:00+10:00",
-      "scheduledAtEpoch": 1785020400000
+      "scheduledAt": "2026-07-22T04:00:00.000Z",
+      "scheduledAtEpoch": 1784692800000
     },
     {
       "id": "drip-bluesky-the-ghost-in-the-city",
@@ -126,8 +126,8 @@
       "type": "text",
       "message": "The Ghost in the City\n\nA city redesigned so that pausing reads as a fault condition, and what that costs the people whose bodies need to stop.\n\nhttps://adrianwedd.com/blog/the-ghost-in-the-city/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-ghost-in-the-city/infographic.jpg",
-      "scheduledAt": "2026-07-26T09:00:00+10:00",
-      "scheduledAtEpoch": 1785020400000
+      "scheduledAt": "2026-07-22T04:00:00.000Z",
+      "scheduledAtEpoch": 1784692800000
     },
     {
       "id": "drip-twitter-the-ghost-in-the-city",
@@ -135,8 +135,8 @@
       "type": "text",
       "message": "The Ghost in the City\n\nA city redesigned so that pausing reads as a fault condition, and what that costs the people whose bodies need to stop.\n\nhttps://adrianwedd.com/blog/the-ghost-in-the-city/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-ghost-in-the-city/infographic.jpg",
-      "scheduledAt": "2026-07-26T09:00:00+10:00",
-      "scheduledAtEpoch": 1785020400000
+      "scheduledAt": "2026-07-22T04:00:00.000Z",
+      "scheduledAtEpoch": 1784692800000
     },
     {
       "id": "drip-facebook-the-boredom-strike",
@@ -144,8 +144,8 @@
       "type": "text",
       "message": "The Boredom Strike\n\nThe attention economy doesn't want your attention. It wants your arousal. Boredom is the one state it can't sell, which makes it a labour tactic.\n\nhttps://adrianwedd.com/blog/the-boredom-strike/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-boredom-strike/infographic.jpg",
-      "scheduledAt": "2026-07-27T09:00:00+10:00",
-      "scheduledAtEpoch": 1785106800000
+      "scheduledAt": "2026-07-22T05:00:00.000Z",
+      "scheduledAtEpoch": 1784696400000
     },
     {
       "id": "drip-bluesky-the-boredom-strike",
@@ -153,8 +153,8 @@
       "type": "text",
       "message": "The Boredom Strike\n\nThe attention economy doesn't want your attention. It wants your arousal. Boredom is the one state it can't sell, which makes it a labour tactic.\n\nhttps://adrianwedd.com/blog/the-boredom-strike/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-boredom-strike/infographic.jpg",
-      "scheduledAt": "2026-07-27T09:00:00+10:00",
-      "scheduledAtEpoch": 1785106800000
+      "scheduledAt": "2026-07-22T05:00:00.000Z",
+      "scheduledAtEpoch": 1784696400000
     },
     {
       "id": "drip-twitter-the-boredom-strike",
@@ -162,8 +162,8 @@
       "type": "text",
       "message": "The Boredom Strike\n\nThe attention economy doesn't want your attention. It wants your arousal. Boredom is the one state it can't sell, which makes it a labour tactic.\n\nhttps://adrianwedd.com/blog/the-boredom-strike/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-boredom-strike/infographic.jpg",
-      "scheduledAt": "2026-07-27T09:00:00+10:00",
-      "scheduledAtEpoch": 1785106800000
+      "scheduledAt": "2026-07-22T05:00:00.000Z",
+      "scheduledAtEpoch": 1784696400000
     },
     {
       "id": "drip-facebook-weaponized-silence",
@@ -171,8 +171,8 @@
       "type": "text",
       "message": "Weaponized Silence\n\nSilence is not an absence. It is the withdrawal of unpaid labour, and the reaction it provokes shows you exactly who was being subsidised.\n\nhttps://adrianwedd.com/blog/weaponized-silence/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/weaponized-silence/infographic.jpg",
-      "scheduledAt": "2026-07-28T09:00:00+10:00",
-      "scheduledAtEpoch": 1785193200000
+      "scheduledAt": "2026-07-22T06:00:00.000Z",
+      "scheduledAtEpoch": 1784700000000
     },
     {
       "id": "drip-bluesky-weaponized-silence",
@@ -180,8 +180,8 @@
       "type": "text",
       "message": "Weaponized Silence\n\nSilence is not an absence. It is the withdrawal of unpaid labour, and the reaction it provokes shows you exactly who was being subsidised.\n\nhttps://adrianwedd.com/blog/weaponized-silence/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/weaponized-silence/infographic.jpg",
-      "scheduledAt": "2026-07-28T09:00:00+10:00",
-      "scheduledAtEpoch": 1785193200000
+      "scheduledAt": "2026-07-22T06:00:00.000Z",
+      "scheduledAtEpoch": 1784700000000
     },
     {
       "id": "drip-twitter-weaponized-silence",
@@ -189,8 +189,8 @@
       "type": "text",
       "message": "Weaponized Silence\n\nSilence is not an absence. It is the withdrawal of unpaid labour, and the reaction it provokes shows you exactly who was being subsidised.\n\nhttps://adrianwedd.com/blog/weaponized-silence/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/weaponized-silence/infographic.jpg",
-      "scheduledAt": "2026-07-28T09:00:00+10:00",
-      "scheduledAtEpoch": 1785193200000
+      "scheduledAt": "2026-07-22T06:00:00.000Z",
+      "scheduledAtEpoch": 1784700000000
     },
     {
       "id": "drip-facebook-sleep-sovereignty",
@@ -198,8 +198,8 @@
       "type": "text",
       "message": "Sleep Sovereignty\n\nSleep is the last stretch of a life the market cannot easily harvest. The 24/7 economy, the wearable and the industrial clock have all gone after it anyway.\n\nhttps://adrianwedd.com/blog/sleep-sovereignty/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/sleep-sovereignty/infographic.jpg",
-      "scheduledAt": "2026-07-29T09:00:00+10:00",
-      "scheduledAtEpoch": 1785279600000
+      "scheduledAt": "2026-07-22T07:00:00.000Z",
+      "scheduledAtEpoch": 1784703600000
     },
     {
       "id": "drip-bluesky-sleep-sovereignty",
@@ -207,8 +207,8 @@
       "type": "text",
       "message": "Sleep Sovereignty\n\nSleep is the last stretch of a life the market cannot easily harvest. The 24/7 economy, the wearable and the industrial clock have all gone after it anyway.\n\nhttps://adrianwedd.com/blog/sleep-sovereignty/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/sleep-sovereignty/infographic.jpg",
-      "scheduledAt": "2026-07-29T09:00:00+10:00",
-      "scheduledAtEpoch": 1785279600000
+      "scheduledAt": "2026-07-22T07:00:00.000Z",
+      "scheduledAtEpoch": 1784703600000
     },
     {
       "id": "drip-twitter-sleep-sovereignty",
@@ -216,8 +216,8 @@
       "type": "text",
       "message": "Sleep Sovereignty\n\nSleep is the last stretch of a life the market cannot easily harvest. The 24/7 economy, the wearable and the industrial clock have all gone after it anyway.\n\nhttps://adrianwedd.com/blog/sleep-sovereignty/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/sleep-sovereignty/infographic.jpg",
-      "scheduledAt": "2026-07-29T09:00:00+10:00",
-      "scheduledAtEpoch": 1785279600000
+      "scheduledAt": "2026-07-22T07:00:00.000Z",
+      "scheduledAtEpoch": 1784703600000
     },
     {
       "id": "drip-facebook-the-analog-insurrection",
@@ -225,8 +225,8 @@
       "type": "text",
       "message": "The Analog Insurrection\n\nDisconnection used to be the default. Now it is a luxury good, and the price of staying unreadable is quietly sorting us into two classes.\n\nhttps://adrianwedd.com/blog/the-analog-insurrection/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-analog-insurrection/infographic.jpg",
-      "scheduledAt": "2026-07-30T09:00:00+10:00",
-      "scheduledAtEpoch": 1785366000000
+      "scheduledAt": "2026-07-22T08:00:00.000Z",
+      "scheduledAtEpoch": 1784707200000
     },
     {
       "id": "drip-bluesky-the-analog-insurrection",
@@ -234,8 +234,8 @@
       "type": "text",
       "message": "The Analog Insurrection\n\nDisconnection used to be the default. Now it is a luxury good, and the price of staying unreadable is quietly sorting us into two classes.\n\nhttps://adrianwedd.com/blog/the-analog-insurrection/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-analog-insurrection/infographic.jpg",
-      "scheduledAt": "2026-07-30T09:00:00+10:00",
-      "scheduledAtEpoch": 1785366000000
+      "scheduledAt": "2026-07-22T08:00:00.000Z",
+      "scheduledAtEpoch": 1784707200000
     },
     {
       "id": "drip-twitter-the-analog-insurrection",
@@ -243,8 +243,8 @@
       "type": "text",
       "message": "The Analog Insurrection\n\nDisconnection used to be the default. Now it is a luxury good, and the price of staying unreadable is quietly sorting us into two classes.\n\nhttps://adrianwedd.com/blog/the-analog-insurrection/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-analog-insurrection/infographic.jpg",
-      "scheduledAt": "2026-07-30T09:00:00+10:00",
-      "scheduledAtEpoch": 1785366000000
+      "scheduledAt": "2026-07-22T08:00:00.000Z",
+      "scheduledAtEpoch": 1784707200000
     },
     {
       "id": "drip-facebook-the-right-to-be-forgotten",
@@ -252,8 +252,8 @@
       "type": "text",
       "message": "The Right to Be Forgotten\n\nThe digital afterlife industry sells immortality and delivers undeadness. Finitude is not a defect in a person, and deletion should be the default.\n\nhttps://adrianwedd.com/blog/the-right-to-be-forgotten/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-right-to-be-forgotten/infographic.jpg",
-      "scheduledAt": "2026-07-31T09:00:00+10:00",
-      "scheduledAtEpoch": 1785452400000
+      "scheduledAt": "2026-07-22T09:00:00.000Z",
+      "scheduledAtEpoch": 1784710800000
     },
     {
       "id": "drip-bluesky-the-right-to-be-forgotten",
@@ -261,8 +261,8 @@
       "type": "text",
       "message": "The Right to Be Forgotten\n\nThe digital afterlife industry sells immortality and delivers undeadness. Finitude is not a defect in a person, and deletion should be the default.\n\nhttps://adrianwedd.com/blog/the-right-to-be-forgotten/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-right-to-be-forgotten/infographic.jpg",
-      "scheduledAt": "2026-07-31T09:00:00+10:00",
-      "scheduledAtEpoch": 1785452400000
+      "scheduledAt": "2026-07-22T09:00:00.000Z",
+      "scheduledAtEpoch": 1784710800000
     },
     {
       "id": "drip-twitter-the-right-to-be-forgotten",
@@ -270,8 +270,8 @@
       "type": "text",
       "message": "The Right to Be Forgotten\n\nThe digital afterlife industry sells immortality and delivers undeadness. Finitude is not a defect in a person, and deletion should be the default.\n\nhttps://adrianwedd.com/blog/the-right-to-be-forgotten/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-right-to-be-forgotten/infographic.jpg",
-      "scheduledAt": "2026-07-31T09:00:00+10:00",
-      "scheduledAtEpoch": 1785452400000
+      "scheduledAt": "2026-07-22T09:00:00.000Z",
+      "scheduledAtEpoch": 1784710800000
     },
     {
       "id": "drip-facebook-memory-wars-and-data-leakage",
@@ -279,8 +279,8 @@
       "type": "text",
       "message": "Memory Wars and Data Leakage\n\nThe state wants a self that remembers everything and contradicts nothing. A body that forgets is not a broken citizen but one the file can no longer hold.\n\nhttps://adrianwedd.com/blog/memory-wars-and-data-leakage/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/memory-wars-and-data-leakage/infographic.jpg",
-      "scheduledAt": "2026-08-01T09:00:00+10:00",
-      "scheduledAtEpoch": 1785538800000
+      "scheduledAt": "2026-07-22T10:00:00.000Z",
+      "scheduledAtEpoch": 1784714400000
     },
     {
       "id": "drip-bluesky-memory-wars-and-data-leakage",
@@ -288,8 +288,8 @@
       "type": "text",
       "message": "Memory Wars and Data Leakage\n\nThe state wants a self that remembers everything and contradicts nothing. A body that forgets is not a broken citizen but one the file can no longer hold.\n\nhttps://adrianwedd.com/blog/memory-wars-and-data-leakage/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/memory-wars-and-data-leakage/infographic.jpg",
-      "scheduledAt": "2026-08-01T09:00:00+10:00",
-      "scheduledAtEpoch": 1785538800000
+      "scheduledAt": "2026-07-22T10:00:00.000Z",
+      "scheduledAtEpoch": 1784714400000
     },
     {
       "id": "drip-twitter-memory-wars-and-data-leakage",
@@ -297,8 +297,8 @@
       "type": "text",
       "message": "Memory Wars and Data Leakage\n\nThe state wants a self that remembers everything and contradicts nothing. A body that forgets is not a broken citizen but one the file can no longer hold.\n\nhttps://adrianwedd.com/blog/memory-wars-and-data-leakage/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/memory-wars-and-data-leakage/infographic.jpg",
-      "scheduledAt": "2026-08-01T09:00:00+10:00",
-      "scheduledAtEpoch": 1785538800000
+      "scheduledAt": "2026-07-22T10:00:00.000Z",
+      "scheduledAtEpoch": 1784714400000
     },
     {
       "id": "drip-facebook-the-data-pyre",
@@ -306,8 +306,8 @@
       "type": "text",
       "message": "The Data Pyre\n\nWe built a civilisation whose every system defaults to save. The archive is perfect and the liturgy of erasure is gone. Deletion has to become a ritual.\n\nhttps://adrianwedd.com/blog/the-data-pyre/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-data-pyre/infographic.jpg",
-      "scheduledAt": "2026-08-02T09:00:00+10:00",
-      "scheduledAtEpoch": 1785625200000
+      "scheduledAt": "2026-07-22T11:00:00.000Z",
+      "scheduledAtEpoch": 1784718000000
     },
     {
       "id": "drip-bluesky-the-data-pyre",
@@ -315,8 +315,8 @@
       "type": "text",
       "message": "The Data Pyre\n\nWe built a civilisation whose every system defaults to save. The archive is perfect and the liturgy of erasure is gone. Deletion has to become a ritual.\n\nhttps://adrianwedd.com/blog/the-data-pyre/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-data-pyre/infographic.jpg",
-      "scheduledAt": "2026-08-02T09:00:00+10:00",
-      "scheduledAtEpoch": 1785625200000
+      "scheduledAt": "2026-07-22T11:00:00.000Z",
+      "scheduledAtEpoch": 1784718000000
     },
     {
       "id": "drip-twitter-the-data-pyre",
@@ -324,8 +324,8 @@
       "type": "text",
       "message": "The Data Pyre\n\nWe built a civilisation whose every system defaults to save. The archive is perfect and the liturgy of erasure is gone. Deletion has to become a ritual.\n\nhttps://adrianwedd.com/blog/the-data-pyre/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-data-pyre/infographic.jpg",
-      "scheduledAt": "2026-08-02T09:00:00+10:00",
-      "scheduledAtEpoch": 1785625200000
+      "scheduledAt": "2026-07-22T11:00:00.000Z",
+      "scheduledAtEpoch": 1784718000000
     },
     {
       "id": "drip-facebook-the-hauntology-of-the-infinite-now",
@@ -333,8 +333,8 @@
       "type": "text",
       "message": "The Hauntology of the Infinite Now\n\nDigital media carries no visible wear, so the past never reads as over. On hauntology, retromania, and a culture that struggles to finish anything.\n\nhttps://adrianwedd.com/blog/the-hauntology-of-the-infinite-now/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-hauntology-of-the-infinite-now/infographic.jpg",
-      "scheduledAt": "2026-08-03T09:00:00+10:00",
-      "scheduledAtEpoch": 1785711600000
+      "scheduledAt": "2026-07-22T12:00:00.000Z",
+      "scheduledAtEpoch": 1784721600000
     },
     {
       "id": "drip-bluesky-the-hauntology-of-the-infinite-now",
@@ -342,8 +342,8 @@
       "type": "text",
       "message": "The Hauntology of the Infinite Now\n\nDigital media carries no visible wear, so the past never reads as over. On hauntology, retromania, and a culture that struggles to finish anything.\n\nhttps://adrianwedd.com/blog/the-hauntology-of-the-infinite-now/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-hauntology-of-the-infinite-now/infographic.jpg",
-      "scheduledAt": "2026-08-03T09:00:00+10:00",
-      "scheduledAtEpoch": 1785711600000
+      "scheduledAt": "2026-07-22T12:00:00.000Z",
+      "scheduledAtEpoch": 1784721600000
     },
     {
       "id": "drip-twitter-the-hauntology-of-the-infinite-now",
@@ -351,8 +351,8 @@
       "type": "text",
       "message": "The Hauntology of the Infinite Now\n\nDigital media carries no visible wear, so the past never reads as over. On hauntology, retromania, and a culture that struggles to finish anything.\n\nhttps://adrianwedd.com/blog/the-hauntology-of-the-infinite-now/",
       "imageUrl": "https://adrianwedd.com/notebook-assets/the-hauntology-of-the-infinite-now/infographic.jpg",
-      "scheduledAt": "2026-08-03T09:00:00+10:00",
-      "scheduledAtEpoch": 1785711600000
+      "scheduledAt": "2026-07-22T12:00:00.000Z",
+      "scheduledAtEpoch": 1784721600000
     }
   ]
 }

--- a/src/content/blog/memory-wars-and-data-leakage.md
+++ b/src/content/blog/memory-wars-and-data-leakage.md
@@ -1,7 +1,7 @@
 ---
 title: 'Memory Wars and Data Leakage'
 description: 'The state wants a self that remembers everything and contradicts nothing. A body that forgets is not a broken citizen but one the file can no longer hold.'
-date: 2026-08-01
+date: 2026-07-22T20:00:00+10:00
 autopublish: true
 heroImage: '/notebook-assets/memory-wars-and-data-leakage/infographic.webp'
 tags: ['memory', 'data', 'privacy', 'identity', 'autonomy']

--- a/src/content/blog/sleep-sovereignty.md
+++ b/src/content/blog/sleep-sovereignty.md
@@ -1,7 +1,7 @@
 ---
 title: 'Sleep Sovereignty'
 description: 'Sleep is the last stretch of a life the market cannot easily harvest. The 24/7 economy, the wearable and the industrial clock have all gone after it anyway.'
-date: 2026-07-29
+date: 2026-07-22T17:00:00+10:00
 autopublish: true
 heroImage: '/notebook-assets/sleep-sovereignty/infographic.webp'
 tags: ['sleep', 'biopolitics', 'wearables', 'autonomy', 'technology']

--- a/src/content/blog/the-analog-insurrection.md
+++ b/src/content/blog/the-analog-insurrection.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Analog Insurrection'
 description: 'Disconnection used to be the default. Now it is a luxury good, and the price of staying unreadable is quietly sorting us into two classes.'
-date: 2026-07-30
+date: 2026-07-22T18:00:00+10:00
 autopublish: true
 heroImage: '/notebook-assets/the-analog-insurrection/infographic.webp'
 tags: ['analog', 'refusal', 'privacy', 'autonomy', 'technology']

--- a/src/content/blog/the-bio-age-trap.md
+++ b/src/content/blog/the-bio-age-trap.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Bio-Age Trap'
 description: 'Insurers are swapping your birthday for a biological age score. The markers it reads are gendered, so menopause gets priced as accelerated decay.'
-date: 2026-07-24
+date: 2026-07-22T12:00:00+10:00
 autopublish: true
 heroImage: '/notebook-assets/the-bio-age-trap/infographic.webp'
 tags: ['biopolitics', 'insurance', 'algorithms', 'surveillance', 'ethics']

--- a/src/content/blog/the-boredom-strike.md
+++ b/src/content/blog/the-boredom-strike.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Boredom Strike'
 description: "The attention economy doesn't want your attention. It wants your arousal. Boredom is the one state it can't sell, which makes it a labour tactic."
-date: 2026-07-27
+date: 2026-07-22T15:00:00+10:00
 autopublish: true
 heroImage: '/notebook-assets/the-boredom-strike/infographic.webp'
 tags: ['attention', 'refusal', 'technology', 'autonomy', 'biopolitics']

--- a/src/content/blog/the-data-pyre.md
+++ b/src/content/blog/the-data-pyre.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Data Pyre'
 description: 'We built a civilisation whose every system defaults to save. The archive is perfect and the liturgy of erasure is gone. Deletion has to become a ritual.'
-date: 2026-08-02
+date: 2026-07-22T21:00:00+10:00
 autopublish: true
 heroImage: '/notebook-assets/the-data-pyre/infographic.webp'
 tags: ['deletion', 'ritual', 'data', 'mortality', 'ethics']

--- a/src/content/blog/the-ghost-in-the-city.md
+++ b/src/content/blog/the-ghost-in-the-city.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Ghost in the City'
 description: 'A city redesigned so that pausing reads as a fault condition, and what that costs the people whose bodies need to stop.'
-date: 2026-07-26
+date: 2026-07-22T14:00:00+10:00
 autopublish: true
 heroImage: '/notebook-assets/the-ghost-in-the-city/infographic.webp'
 tags: ['surveillance', 'cities', 'biopolitics', 'ai', 'autonomy']

--- a/src/content/blog/the-glass-cage.md
+++ b/src/content/blog/the-glass-cage.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Glass Cage'
 description: 'The demand that you be readable is the demand that you be governable. On legibility, the trap of visibility, and why opacity is the freedom left.'
-date: 2026-07-23
+date: 2026-07-22T11:00:00+10:00
 autopublish: true
 heroImage: '/notebook-assets/the-glass-cage/infographic.webp'
 tags: ['surveillance', 'biopolitics', 'privacy', 'autonomy', 'technology']

--- a/src/content/blog/the-gorgon-protocol.md
+++ b/src/content/blog/the-gorgon-protocol.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Gorgon Protocol'
 description: 'Facial recognition fails unevenly, and hardest on the people it was never built for. That failure is a vulnerability you can put on your face.'
-date: 2026-07-25
+date: 2026-07-22T13:00:00+10:00
 autopublish: true
 heroImage: '/notebook-assets/the-gorgon-protocol/infographic.webp'
 tags: ['surveillance', 'biopolitics', 'adversarial', 'autonomy', 'ai']

--- a/src/content/blog/the-hauntology-of-the-infinite-now.md
+++ b/src/content/blog/the-hauntology-of-the-infinite-now.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Hauntology of the Infinite Now'
 description: 'Digital media carries no visible wear, so the past never reads as over. On hauntology, retromania, and a culture that struggles to finish anything.'
-date: 2026-08-03
+date: 2026-07-22T22:00:00+10:00
 autopublish: true
 heroImage: '/notebook-assets/the-hauntology-of-the-infinite-now/infographic.webp'
 tags: ['hauntology', 'memory', 'time', 'technology', 'ethics']

--- a/src/content/blog/the-right-to-be-forgotten.md
+++ b/src/content/blog/the-right-to-be-forgotten.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Right to Be Forgotten'
 description: 'The digital afterlife industry sells immortality and delivers undeadness. Finitude is not a defect in a person, and deletion should be the default.'
-date: 2026-07-31
+date: 2026-07-22T19:00:00+10:00
 autopublish: true
 heroImage: '/notebook-assets/the-right-to-be-forgotten/infographic.webp'
 tags: ['privacy', 'deletion', 'data', 'autonomy', 'ethics']

--- a/src/content/blog/weaponized-silence.md
+++ b/src/content/blog/weaponized-silence.md
@@ -1,7 +1,7 @@
 ---
 title: 'Weaponized Silence'
 description: 'Silence is not an absence. It is the withdrawal of unpaid labour, and the reaction it provokes shows you exactly who was being subsidised.'
-date: 2026-07-28
+date: 2026-07-22T16:00:00+10:00
 autopublish: true
 heroImage: '/notebook-assets/weaponized-silence/infographic.webp'
 tags: ['attention', 'refusal', 'autonomy', 'ethics', 'technology']


### PR DESCRIPTION
Pulls the twelve *Ungovernable Body: Essays* from their future one-per-day schedule (Jul 23–Aug 3) to **today (2026-07-22)**, staggered one hour apart in seriesOrder — **11:00→22:00 AEST**.

**Effect:** they publish now, and the date-driven social queue drips them one per hour over a ~12-hour blast instead of trickling over twelve days. Portrait `heroImage` `.jpg` twins ride as the social cards (unchanged assets — the abstract-landscape infographic swap is a later pure image-swap, to land *after* this blast completes so the queue sync doesn't cancel still-pending posts).

**Verified locally:** `validate-content` 0 errors / 0 warnings; regenerated `social/facebook-posts.json` shows the twelve at 01:00Z→12:00Z in series order, each with its `.jpg` card.

https://claude.ai/code/session_01N7c4k5cUhUedhoVFaC4iYe