### PR TITLE
content(ub): backdate the twelve essays into the Jun 28–Jul 19 archive gap

### DIFF
--- a/src/content/blog/memory-wars-and-data-leakage.md
+++ b/src/content/blog/memory-wars-and-data-leakage.md
@@ -1,7 +1,7 @@
 ---
 title: 'Memory Wars and Data Leakage'
 description: 'The state wants a self that remembers everything and contradicts nothing. A body that forgets is not a broken citizen but one the file can no longer hold.'
-date: 2026-07-22T20:00:00+10:00
+date: 2026-07-16
 autopublish: true
 heroImage: '/notebook-assets/memory-wars-and-data-leakage/infographic.webp'
 tags: ['memory', 'data', 'privacy', 'identity', 'autonomy']

--- a/src/content/blog/sleep-sovereignty.md
+++ b/src/content/blog/sleep-sovereignty.md
@@ -1,7 +1,7 @@
 ---
 title: 'Sleep Sovereignty'
 description: 'Sleep is the last stretch of a life the market cannot easily harvest. The 24/7 economy, the wearable and the industrial clock have all gone after it anyway.'
-date: 2026-07-22T17:00:00+10:00
+date: 2026-07-10
 autopublish: true
 heroImage: '/notebook-assets/sleep-sovereignty/infographic.webp'
 tags: ['sleep', 'biopolitics', 'wearables', 'autonomy', 'technology']

--- a/src/content/blog/the-analog-insurrection.md
+++ b/src/content/blog/the-analog-insurrection.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Analog Insurrection'
 description: 'Disconnection used to be the default. Now it is a luxury good, and the price of staying unreadable is quietly sorting us into two classes.'
-date: 2026-07-22T18:00:00+10:00
+date: 2026-07-12
 autopublish: true
 heroImage: '/notebook-assets/the-analog-insurrection/infographic.webp'
 tags: ['analog', 'refusal', 'privacy', 'autonomy', 'technology']

--- a/src/content/blog/the-bio-age-trap.md
+++ b/src/content/blog/the-bio-age-trap.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Bio-Age Trap'
 description: 'Insurers are swapping your birthday for a biological age score. The markers it reads are gendered, so menopause gets priced as accelerated decay.'
-date: 2026-07-22T12:00:00+10:00
+date: 2026-06-30
 autopublish: true
 heroImage: '/notebook-assets/the-bio-age-trap/infographic.webp'
 tags: ['biopolitics', 'insurance', 'algorithms', 'surveillance', 'ethics']

--- a/src/content/blog/the-boredom-strike.md
+++ b/src/content/blog/the-boredom-strike.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Boredom Strike'
 description: "The attention economy doesn't want your attention. It wants your arousal. Boredom is the one state it can't sell, which makes it a labour tactic."
-date: 2026-07-22T15:00:00+10:00
+date: 2026-07-06
 autopublish: true
 heroImage: '/notebook-assets/the-boredom-strike/infographic.webp'
 tags: ['attention', 'refusal', 'technology', 'autonomy', 'biopolitics']

--- a/src/content/blog/the-data-pyre.md
+++ b/src/content/blog/the-data-pyre.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Data Pyre'
 description: 'We built a civilisation whose every system defaults to save. The archive is perfect and the liturgy of erasure is gone. Deletion has to become a ritual.'
-date: 2026-07-22T21:00:00+10:00
+date: 2026-07-18
 autopublish: true
 heroImage: '/notebook-assets/the-data-pyre/infographic.webp'
 tags: ['deletion', 'ritual', 'data', 'mortality', 'ethics']

--- a/src/content/blog/the-ghost-in-the-city.md
+++ b/src/content/blog/the-ghost-in-the-city.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Ghost in the City'
 description: 'A city redesigned so that pausing reads as a fault condition, and what that costs the people whose bodies need to stop.'
-date: 2026-07-22T14:00:00+10:00
+date: 2026-07-04
 autopublish: true
 heroImage: '/notebook-assets/the-ghost-in-the-city/infographic.webp'
 tags: ['surveillance', 'cities', 'biopolitics', 'ai', 'autonomy']

--- a/src/content/blog/the-glass-cage.md
+++ b/src/content/blog/the-glass-cage.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Glass Cage'
 description: 'The demand that you be readable is the demand that you be governable. On legibility, the trap of visibility, and why opacity is the freedom left.'
-date: 2026-07-22T11:00:00+10:00
+date: 2026-06-28
 autopublish: true
 heroImage: '/notebook-assets/the-glass-cage/infographic.webp'
 tags: ['surveillance', 'biopolitics', 'privacy', 'autonomy', 'technology']

--- a/src/content/blog/the-gorgon-protocol.md
+++ b/src/content/blog/the-gorgon-protocol.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Gorgon Protocol'
 description: 'Facial recognition fails unevenly, and hardest on the people it was never built for. That failure is a vulnerability you can put on your face.'
-date: 2026-07-22T13:00:00+10:00
+date: 2026-07-02
 autopublish: true
 heroImage: '/notebook-assets/the-gorgon-protocol/infographic.webp'
 tags: ['surveillance', 'biopolitics', 'adversarial', 'autonomy', 'ai']

--- a/src/content/blog/the-hauntology-of-the-infinite-now.md
+++ b/src/content/blog/the-hauntology-of-the-infinite-now.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Hauntology of the Infinite Now'
 description: 'Digital media carries no visible wear, so the past never reads as over. On hauntology, retromania, and a culture that struggles to finish anything.'
-date: 2026-07-22T22:00:00+10:00
+date: 2026-07-19
 autopublish: true
 heroImage: '/notebook-assets/the-hauntology-of-the-infinite-now/infographic.webp'
 tags: ['hauntology', 'memory', 'time', 'technology', 'ethics']

--- a/src/content/blog/the-right-to-be-forgotten.md
+++ b/src/content/blog/the-right-to-be-forgotten.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Right to Be Forgotten'
 description: 'The digital afterlife industry sells immortality and delivers undeadness. Finitude is not a defect in a person, and deletion should be the default.'
-date: 2026-07-22T19:00:00+10:00
+date: 2026-07-14
 autopublish: true
 heroImage: '/notebook-assets/the-right-to-be-forgotten/infographic.webp'
 tags: ['privacy', 'deletion', 'data', 'autonomy', 'ethics']

--- a/src/content/blog/weaponized-silence.md
+++ b/src/content/blog/weaponized-silence.md
@@ -1,7 +1,7 @@
 ---
 title: 'Weaponized Silence'
 description: 'Silence is not an absence. It is the withdrawal of unpaid labour, and the reaction it provokes shows you exactly who was being subsidised.'
-date: 2026-07-22T16:00:00+10:00
+date: 2026-07-08
 autopublish: true
 heroImage: '/notebook-assets/weaponized-silence/infographic.webp'
 tags: ['attention', 'refusal', 'autonomy', 'ethics', 'technology']


### PR DESCRIPTION
Fills the empty blog-archive window between `make-ai-data-centres` (2026-06-26) and UB part 1 (2026-07-20).

## Context
The twelve essays were stacked on 2026-07-22 one-per-hour to drive today's ~12-hour social blast. **That blast is now complete** — the 12:03Z cron published the final slot (hauntology ×3) with `remaining:0`, and every essay is idempotency-locked, so a queue re-sync can no longer touch them.

## Change
Backdate the twelve into the gap, ≈ every 2 days in series order:

| date | essay (order) |
|---|---|
| Jun 28 | the-glass-cage (1) |
| Jun 30 | the-bio-age-trap (2) |
| Jul 02 | the-gorgon-protocol (3) |
| Jul 04 | the-ghost-in-the-city (4) |
| Jul 06 | the-boredom-strike (5) |
| Jul 08 | weaponized-silence (6) |
| Jul 10 | sleep-sovereignty (7) |
| Jul 12 | the-analog-insurrection (8) |
| Jul 14 | the-right-to-be-forgotten (9) |
| Jul 16 | memory-wars-and-data-leakage (10) |
| Jul 18 | the-data-pyre (11) |
| Jul 19 | the-hauntology-of-the-infinite-now (12) |

Part 3 stays on 2026-07-22 (with parts 1/2 on Jul 20/21).

## Safety
Date-line-only change to twelve files. The generator's past-date guard drops all twelve from the queue — **regenerated queue has 0 UB essays** — so the sync neither re-creates nor cancels any post. `validate-content` 0/0, prettier clean.

https://claude.ai/code/session_014crKxSGJ2n3V9ip8zxj4oW