### PR TITLE
content(ub): align the twelve audio companions with the backdated essays

### DIFF
--- a/src/content/audio/memory-wars-and-data-leakage-overview.md
+++ b/src/content/audio/memory-wars-and-data-leakage-overview.md
@@ -1,7 +1,7 @@
 ---
 title: 'Memory Wars and Data Leakage — Audio Overview'
 description: 'The database self remembers what you do not. On contradictory records, leakage, and who controls the story your data tells about you.'
-date: 2026-08-01
+date: 2026-07-16
 tags: ['notebooklm', 'memory', 'data', 'privacy', 'identity', 'autonomy']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/memory-wars-and-data-leakage/audio.m4a'
 duration: '19:30'

--- a/src/content/audio/sleep-sovereignty-overview.md
+++ b/src/content/audio/sleep-sovereignty-overview.md
@@ -1,7 +1,7 @@
 ---
 title: 'Sleep Sovereignty — Audio Overview'
 description: 'The colonisation of rest by tracking and optimisation. On sleep scores, the nocturnal imaginary, and reclaiming the unmonitored night.'
-date: 2026-07-29
+date: 2026-07-10
 tags: ['notebooklm', 'sleep', 'biopolitics', 'wearables', 'autonomy', 'technology']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/sleep-sovereignty/audio.m4a'
 duration: '23:46'

--- a/src/content/audio/the-analog-insurrection-overview.md
+++ b/src/content/audio/the-analog-insurrection-overview.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Analog Insurrection — Audio Overview'
 description: 'Paper, cash and the deliberately offline as infrastructure for refusal. On analog practice as a defence against total digital legibility.'
-date: 2026-07-30
+date: 2026-07-12
 tags: ['notebooklm', 'analog', 'refusal', 'privacy', 'autonomy', 'technology']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-analog-insurrection/audio.m4a'
 duration: '29:26'

--- a/src/content/audio/the-bio-age-trap-overview.md
+++ b/src/content/audio/the-bio-age-trap-overview.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Bio-Age Trap — Audio Overview'
 description: 'Algorithmic underwriting turns your body into an actuarial forecast. On biological age scores and the politics of being made legible to insurers.'
-date: 2026-07-24
+date: 2026-06-30
 tags: ['notebooklm', 'biopolitics', 'insurance', 'algorithms', 'surveillance', 'ethics']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-bio-age-trap/audio.m4a'
 duration: '21:25'

--- a/src/content/audio/the-boredom-strike-overview.md
+++ b/src/content/audio/the-boredom-strike-overview.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Boredom Strike — Audio Overview'
 description: 'Refusing to generate engagement is a political act. On boredom, the attention economy, and withdrawal as a form of resistance.'
-date: 2026-07-27
+date: 2026-07-06
 tags: ['notebooklm', 'attention', 'refusal', 'technology', 'autonomy', 'biopolitics']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-boredom-strike/audio.m4a'
 duration: '22:01'

--- a/src/content/audio/the-data-pyre-overview.md
+++ b/src/content/audio/the-data-pyre-overview.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Data Pyre — Audio Overview'
 description: 'Deletion as ritual rather than accident. On ceremonial erasure, controlled burns, and what it would mean to grieve data properly.'
-date: 2026-08-02
+date: 2026-07-18
 tags: ['notebooklm', 'deletion', 'ritual', 'data', 'mortality', 'ethics']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-data-pyre/audio.m4a'
 duration: '23:04'

--- a/src/content/audio/the-ghost-in-the-city-overview.md
+++ b/src/content/audio/the-ghost-in-the-city-overview.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Ghost in the City — Audio Overview'
 description: 'Moving through urban space that is always counting you. On transit, sensors, and the vanishing possibility of being an anonymous body in public.'
-date: 2026-07-26
+date: 2026-07-04
 tags: ['notebooklm', 'surveillance', 'cities', 'biopolitics', 'ai', 'autonomy']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-ghost-in-the-city/audio.m4a'
 duration: '12:40'

--- a/src/content/audio/the-glass-cage-overview.md
+++ b/src/content/audio/the-glass-cage-overview.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Glass Cage — Audio Overview'
 description: 'Legibility as the precondition of governance: why the demand to be readable is a demand to be governable, and why opacity is the freedom left.'
-date: 2026-07-23
+date: 2026-06-28
 tags: ['notebooklm', 'surveillance', 'biopolitics', 'privacy', 'autonomy', 'technology']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-glass-cage/audio.m4a'
 duration: '20:32'

--- a/src/content/audio/the-gorgon-protocol-overview.md
+++ b/src/content/audio/the-gorgon-protocol-overview.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Gorgon Protocol — Audio Overview'
 description: 'Adversarial aesthetics as refusal: what it means to make yourself unreadable to a classifier, and the uses of the grotesque against machine vision.'
-date: 2026-07-25
+date: 2026-07-02
 tags: ['notebooklm', 'surveillance', 'biopolitics', 'adversarial', 'autonomy', 'ai']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-gorgon-protocol/audio.m4a'
 duration: '22:44'

--- a/src/content/audio/the-hauntology-of-the-infinite-now-overview.md
+++ b/src/content/audio/the-hauntology-of-the-infinite-now-overview.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Hauntology of the Infinite Now — Audio Overview'
 description: 'A present haunted by its own archive. On feeds that never end, time folded back on itself, and the loss of the past as past.'
-date: 2026-08-03
+date: 2026-07-19
 tags: ['notebooklm', 'hauntology', 'memory', 'time', 'technology', 'ethics']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-hauntology-of-the-infinite-now/audio.m4a'
 duration: '24:22'

--- a/src/content/audio/the-right-to-be-forgotten-overview.md
+++ b/src/content/audio/the-right-to-be-forgotten-overview.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Right to Be Forgotten — Audio Overview'
 description: 'Finitude as a right: why a self that can never be erased is a self that can never change, and the case for data death.'
-date: 2026-07-31
+date: 2026-07-14
 tags: ['notebooklm', 'privacy', 'deletion', 'data', 'autonomy', 'ethics']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/the-right-to-be-forgotten/audio.m4a'
 duration: '23:04'

--- a/src/content/audio/weaponized-silence-overview.md
+++ b/src/content/audio/weaponized-silence-overview.md
@@ -1,7 +1,7 @@
 ---
 title: 'Weaponized Silence — Audio Overview'
 description: 'Saying nothing as a tactic against systems that require your speech to function. On silence, non-response, and the limits of voice as agency.'
-date: 2026-07-28
+date: 2026-07-08
 tags: ['notebooklm', 'attention', 'refusal', 'autonomy', 'ethics', 'technology']
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/weaponized-silence/audio.m4a'
 duration: '21:09'


### PR DESCRIPTION
Follow-up to #574 (essay gap-fill backdate). That PR moved the twelve essay **blog** posts to Jun 28 – Jul 19 but left their **audio** collection entries on their old future dates (Jul 23 – Aug 3).

## Why it mattered
`/audio` and the podcast feed sort by date descending with **no future-date filter** (`audio/[...page].astro:11-12`), so the twelve companions were floating at the **top** of the audio listing as "newest/upcoming" while their blog posts sat backdated in the past — the two halves of the same work inverted on the site.

## Change
Re-date all twelve audio overviews to match their blog posts exactly (Jun 28 → Jul 19, series order). Audio is **not** a social-autopublish collection (the queue generator only scans blog + projects), so this changes no broadcast. `validate-content` 0/0, prettier clean.

## Also surfaced (not in this PR — needs NLM re-roll)
A full read of all twelve live heroImage infographics (the cards broadcast Jul 22): 7 clean, 5 with baked-in defects — **memory-wars** (wrong title: "The Ungovernable Body: Liberation from the File"), **right-to-be-forgotten** (title "The Right to Data Death"), **bio-age-trap** ("PEINOD"), **hauntology** ("Ghests"), **analog-insurrection** (garbled chalkboard). Scopes the pending abstract-infographic swap.

https://claude.ai/code/session_014crKxSGJ2n3V9ip8zxj4oW