### PR TITLE
feat(worker): authed /api/health returns 503 when any platform token is invalid

### DIFF
--- a/.github/workflows/social-token-alert.yml
+++ b/.github/workflows/social-token-alert.yml
@@ -40,6 +40,8 @@ jobs:
       - name: Fetch token health
         id: health
         run: |
+          # NOTE: no -f/--fail on this curl — a 503 is a VALID response here
+          # (worker up, token invalid) and must reach the parsing below.
           RESPONSE=$(curl -s -w "\n%{http_code}" \
             "${SOCIAL_WORKER_URL}/api/health" \
             -H "Authorization: Bearer ${SOCIAL_CRON_SECRET}" \

--- a/.github/workflows/social-token-alert.yml
+++ b/.github/workflows/social-token-alert.yml
@@ -47,7 +47,9 @@ jobs:
           HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
           BODY=$(echo "$RESPONSE" | sed '$d')
           echo "HTTP status: $HTTP_CODE"
-          if [ "$HTTP_CODE" != "200" ]; then
+          # 503 = worker up but a platform token is invalid — the body still
+          # carries the platforms block this job exists to act on.
+          if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "503" ]; then
             echo "::error::Health check returned HTTP $HTTP_CODE"
             echo "$BODY"
             exit 1

--- a/worker/src/__tests__/publish.test.ts
+++ b/worker/src/__tests__/publish.test.ts
@@ -998,6 +998,34 @@ describe('post type validation', () => {
   });
 });
 
+// An invalid platform token must surface as a 503 on the authenticated
+// /api/health so uptime monitoring alerts on it (body unchanged).
+describe('GET /api/health token status', () => {
+  it('returns 503 when any configured platform reports an invalid token', async () => {
+    const kv = mockKV();
+    mockDebugAuth.mockResolvedValue({ ...healthyToken, valid: false });
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/health', {
+        headers: { Authorization: 'Bearer test-cron-secret' },
+      }),
+      makeEnv(kv),
+    );
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { platforms: Record<string, { tokenValid: boolean }> };
+    expect(body.platforms.facebook.tokenValid).toBe(false);
+  });
+
+  it('still returns 200 unauthenticated regardless of token state', async () => {
+    const kv = mockKV();
+    mockDebugAuth.mockResolvedValue({ ...healthyToken, valid: false });
+
+    const res = await app.fetch(new Request('http://localhost/api/health'), makeEnv(kv));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});
+
 // Crisis flags are surfaced separately in /api/health (flag-crisis: prefix,
 // written by cron/comments.ts) so monitoring can alert on a non-zero count.
 describe('GET /api/health crisisFlags', () => {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -827,20 +827,29 @@ app.get('/api/health', async (c) => {
     }
   }
 
-  return json({
-    platforms: platformsHealth,
-    queue: {
-      facebook: {
-        queued: queuedResult.count,
-        published: publishedResult.count,
-        failed: failedResult.count,
-        nextScheduled,
+  // An invalid token is a 503 so uptime monitors alert on status code alone;
+  // consumers parsing the body (social-token-alert.yml) accept 200 and 503.
+  const anyTokenInvalid = Object.values(platformsHealth).some(
+    (p) => (p as { tokenValid: boolean }).tokenValid === false,
+  );
+
+  return json(
+    {
+      platforms: platformsHealth,
+      queue: {
+        facebook: {
+          queued: queuedResult.count,
+          published: publishedResult.count,
+          failed: failedResult.count,
+          nextScheduled,
+        },
       },
+      recentActivity: { flaggedComments: flaggedResult.count, crisisFlags: crisisResult.count },
+      // Honest signal that a count is a floor, not silently truncated.
+      ...(truncated ? { countsTruncated: true } : {}),
     },
-    recentActivity: { flaggedComments: flaggedResult.count, crisisFlags: crisisResult.count },
-    // Honest signal that a count is a floor, not silently truncated.
-    ...(truncated ? { countsTruncated: true } : {}),
-  });
+    anyTokenInvalid ? 503 : 200,
+  );
 });
 
 export default app;


### PR DESCRIPTION
Lets Upptime alert on social platform token expiry from the status code alone.

- Authed `GET /api/health` now returns **503** when any configured platform reports `tokenValid: false` (body unchanged — still the full platforms/queue/recentActivity payload).
- Unauthenticated health stays a plain 200 `{ok:true}` (no info leak, no false Upptime alarms).
- `social-token-alert.yml` accepts 200 **or** 503 so its issue open/close logic keeps working.
- Tests: 218/218 worker suite, tsc clean. New tests cover both the 503 and the unauthenticated 200.

Part of wiring form/token infrastructure into Upptime monitoring.

https://claude.ai/code/session_01RuEYUXmyTg1yeGWRo229Ms