### PR TITLE
content: paid-discovery repositioning + Evolve publication-gate remediation

### DIFF
--- a/docs/superpowers/specs/2026-07-22-proof-boundaries-editorial-batch-design.md
+++ b/docs/superpowers/specs/2026-07-22-proof-boundaries-editorial-batch-design.md
@@ -1,0 +1,324 @@
+# Proof Boundaries Editorial Batch — Design
+
+**Date:** 2026-07-22
+**Status:** Editorial shape and publishing order approved by Adrian; publishability gate pending
+**Target:** `src/content/blog/` and two existing entries in `src/content/projects/`
+**Through-line:** Do not let the interface, model, or prose claim more than the machinery can prove.
+
+## Outcome
+
+Publish three new pieces in this order:
+
+1. Dead Air phantom-adapter post — the concrete burn.
+2. Robotics Specs + Factory Floor post — the architectural generalisation and batch anchor.
+3. *The Ungovernable Body*, Part 4 — the philosophical culmination.
+
+Alongside them, update the existing ADHDo and Lunar Tools project pages in place. Those two
+updates retain their permanent URLs and receive an `updatedDate`; they are not new feed entries.
+ADHDo 2.0 does not receive a standalone essay in this batch.
+
+The sequence is deliberately self-demonstrating. Every piece states what the implementation can
+support, identifies the boundary where evidence stops, and refuses the more impressive sentence
+that the available evidence cannot yet carry.
+
+## Hard pre-draft gates
+
+No article or project-page prose is drafted until both gates below are complete. Verification
+notes should be recorded as a compact evidence ledger in the implementation work so later edits
+can distinguish a checked claim from an inherited one.
+
+### Gate 1: publishability and link policy
+
+GitHub visibility was machine-checked with `gh repo view` on 2026-07-22. Visibility is evidence
+about access, not blanket editorial permission; Adrian must still approve the treatment below
+before drafting starts.
+
+| Repository | Visibility checked 2026-07-22 | Proposed publication treatment | Author clearance |
+|---|---|---|---|
+| `adrianwedd/robotics-specs` | Public | Link the repository and public specification/conformance artifacts. Describe it as an open v0 boundary, not an adopted standard. | Pending |
+| `adrianwedd/factory-floor` | Private | Do not link the repository. Refer to Factory Floor as implementation #1 only at the level Adrian approves; prefer public evidence in `robotics-specs/examples/factory-floor.yaml` and the existing public project page/site. | Pending |
+| `adrianwedd/dead-air` | Private | Do not link the repository or private PRs. The public package/documentation discrepancy may be described by package name, but private implementation detail must be either independently public or paraphrased at an approved level. | Pending |
+| `adrianwedd/ADHDo` | Public | Retain the existing `repo:` link. Clearly separate merged foundation work from open PR #117 and unfinished device gates. | Pending |
+| `adrianwedd/lunar_tools_prototypes` | Public | Retain the existing `repo:` link and cite only merged/current capabilities. | Pending |
+
+Additional link rules:
+
+- A private GitHub URL is never emitted into frontmatter, body copy, footnotes, or generated
+  notebook assets.
+- Private PR numbers may be used in the internal evidence ledger but not the published copy.
+- Public package claims must be rechecked against the public registry and public documentation,
+  not inferred solely from a private-repository decision record.
+- Existing public project-site links may remain only if a pre-publish link check confirms that
+  they resolve to the intended material.
+
+### Gate 2: source and claim verification
+
+Before writing prose, verify the repository state and the current site copy. A PR title, audit
+summary, memory note, or earlier agent report is a lead, not evidence.
+
+| Artifact | Required verification before drafting |
+|---|---|
+| Dead Air post | Read merged private PR #57 and its executed Phase-0 artifacts in full; confirm PR #58 is still planning/open rather than shipped behaviour; rerun or inspect the recorded workerd, raw-PCM, G.711, and handwritten-WebSocket gate results; independently check the named package publication state; compare the findings with the existing Dead Air project page so the two do not contradict each other. |
+| Robotics Specs post | Read the public v0 specifications, governance documents, conformance implementation, examples, and current README at an exact commit; run the conformance test suite; confirm that Factory Floor's manifest and fail-closed test gate exist at the cited private-repository commit; confirm whether each Factory Floor fact is also safe to publish. The repository currently has direct commits rather than PR evidence, so the post must cite commits/artifacts rather than inventing a PR narrative. |
+| Ungovernable Body Part 4 | Read ADR-035, the take registry schema/data, the observation quarantine, public-storyboard allowlist, human-attestation path, and negative dependency tests at an exact commit; run the relevant tests; compare the proposed claims with Parts 1–3 so Part 4 advances rather than repeats the series. |
+| ADHDo page | Read the existing page line by line; read merged public PR #112 and verify its landed files/tests; read open PR #117 only to mark it as in flight; separately verify the actual on-device/audible and service state. Remove or qualify any existing latency, speaker, crisis-detection, or behavioural claim that the current evidence does not support. |
+| Lunar Tools page | Read the existing page line by line; verify merged public PRs #26, #27, and #28 against current `main`; run the documented validation; confirm the installation count, status counts, local-only default, MLX backends, Afterwords integration, headless mode, CLI, and test count from current artifacts rather than the audit summary. |
+
+For every material claim, the evidence ledger records:
+
+- the exact source repository and commit;
+- the file, test, or merged PR that supports it;
+- whether the evidence is public or private;
+- the strongest publishable wording it permits; and
+- the tempting stronger wording that must not appear.
+
+If verification weakens a premise, the prose follows the evidence. The gate does not become a
+box-ticking exercise that preserves the audit's original story.
+
+## Article 1: Dead Air phantom adapter
+
+**Role in batch:** opener; a concrete dependency failure with a useful engineering resolution.
+**Working title:** *The Voice Adapter That Wasn't There*
+**Form:** standalone post, not a Dead Air project-page rewrite.
+**Target length:** approximately 1,400–2,000 words.
+
+### Story spine
+
+The planned carrier stack appeared to have documented adapters. Installation revealed that one
+named package was an empty `0.0.0` stub and others were unpublished. Instead of quietly rewriting
+that discovery as a completed integration, the project stopped and ran a Phase-0 feasibility
+gate in the intended runtime: structural provider composition, explicit PCM rather than an MP3
+default, G.711 round-trip, raw audio through the pipeline, and hand-built WebSocket frames.
+
+The result is not a triumphalist “we shipped telephony anyway.” It is a narrower and more useful
+finding: the missing adapter layer is reconstructible, and the architecture may proceed without
+pretending the production slice already exists.
+
+### Precision clause
+
+> **Proved:** the required transport boundary is reconstructible; the executed gate supports a
+> `PROCEED` decision. **Not proved:** a production PSTN implementation, a live carrier path, or
+> shipped Deepgram/ElevenLabs/Twilio behaviour.
+
+Every section must remain inside that clause. PR #58's plan is future work, not retrospective
+evidence.
+
+### Beat structure
+
+1. Open on the install, not on generic voice-agent context: the dependency exists in the
+   architecture and documentation, then fails to exist as usable software.
+2. Establish why a phantom abstraction is dangerous: it lets diagrams and plans silently claim
+   an implementation boundary no one has exercised.
+3. Show the gate as a sequence of falsifiable questions, with the actual result of each.
+4. Explain the handwritten transport conclusion without inflating it into a carrier integration.
+5. Close on the batch principle: an interface name is not evidence that an interface exists.
+
+### Publication constraints
+
+- The Dead Air repository and private PR URLs are not linked.
+- Package names may appear only after public registry/documentation verification.
+- Do not imply misconduct or intent; describe observable publication state and its engineering
+  consequence.
+- Reconcile any contradictory language on the existing Dead Air project page before publication.
+  A corrective consistency edit may be proposed separately if verification shows one is needed.
+
+## Article 2: Robotics Specs + Factory Floor
+
+**Role in batch:** anchor; generalises the opener's dependency lesson into an architectural method.
+**Working title:** *When the Specification Can Say No*
+**Form:** standalone post linking the public Robotics Specs repository.
+**Target length:** approximately 1,800–2,500 words.
+
+### Story spine
+
+Prose requirements are useful but permissive: an implementation can describe itself as compliant
+without anything mechanically testing that description. Robotics Specs v0 turns selected
+requirements into schemas, semantic checks, composite checks, examples, and a fail-closed
+conformance command. Factory Floor then becomes implementation #1: a real system forced to state
+its capabilities and prohibitions in a manifest and pass the boundary it claims to satisfy.
+
+The post is about the movement from doctrine to rejection. It is not an announcement that a new
+industry standard has won adoption.
+
+### Precision clause
+
+> **Proved:** requirements have been compiled into a conformance boundary that can reject
+> unsupported claims, and Factory Floor is implementation #1 against that boundary. **Not
+> proved:** external adoption, ecosystem consensus, interoperability across independent vendors,
+> or standards-body status.
+
+Use “specification,” “open v0,” “conformance package,” and “implementation #1.” Avoid an
+unqualified “standard” where readers could reasonably hear adoption or institutional authority.
+
+### Beat structure
+
+1. Bridge from Dead Air: documentation can name an abstraction that reality cannot supply.
+2. Ask what changes when a requirement becomes executable and capable of refusal.
+3. Show the safety classes and module manifest at the conceptual level, then the strict loader,
+   schema, semantic, and composite gates that enforce them.
+4. Introduce Factory Floor as implementation #1, including a useful example of a declaration or
+   prohibition the conformance boundary can reject.
+5. Name what remains unproved: one implementation validates the boundary's usefulness, not its
+   adoption.
+6. Hand off to Part 4: machinery can reject unsupported system claims, but generated media raises
+   the harder question of who is authorised to judge evidence.
+
+### Publication constraints
+
+- Link public Robotics Specs artifacts at stable GitHub paths or exact commits where practical.
+- Do not link the private Factory Floor repository.
+- Prefer the public Factory Floor example bundled with Robotics Specs for inspectable detail.
+- Treat private implementation details as unavailable unless Adrian explicitly clears them.
+- “Factory Floor is implementation #1” is descriptive provenance, not a claim of independent
+  validation.
+
+## Article 3: The Ungovernable Body, Part 4
+
+**Role in batch:** culmination; moves from executable system claims to authority over perception.
+**Working title:** *Who Grades the Take?*
+**Form:** Part 4 of the existing series, using the established `series` value and `seriesOrder: 4`.
+**Target length:** approximately 1,800–2,500 words.
+
+### Story spine
+
+Generated footage creates a circular evaluation problem: the same class of system that generated
+a take can produce fluent reasons why that take works. Those observations may be useful without
+being authoritative. The production therefore separates deterministic facts, perception-derived
+observations, and accountable publication decisions. Observation output is quarantined exhaust;
+the take registry does not read it as evidence; public storyboard claims pass through an allowlist
+and a human-reviewed attestation path.
+
+The essay should not collapse into “humans good, models bad.” Its claim is about authority and
+promotion: a model may observe, compare, or flag, but it may not silently upgrade its own account
+into the evidence that grades the work.
+
+### Precision clause
+
+> **Proved:** the repository prevents quarantined observations from silently promoting themselves
+> into grading or public evidence, and makes human-reviewed authority explicit. **Not proved:**
+> that the resulting human judgement is objectively correct, that model observations are useless,
+> or that the finished film is good.
+
+### Beat structure
+
+1. Open with the question: “How do you grade a generated take without letting the model mark its
+   own homework?”
+2. Show the seductive failure: a generated clip receives a confident generated rationale and the
+   rationale becomes a score by administrative drift.
+3. Define the evidence classes without turning the essay into schema documentation.
+4. Walk the authority path: media → measurements/observations → quarantine → human ruling →
+   registry/public statement.
+5. Show the negative dependency test as the key move: the public path proves which files it does
+   not read.
+6. Admit the remaining human problem. Explicit authority creates accountability; it does not make
+   taste deterministic.
+7. Close the three-post arc: interfaces, specifications, and evaluators all need boundaries that
+   can refuse the stronger claim.
+
+### Series continuity
+
+- Link Parts 1–3 and the project page using existing permanent URLs.
+- Match the first-person, technically literate, restrained register of the series.
+- Avoid re-explaining the entire production pipeline, world, or research corpus.
+- Start with `draft: true`; publication date and supporting assets are assigned only after prose
+  review.
+
+## Project-page update: ADHDo 2.0
+
+**File:** `src/content/projects/adhdo.md`
+**URL:** unchanged
+**Metadata:** preserve original `date`; add or update `updatedDate` when the rewrite lands.
+
+Rewrite the page as a status document with an explicit evidence boundary:
+
+1. Why the original request/response assistant is being replaced.
+2. **Landed:** the merged PR #112 foundation, described only to the level verified in `main` and
+   on the device.
+3. **In flight:** PR #117's personalization, Telegram, and dashboard work, clearly labelled open.
+4. **Still gated:** audible end-to-end behaviour, cron/service operation, or other on-device claims
+   that have not been independently checked.
+5. The design principle that quiet hours, rate limits, serialization, and auditability belong in
+   tools and services rather than model discretion.
+
+The page may say “the 2.0 rewrite is underway” and identify the architecture. It must not narrate
+the in-flight system as settled behaviour. A standalone ADHDo 2.0 essay remains deferred until PR
+#117 is merged and the on-device gates are observed running.
+
+## Project-page update: Lunar Tools
+
+**File:** `src/content/projects/lunar-tools-prototypes.md`
+**URL:** unchanged
+**Metadata:** preserve original `date`; add or update `updatedDate` when the refresh lands.
+
+Replace the GPT-4/DALL-E-era inventory with the verified current system:
+
+- 29 installations and their checked status breakdown;
+- MLX-native Apple Silicon defaults;
+- local-only privacy mode and the explicit cloud opt-in boundary;
+- pluggable language, speech, and image backends;
+- Afterwords/Qwen3-TTS integration;
+- deterministic headless fakes and CI operation;
+- the `list`, `doctor`, and `run` CLI surface; and
+- the current test/validation result.
+
+Retain some concrete installation examples so the page remains about artworks rather than becoming
+a framework README. Counts and test totals are point-in-time claims and must be verified immediately
+before drafting.
+
+## Shared editorial rules
+
+- Use first person and concrete failure/recovery beats; do not turn the through-line into a slogan
+  repeated verbatim in every introduction.
+- Place the precision clause in each article's drafting notes. It need not appear as a labelled box
+  in the published prose, but every claim must fit inside it.
+- Distinguish executed tests, merged code, deployed behaviour, planned work, and author judgement.
+- Never convert a private source into a public link merely because the author owns both repos.
+- Never rename an existing content file. New post slugs are locked only after final titles are
+  approved because published URLs are permanent.
+- New posts begin with `draft: true`. `date`, `autopublish`, social distribution, and NotebookLM
+  assets are separate release decisions, not drafting defaults.
+- Descriptions remain at or below 160 characters. Local images, if later added, use Astro's image
+  pipeline conventions.
+
+## Draft and review order
+
+After both pre-draft gates are cleared:
+
+1. Draft Dead Air and verify every public package reference.
+2. Review Dead Air's precision clause before starting the anchor.
+3. Draft Robotics Specs + Factory Floor and verify every linked artifact plus every privately
+   sourced Factory Floor sentence.
+4. Review the anchor's precision clause before starting Part 4.
+5. Draft Part 4 and run the series-continuity read across Parts 1–4.
+6. Rewrite ADHDo in place.
+7. Refresh Lunar Tools in place.
+8. Run a cross-batch claims review: each piece must label its evidence boundary without copying
+   language from the others.
+
+This order preserves the approved public arc while allowing the two non-feed pages to describe the
+latest verified state at the end of the drafting pass.
+
+## Acceptance criteria
+
+- The publishability table has an explicit author decision in every row before drafting begins.
+- Every material technical claim has an exact, inspected source; every cited PR has been read, not
+  inferred from its title or audit summary.
+- The existing ADHDo and Lunar Tools pages have been compared line by line with current repository
+  state before they are rewritten.
+- Dead Air says `PROCEED`/reconstructible and never implies production PSTN shipped.
+- Robotics Specs says executable conformance boundary and implementation #1, never adoption.
+- Part 4 prevents silent promotion of observations into evidence without claiming infallible human
+  judgement.
+- ADHDo visibly separates landed, in-flight, and still-gated work.
+- Lunar Tools contains only current, rerun counts and capabilities.
+- Existing page URLs remain unchanged; private repositories receive no public repository links.
+- Content validation, lint, production build, and relevant link checks pass before publication.
+
+## Out of scope
+
+- A standalone ADHDo 2.0 essay before PR #117 and the device gates are complete.
+- A new Lunar Tools essay.
+- Claims that Robotics Specs is adopted beyond its first implementation.
+- Claims that Dead Air has shipped production telephony.
+- NotebookLM companions, infographics, audio/video, social scheduling, or publication dates. These
+  begin only after the text is approved and receive their own artifact QA.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@astrojs/preact": "^5.1.4",
         "@astrojs/rss": "^4.0.19",
         "@astrojs/sitemap": "^3.7.3",
-        "@google-analytics/data": "^6.1.0",
         "@tailwindcss/vite": "^4.3.0",
         "astro": "^6.4.2",
         "preact": "^10.29.2",
@@ -23,6 +22,7 @@
         "typescript": ">=5.0.0 <6.0.0"
       },
       "devDependencies": {
+        "@google-analytics/data": "^6.1.0",
         "@lhci/cli": "^0.15.1",
         "@playwright/test": "1.55.1",
         "@tailwindcss/typography": "^0.5.20",
@@ -1239,6 +1239,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@google-analytics/data/-/data-6.1.0.tgz",
       "integrity": "sha512-72sICGmThvOuy1yVlaVRvWgUZ+4VvAlmkIlDgzo1SSSRl2MvbNJavnMTG7uGhNnlgwuHNwReKrm6R/7gAKo4hw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "google-gax": "^5.0.0"
@@ -1251,6 +1252,7 @@
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
       "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
@@ -1264,6 +1266,7 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
       "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
@@ -1455,9 +1458,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1473,9 +1473,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1493,9 +1490,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1511,9 +1505,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1531,9 +1522,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1549,9 +1537,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1569,9 +1554,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1588,9 +1570,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1606,9 +1585,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1632,9 +1608,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1656,9 +1629,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1682,9 +1652,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1706,9 +1673,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1732,9 +1696,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1757,9 +1718,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1781,9 +1739,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1896,6 +1851,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -1958,6 +1914,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2434,6 +2391,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2590,30 +2548,35 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
       "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
       "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1"
@@ -2623,24 +2586,28 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@puppeteer/browsers": {
@@ -4119,6 +4086,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -4165,6 +4133,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4177,6 +4146,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4281,9 +4251,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.6.tgz",
-      "integrity": "sha512-48OBTBKR9ctbf+DQxpOuxGl8ebfn59zTuNQMBzptmG/Mi/H8IdfMSbJgGuX1I/4U6g9yazG1p4BHlf4+2hWU4Q==",
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.8.tgz",
+      "integrity": "sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
@@ -4654,6 +4624,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4696,15 +4667,16 @@
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4750,16 +4722,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4822,6 +4794,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
@@ -5064,9 +5037,9 @@
       "license": "MIT"
     },
     "node_modules/chrome-launcher/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5509,6 +5482,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5677,6 +5651,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -5955,6 +5930,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
       "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.4.1",
@@ -5967,12 +5943,14 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -6011,6 +5989,7 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex-xs": {
@@ -6036,6 +6015,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -6943,6 +6923,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7125,6 +7106,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -7141,6 +7123,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
@@ -7204,6 +7187,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
       "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -7218,6 +7202,7 @@
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
       "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "gaxios": "^7.0.0",
@@ -7352,6 +7337,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -7385,12 +7371,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
       "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -7400,6 +7388,7 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -7428,6 +7417,7 @@
       "version": "10.6.2",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
       "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -7445,6 +7435,7 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.6.tgz",
       "integrity": "sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.12.6",
@@ -7467,6 +7458,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
       "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -7894,6 +7886,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -7907,6 +7900,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -7979,6 +7973,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/inline-style-parser": {
@@ -8316,6 +8311,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isomorphic-fetch": {
@@ -8354,6 +8350,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -8435,6 +8432,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
@@ -8483,6 +8481,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
@@ -8494,6 +8493,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jwa": "^2.0.1",
@@ -9055,12 +9055,14 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
@@ -10361,6 +10363,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -10415,9 +10418,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -10486,6 +10489,7 @@
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10505,6 +10509,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -10576,6 +10581,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -10651,6 +10657,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -10886,6 +10893,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/package-manager-detector": {
@@ -11057,6 +11065,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11066,6 +11075,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -11082,6 +11092,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
@@ -11177,9 +11188,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -11196,7 +11207,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -11395,6 +11406,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
       "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "protobufjs": "^7.4.0"
@@ -11404,9 +11416,10 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -11619,6 +11632,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -12030,6 +12044,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.2.tgz",
       "integrity": "sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "extend": "^3.0.2",
@@ -12054,6 +12069,7 @@
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
       "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^10.3.7"
@@ -12184,6 +12200,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12408,6 +12425,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -12420,6 +12438,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12531,6 +12550,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -12728,6 +12748,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "stubs": "^3.0.0"
@@ -12743,6 +12764,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/streamx": {
@@ -12761,6 +12783,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -12770,6 +12793,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -12788,6 +12812,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -12802,6 +12827,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12811,12 +12837,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -12849,6 +12877,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -12865,6 +12894,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -12877,6 +12907,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12908,6 +12939,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/style-to-js": {
@@ -13043,6 +13075,7 @@
       "version": "10.1.2",
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.2.tgz",
       "integrity": "sha512-Xj0ZAQ0CeuQn6UxCDPLbFRlgcSTUEyO3+wiepr2grjIjyL/lMMs1Z4OwXn8kLvn/V1OuaEP0UY7Na6UDNNsYrQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "http-proxy-agent": "^7.0.0",
@@ -13736,6 +13769,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -14287,6 +14321,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -14328,6 +14363,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -14386,6 +14422,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -14404,6 +14441,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -14421,6 +14459,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14430,6 +14469,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -14445,12 +14485,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -14465,6 +14507,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -14477,6 +14520,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@astrojs/preact": "^5.1.4",
     "@astrojs/rss": "^4.0.19",
     "@astrojs/sitemap": "^3.7.3",
-    "@google-analytics/data": "^6.1.0",
     "@tailwindcss/vite": "^4.3.0",
     "astro": "^6.4.2",
     "preact": "^10.29.2",
@@ -65,6 +64,7 @@
     "js-yaml@4": "^4.3.0"
   },
   "devDependencies": {
+    "@google-analytics/data": "^6.1.0",
     "@lhci/cli": "^0.15.1",
     "@playwright/test": "1.55.1",
     "@tailwindcss/typography": "^0.5.20",

--- a/src/content/case-studies/regulated-health-and-personal-brand.md
+++ b/src/content/case-studies/regulated-health-and-personal-brand.md
@@ -17,7 +17,7 @@ Regulated health practitioners in Australia can't publish patient testimonials o
 
 ## What I built
 
-Two public sites sharing one visual design system, so they read as connected without reading as identical, plus a private, password-gated hub so the practice owner could manage day-to-day requests herself: a kanban board of open items, a simple form to raise a new one, and an internal booking assistant for schedule and appointment lookups.
+Two public sites sharing one visual design system, so they read as connected without reading as identical, plus a private hub so the practice owner could manage day-to-day requests herself: a kanban board of open items, a simple form to raise a new one, and an internal assistant for day-to-day practice admin.
 
 ## Best parts
 

--- a/src/content/case-studies/regulated-health-and-personal-brand.md
+++ b/src/content/case-studies/regulated-health-and-personal-brand.md
@@ -7,7 +7,7 @@ category: 'Multi-site build'
 draft: false
 ---
 
-_Generalised to protect client confidentiality — this describes a pattern from the work, not an identifiable business._
+_Generalised from client work described elsewhere on this site — this focuses on the pattern, not the particulars._
 
 A health practice and a personal brand needed to sit side by side online without confusing either audience. One of them operates under advertising rules strict enough that a single wrong sentence — a testimonial, an outcome claim — can carry a serious fine. The other had no such restriction and needed to sound completely different.
 
@@ -21,7 +21,7 @@ Two public sites sharing one visual design system, so they read as connected wit
 
 ## Best parts
 
-The compliance boundary got built into the system, not just written into a style guide. The internal booking assistant (staff-only, full access) and anything patient-facing run on separate tool sets with separate guardrails baked into their instructions, so the regulated behaviour can't leak across by a copy-paste mistake or a rushed feature request.
+The regulatory boundary got built into the system, not just written into a style guide. Internal tooling and anything patient-facing run on separate tool sets with separate guardrails baked into their instructions, so the regulated behaviour can't leak across by a copy-paste mistake or a rushed feature request.
 
 ## Why it matters for local businesses
 

--- a/src/content/fixes/local-cafe.md
+++ b/src/content/fixes/local-cafe.md
@@ -1,32 +1,32 @@
 ---
-title: 'Tune-up: a Huon Valley cafe losing the holiday walk-in'
-description: 'Three easy fixes that stop a great local cafe losing summer bookings, no rebuild required.'
+title: 'Five online details worth checking before the holiday season'
+description: 'Small, mostly free checks that help a local cafe make the most of holiday visitors — no rebuild required.'
 date: 2026-06-29
 tags: ['local', 'cafe', 'google-business']
 category: 'Cafe'
 draft: false
 ---
 
-_A composite example, drawn from patterns I see often across Huon Valley cafes — not a write-up of one specific business._
+_General guidance drawn from patterns common across Huon Valley cafes — not a write-up of any specific business._
 
-A typical Huon cafe does the hard part well: good food, real personality, loyal regulars. Online is where the holiday walk-in quietly slips away.
+A typical Huon cafe does the hard part well: good food, real personality, loyal regulars. The online details are worth a check before the busy season, because that's where planning visitors look first.
 
-## What's working
+## What's usually working
 
 Strong photos and a clear sense of the place. Real reviews, recently.
 
-## What's probably costing bookings
+## Where friction can creep in
 
-Google shows the wrong holiday hours, and the menu online is a year out of date. A planning tourist checks both before they drive out.
+Google can show outdated holiday hours, and an online menu can drift a year behind the one on the wall. A planning tourist checks both before they drive out.
 
-## What you can fix yourself
+## What you can check yourself
 
-Set your Google hours for the holiday period, public holidays included. This is the single biggest walk-in leak, and it is free to fix.
+Set your Google hours for the holiday period, public holidays included. It's free, takes minutes, and is the highest-value check on this list.
 
 ## What to ask your provider for
 
 Make the basics clear in five seconds on a phone: town, what you serve, and open-now all visible without scrolling.
 
-## What I'd build on first
+## If you want to go further
 
-Get the online menu matching the menu on the wall, then keep one source of truth so it never drifts again. None of this needs a rebuild. The point of the tune-up is to find the cheapest fixes first.
+Get the online menu matching the menu on the wall, then keep one source of truth so it never drifts again. None of this needs a rebuild — the cheapest checks come first. Analysis of your specific operation is what the paid diagnostic is for.

--- a/src/content/fixes/local-tradie.md
+++ b/src/content/fixes/local-tradie.md
@@ -1,25 +1,25 @@
 ---
-title: 'Tune-up: a local tradie nobody could contact'
-description: 'A solid local trade business losing enquiries to a phone link that did not work on mobile.'
+title: 'Making it easier for customers to contact a local trade business'
+description: 'Simple contact-path checks for a local trade business — phone links, form confirmations, and a clearly named service area.'
 date: 2026-06-29
 tags: ['local', 'tradie', 'enquiries']
 category: 'Trade'
 draft: false
 ---
 
-_A composite example, drawn from patterns I see often across local trade businesses — not a write-up of one specific business._
+_General guidance drawn from patterns common across local trade businesses — not a write-up of any specific business._
 
-Plenty of word-of-mouth, a real reputation, and a website that quietly dropped enquiries.
+Plenty of local trade businesses run on word-of-mouth and a real reputation. The website's job is simply to make contact easy — and a few small details decide whether it does.
 
-## What's working
+## What's usually working
 
 A clear list of services and a genuine local story.
 
-## What's probably costing enquiries
+## Where friction can creep in
 
-The phone number looked fine on a desktop and did nothing on a phone, which is where the customers were. The contact form sent nothing back, so a customer never knew it arrived.
+A phone number can look fine on a desktop and do nothing on a phone, which is where the customers are. A contact form that sends no confirmation leaves a customer unsure it arrived.
 
-## What you can fix yourself
+## What you can check yourself
 
 Make the phone number tap-to-call on mobile. Test it from your own phone.
 
@@ -27,6 +27,6 @@ Make the phone number tap-to-call on mobile. Test it from your own phone.
 
 Set the contact form to send a confirmation, so the customer knows it arrived and you know to reply.
 
-## What I'd build on first
+## If you want to go further
 
-Name the service area plainly, so someone two towns over knows straight away whether they are covered. Three small fixes, no redesign. That is the whole idea.
+Name the service area plainly, so someone two towns over knows straight away whether they are covered. Three small checks, no redesign. Analysis of your specific operation is what the paid diagnostic is for.

--- a/src/pages/case-studies/index.astro
+++ b/src/pages/case-studies/index.astro
@@ -16,8 +16,8 @@ const caseStudies = (await getCollection('case-studies'))
   <section aria-labelledby="case-studies-heading" class="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
     <h1 id="case-studies-heading" class="text-text">Case studies</h1>
     <p class="text-text-muted mt-6 max-w-prose">
-      Bigger builds, looked back on. Where the free guides are short and general, these are full projects with real stakes
-      — what worked, what mattered, and why it's relevant if you run a local business.
+      Bigger builds, looked back on. Where the free guides are short and general, these are full projects with real
+      stakes — what worked, what mattered, and why it's relevant if you run a local business.
     </p>
     <div class="mt-8 grid gap-6 sm:grid-cols-2">
       {

--- a/src/pages/case-studies/index.astro
+++ b/src/pages/case-studies/index.astro
@@ -16,7 +16,7 @@ const caseStudies = (await getCollection('case-studies'))
   <section aria-labelledby="case-studies-heading" class="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
     <h1 id="case-studies-heading" class="text-text">Case studies</h1>
     <p class="text-text-muted mt-6 max-w-prose">
-      Bigger builds, looked back on. Where the tune-ups are short and specific, these are full projects with real stakes
+      Bigger builds, looked back on. Where the free guides are short and general, these are full projects with real stakes
       — what worked, what mattered, and why it's relevant if you run a local business.
     </p>
     <div class="mt-8 grid gap-6 sm:grid-cols-2">

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -91,8 +91,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             class="border-border bg-surface text-text focus:border-accent mt-1 w-full rounded border px-3 py-2 text-sm focus:outline-none"
           >
             <option value="">Not sure</option>
-            <option value="Under $1k">Under $1k</option>
-            <option value="$1k–$5k">$1k–$5k</option>
+            <option value="$1.5k–$5k">$1.5k–$5k</option>
             <option value="$5k–$15k">$5k–$15k</option>
             <option value="$15k+">$15k+</option>
           </select>
@@ -107,10 +106,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             class="border-border bg-surface text-text focus:border-accent mt-1 w-full rounded border px-3 py-2 text-sm focus:outline-none"
           >
             <option value="">Select...</option>
-            <option value="New website">New website</option>
-            <option value="Redesign">Redesign</option>
-            <option value="CMS / content management">CMS / content management</option>
+            <option value="Discovery / diagnostic">Discovery / diagnostic</option>
+            <option value="System build">System build</option>
             <option value="Automation / AI">Automation / AI</option>
+            <option value="Website">Website</option>
             <option value="Other">Other</option>
           </select>
         </div>

--- a/src/pages/fixes/[...slug].astro
+++ b/src/pages/fixes/[...slug].astro
@@ -57,9 +57,9 @@ const ogImage = `/og/fixes/${fixSlug}.png`;
   />
   <article class="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
     <Breadcrumb
-      crumbs={[{ label: 'Home', href: '/' }, { label: 'Tune-ups', href: '/fixes/' }, { label: fix.data.title }]}
+      crumbs={[{ label: 'Home', href: '/' }, { label: 'Free guides', href: '/fixes/' }, { label: fix.data.title }]}
     />
-    <p class="text-accent text-sm font-medium">{fix.data.category} tune-up</p>
+    <p class="text-accent text-sm font-medium">{fix.data.category} guide</p>
     <h1 class="text-text mt-2">{fix.data.title}</h1>
     <div
       class="prose prose-headings:mb-4 prose-headings:mt-8 prose-headings:font-semibold prose-headings:text-text prose-p:mb-4 prose-p:leading-relaxed prose-p:text-text prose-a:text-accent prose-a:no-underline hover:prose-a:underline prose-blockquote:my-4 prose-blockquote:border-accent prose-blockquote:text-text-muted prose-strong:text-text prose-code:text-text prose-pre:border prose-pre:border-border prose-pre:bg-surface-alt prose-ol:my-4 prose-ul:my-4 prose-li:text-text mt-8 max-w-none"

--- a/src/pages/fixes/index.astro
+++ b/src/pages/fixes/index.astro
@@ -9,15 +9,17 @@ const fixes = (await getCollection('fixes'))
 ---
 
 <BaseLayout
-  title="Local Website Tune-Ups"
-  description="Short, specific tune-ups of local business websites: what works, and the easy fixes worth doing."
+  title="Local Website Fixes — Free Guides"
+  description="Free general guidance for local business websites: common problems and the easy fixes worth doing, most of them yourself."
   heroAnimation="pulse"
 >
   <section aria-labelledby="fixes-heading" class="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
-    <h1 id="fixes-heading" class="text-text">Local website tune-ups</h1>
+    <h1 id="fixes-heading" class="text-text">Local website fixes — free guides</h1>
     <p class="text-text-muted mt-6 max-w-prose">
-      Composite examples of the tune-ups I do for local businesses — common patterns pulled from real audits, not
-      write-ups of specific clients. What's working, and the easy fixes worth doing, most of them free to sort yourself.
+      Composite examples of common local-business website problems — general patterns, not write-ups of specific
+      clients. What's usually working, and the easy fixes worth doing, most of them free to sort yourself. If you want
+      this level of attention on your specific operation, that's a
+      <a href="/local/" class="text-accent hover:underline">paid diagnostic</a>.
     </p>
     <div class="mt-8 grid gap-6 sm:grid-cols-2">
       {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -45,7 +45,7 @@ const recentPosts = allPosts
             '@type': 'Offer',
             itemOffered: {
               '@type': 'Service',
-              name: 'AI Consulting & Development',
+              name: 'Discovery, Systems & AI Engineering',
               url: 'https://adrianwedd.com/services/',
             },
           },
@@ -183,7 +183,7 @@ const recentPosts = allPosts
           href="/contact/"
           class="btn-secondary border-border text-text hover:border-accent hover:text-accent inline-block rounded-lg border px-5 py-2.5 text-sm font-medium no-underline"
         >
-          Book a free call
+          Book an intro call
         </a>
       </div>
     </div>

--- a/src/pages/local.astro
+++ b/src/pages/local.astro
@@ -3,23 +3,17 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 const paths = [
   {
-    title: 'Fix my existing site',
-    desc: 'A rebuild or tune-up of a site that is embarrassing, broken, or losing you bookings.',
+    title: 'A conversation first',
+    desc: 'Tell me how your business actually runs and where the friction is. If I am not useful to you, I will say so — and the free guides below cover the fixes most businesses can do themselves.',
   },
   {
-    title: 'Make my enquiries work',
-    desc: 'Booking and enquiry flows, forms, confirmations, and the follow-up that turns an enquiry into a job.',
+    title: 'A paid diagnostic',
+    desc: 'A fixed-price look at how your operation works: a focused workshop and short written findings — the key frictions and the one change worth making first. Sometimes the map is all you need, and that is a good outcome.',
   },
   {
-    title: 'Get found locally',
-    desc: 'Google Business Profile and local visibility so the right nearby customers actually find you.',
+    title: 'A build, if it is warranted',
+    desc: 'Websites, bookings, admin automation, ordering — scoped in writing from the diagnostic, with a named endpoint. You own everything I build.',
   },
-];
-
-const addons = [
-  'Admin and follow-up automation',
-  'Ordering, menu, and availability',
-  'Making sure your emails do not land in spam, plus domain basics',
 ];
 
 const pillars = [
@@ -40,7 +34,7 @@ const pillars = [
 
 <BaseLayout
   title="Local businesses: the digital side, done properly"
-  description="Websites, bookings, and Google visibility for Huon Valley and southern Tasmania businesses. Plain pricing, agreed scope, and I finish the job."
+  description="Websites, bookings, and admin systems for Huon Valley and southern Tasmania businesses. A paid diagnostic first, plain pricing, agreed scope, and I finish the job."
   heroAnimation="pulse"
 >
   <section
@@ -54,8 +48,9 @@ const pillars = [
         <span class="text-text-muted">done properly.</span>
       </h1>
       <p class="text-text-muted mt-6 max-w-prose text-base leading-relaxed">
-        If you run a cafe, clinic, shop, or service in the Huon Valley or southern Tasmania, I build and fix the website
-        side so customers can find you, trust you, and book you. Plain pricing, agreed scope, and I finish the job.
+        If you run a cafe, farm, shop, or service business in the Huon Valley or southern Tasmania, I build the systems
+        side — websites, bookings, and the repetitive admin — so it fits how you actually work. Plain pricing, agreed
+        scope, and I finish the job.
       </p>
       <div class="mt-8 flex flex-wrap gap-4">
         <a
@@ -75,7 +70,7 @@ const pillars = [
   <div class="section-divider mx-auto max-w-3xl px-4 sm:px-6 lg:px-8"></div>
 
   <section id="paths" aria-labelledby="paths-heading" class="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
-    <h2 id="paths-heading" class="text-text">Three things I help with most</h2>
+    <h2 id="paths-heading" class="text-text">How working together goes</h2>
     <div class="mt-8 grid gap-6 sm:grid-cols-3">
       {
         paths.map(({ title, desc }) => (
@@ -86,7 +81,6 @@ const pillars = [
         ))
       }
     </div>
-    <p class="text-text-muted mt-6 text-sm">Also: {addons.join('; ')}.</p>
   </section>
 
   <div class="section-divider mx-auto max-w-3xl px-4 sm:px-6 lg:px-8"></div>
@@ -111,12 +105,13 @@ const pillars = [
   <div class="section-divider mx-auto max-w-3xl px-4 sm:px-6 lg:px-8"></div>
 
   <section id="proof" aria-labelledby="proof-heading" class="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
-    <h2 id="proof-heading" class="text-text">See the work</h2>
+    <h2 id="proof-heading" class="text-text">Free guidance</h2>
     <p class="text-text-muted mt-6 max-w-prose">
-      Composite examples of the tune-ups I do for local businesses — common patterns, not write-ups of specific clients.
+      Common website problems local businesses can fix themselves, written up as composite examples — general guidance,
+      free. Analysis of your specific operation is what the paid diagnostic is for.
     </p>
     <div class="mt-6">
-      <a href="/fixes/" class="text-accent hover:underline">Browse the local website tune-ups &rarr;</a>
+      <a href="/fixes/" class="text-accent hover:underline">Browse the free guides &rarr;</a>
     </div>
   </section>
 

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -132,7 +132,7 @@ const pricing = [
     title: 'Discovery',
     cadence: 'Fixed price',
     typical: '$1,500 or $4,500',
-    desc: 'Compact diagnostic ($1,500): a focused workshop plus short written findings — key frictions and the recommended next step. Full operational deep-dive ($4,500): interviews, systems and workflow inventory, friction and risk map, recommended intervention, and implementation options. Never credited against a build.',
+    desc: 'Compact diagnostic ($1,500): a focused workshop plus short written findings — key frictions and the recommended next step. Full operational deep-dive ($4,500): interviews, systems and workflow inventory, friction and technical/operational risk map (never regulatory advice), recommended intervention, and implementation options. Never credited against a build.',
   },
   {
     title: 'Project',

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -51,7 +51,7 @@ const capabilities = [
 const domains = [
   {
     title: 'Healthcare AI',
-    desc: 'AHPRA-compliant digital presence. Cliniko API integration. NDIS-aware tooling. Clinical decision support systems tested against real case datasets. I understand the regulatory surface and build inside it — not around it.',
+    desc: 'Digital presence engineered around documented AHPRA advertising constraints. Cliniko API integration. NDIS-aware tooling. Clinical decision support systems tested against real case datasets. I understand the regulatory surface and build inside it — not around it.',
   },
   {
     title: 'Legal intelligence',
@@ -87,8 +87,8 @@ const caseStudies = [
   {
     name: 'Evolve Evolution',
     url: 'https://evolvechiropractictas.com',
-    desc: 'Four-part ecosystem built for a healthcare practice: chiropractic site, personal coaching brand, author hub, and a private operations dashboard. Shared brand system across all four. AHPRA-compliant content. Password-gated hub for internal docs, kanban, and GitHub issues.',
-    tags: ['Healthcare', 'Multi-site', 'Ops hub', 'AHPRA'],
+    desc: 'Four-part ecosystem built for a healthcare practice: chiropractic site, personal coaching brand, author hub, and a private operations dashboard. Shared brand system across all four. Content engineered around documented AHPRA advertising constraints. Password-gated hub for internal docs, kanban, and GitHub issues.',
+    tags: ['Healthcare', 'Multi-site', 'Ops hub', 'Regulatory-aware'],
   },
   {
     name: 'Tanda Pizza',
@@ -108,26 +108,37 @@ const steps = [
   {
     n: '1',
     title: 'Talk',
-    desc: "Tell me what you're trying to solve. No forms, no pitch deck. I'll tell you honestly if I can help and what I'd do.",
+    desc: "A short call to work out whether I'm useful to you. No forms, no pitch deck. If I'm not the right fit, I'll say so and point you somewhere better.",
   },
   {
     n: '2',
-    title: 'Build',
-    desc: 'I move fast. Iterative, visible progress. You stay in the loop at every stage. Scope and deposit are agreed before work starts. If scope changes, extra work gets a written estimate before it begins — no bill shock.',
+    title: 'Discover',
+    desc: 'Paid, fixed-price, with a named endpoint. I embed in how your work actually runs and map where the friction and risk really are. Three outcomes, all of them successes: you needed the map and the judgment; one small, high-value fix; or a larger build, separately scoped. The discovery fee is never credited against a build — the thinking is the product.',
   },
   {
     n: '3',
-    title: 'Stay',
-    desc: 'Most clients keep me on. Monthly retainer: reserved capacity for scoped improvements, support, and new work. No open tab, no surprise invoice.',
+    title: 'Build',
+    desc: 'Scoped from discovery output, in writing, before work starts — with a deposit and a named endpoint. Iterative, visible progress; you stay in the loop at every stage. If scope changes, extra work gets a written estimate before it begins — no bill shock.',
+  },
+  {
+    n: '4',
+    title: 'Hand over',
+    desc: 'You own what I build. Handover documentation, credentials moved, and explicit re-engagement terms. Bounded support retainers if you want me to stay on — reserved capacity, no open tab, no surprise invoice.',
   },
 ];
 
 const pricing = [
   {
+    title: 'Discovery',
+    cadence: 'Fixed price',
+    typical: '$1,500 or $4,500',
+    desc: 'Compact diagnostic ($1,500): a focused workshop plus short written findings — key frictions and the recommended next step. Full operational deep-dive ($4,500): interviews, systems and workflow inventory, friction and risk map, recommended intervention, and implementation options. Never credited against a build.',
+  },
+  {
     title: 'Project',
     cadence: 'Fixed scope',
     typical: 'Typically $3K–$25K',
-    desc: 'Scoped, priced, and agreed upfront. No surprises. 2–8 weeks depending on complexity. Right for a defined build with a clear outcome.',
+    desc: 'Scoped, priced, and agreed upfront. No surprises. 2–8 weeks depending on complexity. Right for a defined build with a clear outcome — usually scoped from discovery output.',
   },
   {
     title: 'Retainer',
@@ -145,8 +156,8 @@ const pricing = [
 ---
 
 <BaseLayout
-  title="Services — AI Consulting & Development"
-  description="AI integration, security evaluation, voice agents, agentic systems, and web development. Tasmania-based, working globally."
+  title="Services — Discovery, Systems & AI Engineering"
+  description="Paid operational discovery, bounded system builds, AI integration, and security evaluation. Tasmania-based, working globally."
   image="/og/services.png"
   heroAnimation="pulse"
 >
@@ -156,7 +167,7 @@ const pricing = [
     set:html={JSON.stringify({
       '@context': 'https://schema.org',
       '@type': 'ProfessionalService',
-      name: 'Adrian Wedd — AI Consulting & Development',
+      name: 'Adrian Wedd — Discovery, Systems & AI Engineering',
       url: 'https://adrianwedd.com/services/',
       provider: {
         '@type': 'Person',
@@ -165,10 +176,11 @@ const pricing = [
       },
       areaServed: ['Australia', 'Worldwide'],
       serviceType: [
+        'Operational Discovery',
         'AI Integration',
         'Security Evaluation',
         'Voice AI',
-        'Web Development',
+        'Systems Engineering',
         'AI Governance',
         'Agentic Systems',
       ],
@@ -188,9 +200,10 @@ const pricing = [
         <span class="text-text-muted">I'll tell you honestly if I can help.</span>
       </h1>
       <p class="text-text-muted mt-6 max-w-prose text-base leading-relaxed">
-        Practical digital systems and AI/security judgement, delivered directly by the operator doing the work. From
-        local business infrastructure to production-critical AI evaluation, work is scoped, priced, and agreed before
-        anything starts — from Greenpeace operations to
+        I embed with people who know their work deeply, map how it really operates, and build dependable systems that
+        remove the friction between their ideas and reality — engineered with regulatory awareness, delivered in
+        focused increments, handed over clean. Engagements start with a paid, fixed-price discovery, and the work is
+        scoped, priced, and agreed in writing before anything is built — from Greenpeace operations to
         <a href="/blog/120-models-18k-prompts/" class="text-accent hover:underline">18,000 adversarial prompts</a>
         to the thing you need built next.
       </p>
@@ -199,7 +212,7 @@ const pricing = [
           href="/contact/"
           class="btn-primary bg-accent text-surface inline-block rounded-lg px-6 py-3 text-sm font-semibold no-underline hover:opacity-90"
         >
-          Book a free call
+          Book an intro call
         </a>
         <a
           href="#what-i-do"
@@ -435,7 +448,7 @@ const pricing = [
     data-pagefind-body
   >
     <h2 id="pricing-heading" class="text-text">Pricing</h2>
-    <div class="mt-8 grid gap-6 sm:grid-cols-3">
+    <div class="mt-8 grid gap-6 sm:grid-cols-2">
       {
         pricing.map(({ title, cadence, typical, desc }) => (
           <div class="border-border bg-surface-alt rounded-xl border p-6">
@@ -472,7 +485,7 @@ const pricing = [
         href="/contact/"
         class="btn-primary bg-accent text-surface inline-block rounded-lg px-6 py-3 text-sm font-semibold no-underline hover:opacity-90"
       >
-        Book a free consult
+        Book an intro call
       </a>
       <a
         href="mailto:adrian@adrianwedd.com?subject=Services%20enquiry"

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -51,7 +51,7 @@ const capabilities = [
 const domains = [
   {
     title: 'Healthcare AI',
-    desc: 'Digital presence engineered around documented AHPRA advertising constraints. Cliniko API integration. NDIS-aware tooling. Clinical decision support systems tested against real case datasets. I understand the regulatory surface and build inside it — not around it.',
+    desc: 'Digital presence engineered around documented AHPRA advertising constraints. Integrated practice-management workflows. NDIS-aware tooling. Clinical decision support systems tested against real case datasets. I understand the regulatory surface and build inside it — not around it.',
   },
   {
     title: 'Legal intelligence',

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -201,9 +201,9 @@ const pricing = [
       </h1>
       <p class="text-text-muted mt-6 max-w-prose text-base leading-relaxed">
         I embed with people who know their work deeply, map how it really operates, and build dependable systems that
-        remove the friction between their ideas and reality — engineered with regulatory awareness, delivered in
-        focused increments, handed over clean. Engagements start with a paid, fixed-price discovery, and the work is
-        scoped, priced, and agreed in writing before anything is built — from Greenpeace operations to
+        remove the friction between their ideas and reality — engineered with regulatory awareness, delivered in focused
+        increments, handed over clean. Engagements start with a paid, fixed-price discovery, and the work is scoped,
+        priced, and agreed in writing before anything is built — from Greenpeace operations to
         <a href="/blog/120-models-18k-prompts/" class="text-accent hover:underline">18,000 adversarial prompts</a>
         to the thing you need built next.
       </p>

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -87,7 +87,7 @@ const caseStudies = [
   {
     name: 'Evolve Evolution',
     url: 'https://evolvechiropractictas.com',
-    desc: 'Four-part ecosystem built for a healthcare practice: chiropractic site, personal coaching brand, author hub, and a private operations dashboard. Shared brand system across all four. Content engineered around documented AHPRA advertising constraints. Password-gated hub for internal docs, kanban, and GitHub issues.',
+    desc: 'Four-part ecosystem built for a healthcare practice: chiropractic site, personal coaching brand, author hub, and a private operations dashboard. Shared brand system across all four. Content engineered around documented AHPRA advertising constraints. Private operations hub for day-to-day practice admin.',
     tags: ['Healthcare', 'Multi-site', 'Ops hub', 'Regulatory-aware'],
   },
   {


### PR DESCRIPTION
Five commits repositioning the commercial pages around the OFFER.md doctrine and closing the Evolve publication gate:

- 8ba3a70 — proof-boundaries editorial batch (pre-existing)
- 44d6319 — services//local//fixes//contact/homepage rewritten around paid discovery; compliance-guarantee and access-detail language removed
- 5c1bd08 — /fixes/ articles neutralized to general guidance; discovery risk-map wording qualified
- 1b13f8e — security/privacy review remediations (appointment-data mention, hub auth/contents disclosure)
- c9de764 — Cliniko naming replaced with approved practice-management wording

Permissions + dated security/privacy review recorded in adrianwedd-ops (evolve-public-evidence-permissions.md, through 5286912). Gates green locally: ESLint, content validation 0/0, build 773 pages + Pagefind.

https://claude.ai/code/session_01NKgtKYwieVBv6RAECCffnf