### PR TITLE
fix(ci): let the watchdog actually record what it found

### DIFF
--- a/.github/workflows/monitor-watchdog.yml
+++ b/.github/workflows/monitor-watchdog.yml
@@ -393,6 +393,14 @@ jobs:
       - name: Open / update / close the watchdog issue
         if: success()
         env:
+          # Overrides the job-level PAT deliberately. The PAT exists for
+          # cross-repo *reads*; issue writes are same-repo, which the job's
+          # `issues: write` already grants to github.token. Running this step on
+          # the PAT made the watchdog's first real run go red on
+          # "Resource not accessible by personal access token (createIssue)" —
+          # findings computed, findings discarded — and no PAT scope needs to
+          # exist for a write the default token can already do.
+          GH_TOKEN: ${{ github.token }}
           FINDING_COUNT: ${{ steps.check.outputs.count }}
         run: |
           set +e -u +o pipefail  # see the note on the first step


### PR DESCRIPTION
## The fault

The watchdog's first real run (30597310699) computed **five** findings and discarded every one:

```
GraphQL: Resource not accessible by personal access token (createIssue)
::error::Could not create the watchdog issue — findings were NOT recorded: ...
```

Job-level `GH_TOKEN` is `PIPELINE_PAT`, which exists for cross-repo Actions **reads**. The job's `permissions: issues: write` grants nothing to a PAT, so the issue write could never have worked.

## The fix

Override `GH_TOKEN: ${{ github.token }}` on the issue step only. Issue management is same-repo, already covered by `issues: write`. The PAT stays on the cross-repo read steps where it is actually needed.

## Verification

Dispatched on this branch: run [30597383517](https://github.com/adrianwedd/adrianwedd.com/actions/runs/30597383517) — **success**, and it opened #582 with all five findings recorded. The pre-fix run went red rather than green, which is the intended failure mode working.

Closes nothing; #582 is the findings ticket and stays open for triage.

https://claude.ai/code/session_01HtvztPz37JnVccwAnncXBz