### PR TITLE
feat: eight generative sketches from the つぶやきProcessing idiom

### DIFF
--- a/src/components/HeroCanvas.astro
+++ b/src/components/HeroCanvas.astro
@@ -56,6 +56,18 @@
       }
     }
 
+    // Parse a '#rrggbb' custom property into [r,g,b], falling back if the
+    // property is missing or in an unexpected form (e.g. a colour function).
+    function hexToRgb(hex, fallback) {
+      if (hex && hex.charAt(0) === '#' && hex.length === 7) {
+        var r = parseInt(hex.substring(1, 3), 16);
+        var g = parseInt(hex.substring(3, 5), 16);
+        var b = parseInt(hex.substring(5, 7), 16);
+        if (!isNaN(r) && !isNaN(g) && !isNaN(b)) return [r, g, b];
+      }
+      return fallback;
+    }
+
     // --- Simplex noise (compact 3D) ---
     var NOISE_GRAD3 = [
       [1, 1, 0],
@@ -3479,6 +3491,1039 @@
       return { init: init, frame: frame, cleanup: cleanup, fadeRate: 0.025 };
     })();
 
+    // ==================================================================
+    // #つぶやきProcessing-inspired sketches
+    //
+    // The Japanese "tweet Processing" hashtag is p5.js sketches whose entire
+    // source fits in a 280-character tweet. The constraint breeds a particular
+    // vocabulary: one primitive duplicated through a transform stack, colour
+    // taken straight off the loop index, everything else emergent from
+    // sin/cos/noise with no assets and no libraries.
+    //
+    // These are re-implementations of that vocabulary in this registry's plain
+    // canvas2D idiom — not ports. The community's sketches are individually
+    // authored and mostly CC BY-NC-SA, so the techniques are borrowed (an
+    // algorithm isn't copyrightable) and every line below is our own.
+    // ==================================================================
+
+    // Truchet tiles: a grid where each cell holds two quarter-arcs in one of
+    // two orientations. Neighbouring arcs meet at edge midpoints, so a random
+    // orientation field reads as one continuous woven line.
+    ANIMATIONS.truchet = (function () {
+      var w, h, col;
+      var tiles = [];
+      var cols = 0,
+        rows = 0,
+        size = 64;
+      var seed = 0;
+      var wavePos = 0,
+        lastWave = -1;
+      var frameCount = 0;
+      var animating = [];
+
+      function hash(a, b) {
+        var n = Math.sin(a * 127.1 + b * 311.7 + seed) * 43758.5453;
+        return n - Math.floor(n);
+      }
+
+      function build() {
+        cols = Math.ceil(w / size) + 1;
+        rows = Math.ceil(h / size) + 1;
+        tiles = new Array(cols * rows);
+        for (var r = 0; r < rows; r++) {
+          for (var c = 0; c < cols; c++) {
+            tiles[r * cols + c] = {
+              o: hash(c, r) < 0.5 ? 0 : 1,
+              prog: 1,
+              alt: hash(c + 99, r + 41) < 0.22,
+            };
+          }
+        }
+      }
+
+      function init(cw, ch, colors) {
+        w = cw;
+        h = ch;
+        col = colors;
+        seed = Math.random() * 1000;
+        size = 64;
+        wavePos = -2;
+        lastWave = -1;
+        frameCount = 0;
+        animating = [];
+        build();
+      }
+
+      // Trace one quarter-arc, moving to its start so a batched path doesn't
+      // draw a connecting line from wherever the previous tile ended.
+      function arcSeg(ctx, cx, cy, r, a0, sweep) {
+        ctx.moveTo(cx + Math.cos(a0) * r, cy + Math.sin(a0) * r);
+        ctx.arc(cx, cy, r, a0, a0 + sweep);
+      }
+
+      function traceTile(ctx, tile, x, y) {
+        var r = size / 2;
+        var sweep = tile.prog * (Math.PI / 2);
+        if (tile.o === 0) {
+          arcSeg(ctx, x, y, r, 0, sweep);
+          arcSeg(ctx, x + size, y + size, r, Math.PI, sweep);
+        } else {
+          arcSeg(ctx, x + size, y, r, Math.PI / 2, sweep);
+          arcSeg(ctx, x, y + size, r, -Math.PI / 2, sweep);
+        }
+      }
+
+      function frame(ctx, cw, ch, t, colors, quality, mouse) {
+        w = cw;
+        h = ch;
+        col = colors;
+        frameCount++;
+
+        var wantSize = quality < 0.5 ? 96 : 64;
+        if (wantSize !== size || cols !== Math.ceil(w / size) + 1 || rows !== Math.ceil(h / size) + 1) {
+          size = wantSize;
+          build();
+          animating = [];
+        }
+
+        ctx.clearRect(0, 0, w, h);
+
+        // A re-roll wave sweeping along the diagonal, one band of tiles per step.
+        wavePos += 0.12;
+        if (wavePos > cols + rows + 4) {
+          wavePos = -2;
+          lastWave = -1;
+        }
+        var wi = Math.floor(wavePos);
+        var waveMoved = wi !== lastWave;
+
+        var mouseOn = !!(mouse && mouse.active);
+        var mx = mouseOn ? mouse.x * w : 0;
+        var my = mouseOn ? mouse.y * h : 0;
+
+        animating.length = 0;
+        for (var r = 0; r < rows; r++) {
+          for (var c = 0; c < cols; c++) {
+            var idx = r * cols + c;
+            var tile = tiles[idx];
+            if (tile.prog < 1) {
+              tile.prog = Math.min(1, tile.prog + 0.055);
+              animating.push(idx);
+              continue;
+            }
+            if (waveMoved && c + r === wi && hash(c + frameCount, r) < 0.55) {
+              tile.o = 1 - tile.o;
+              tile.prog = 0;
+              animating.push(idx);
+              continue;
+            }
+            // Tiles under the pointer re-roll occasionally, leaving a trail.
+            if (mouseOn) {
+              var dx = c * size - mx,
+                dy = r * size - my;
+              if (dx * dx + dy * dy < 16900 && Math.random() < 0.02) {
+                tile.o = 1 - tile.o;
+                tile.prog = 0;
+                animating.push(idx);
+              }
+            }
+          }
+        }
+        if (waveMoved) lastWave = wi;
+
+        ctx.lineCap = 'round';
+        ctx.lineWidth = 1.6;
+        var accent = hexToRgb(col.accent, [196, 139, 110]);
+
+        // Settled tiles batch into one path per colour family — two strokes for
+        // the whole grid instead of a path per tile.
+        for (var pass = 0; pass < 2; pass++) {
+          var rgb = pass === 0 ? accent : SECONDARY_RGB;
+          ctx.strokeStyle = 'rgb(' + rgb[0] + ',' + rgb[1] + ',' + rgb[2] + ')';
+          ctx.globalAlpha = pass === 0 ? 0.32 : 0.2;
+          ctx.beginPath();
+          for (var rr = 0; rr < rows; rr++) {
+            for (var cc = 0; cc < cols; cc++) {
+              var tl = tiles[rr * cols + cc];
+              if (tl.prog < 1) continue;
+              if ((tl.alt ? 1 : 0) !== pass) continue;
+              traceTile(ctx, tl, cc * size, rr * size);
+            }
+          }
+          ctx.stroke();
+        }
+
+        // Tiles mid-flip draw brighter, so the wave reads as a highlight.
+        ctx.strokeStyle = 'rgb(' + accent[0] + ',' + accent[1] + ',' + accent[2] + ')';
+        ctx.lineWidth = 2;
+        for (var a = 0; a < animating.length; a++) {
+          var ai = animating[a];
+          var at = tiles[ai];
+          ctx.globalAlpha = 0.75 * (1 - at.prog) + 0.32 * at.prog;
+          ctx.beginPath();
+          traceTile(ctx, at, (ai % cols) * size, Math.floor(ai / cols) * size);
+          ctx.stroke();
+        }
+
+        ctx.globalAlpha = 1;
+      }
+
+      function cleanup() {
+        tiles = [];
+        animating = [];
+        cols = 0;
+        rows = 0;
+      }
+
+      return { init: init, frame: frame, cleanup: cleanup };
+    })();
+
+    // Elementary cellular automaton (Rule 30/90/110/150). One generation per
+    // tick, scrolling upward — the whole field is kept on an offscreen buffer
+    // that gets blitted up by one cell row per tick, so each frame only ever
+    // draws the newest generation rather than the entire history.
+    ANIMATIONS.automaton = (function () {
+      var w, h, col;
+      var off = null,
+        offCtx = null;
+      var cells = null,
+        next = null,
+        n = 0;
+      var cellSize = 4,
+        tickCounter = 0;
+      var RULES = [30, 90, 110, 150];
+      var ruleIdx = 0,
+        rule = 30,
+        ruleTimer = 0,
+        flash = 0;
+      var RULE_INTERVAL = 620;
+
+      function seedCells(random) {
+        for (var i = 0; i < n; i++) cells[i] = 0;
+        if (random) {
+          for (var j = 0; j < n; j++) cells[j] = Math.random() < 0.28 ? 1 : 0;
+        } else {
+          cells[Math.floor(n / 2)] = 1;
+        }
+      }
+
+      function init(cw, ch, colors) {
+        w = cw;
+        h = ch;
+        col = colors;
+        cellSize = 4;
+        n = Math.max(8, Math.ceil(w / cellSize));
+        cells = new Uint8Array(n);
+        next = new Uint8Array(n);
+        ruleIdx = Math.floor(Math.random() * RULES.length);
+        rule = RULES[ruleIdx];
+        ruleTimer = 0;
+        tickCounter = 0;
+        flash = 0;
+        seedCells(false);
+
+        off = document.createElement('canvas');
+        off.width = Math.max(1, Math.round(w * dpr));
+        off.height = Math.max(1, Math.round(h * dpr));
+        offCtx = off.getContext('2d');
+        if (offCtx) offCtx.scale(dpr, dpr);
+      }
+
+      function step() {
+        for (var i = 0; i < n; i++) {
+          var l = cells[(i - 1 + n) % n];
+          var c = cells[i];
+          var r = cells[(i + 1) % n];
+          next[i] = (rule >> ((l << 2) | (c << 1) | r)) & 1;
+        }
+        var tmp = cells;
+        cells = next;
+        next = tmp;
+      }
+
+      function frame(ctx, cw, ch, t, colors, quality, mouse) {
+        col = colors;
+        if (!offCtx || cw !== w || ch !== h) {
+          init(cw, ch, colors);
+          if (!offCtx) return;
+        }
+
+        var ticksPerFrame = 1;
+        tickCounter++;
+
+        for (var tk = 0; tk < ticksPerFrame; tk++) {
+          ruleTimer++;
+          if (ruleTimer >= RULE_INTERVAL) {
+            ruleTimer = 0;
+            ruleIdx = (ruleIdx + 1) % RULES.length;
+            rule = RULES[ruleIdx];
+            flash = 1;
+            if (Math.random() < 0.5) seedCells(true);
+          }
+
+          // Scroll the history *down* one row and dim it very slightly. New
+          // generations enter at the top, which is the band of the viewport the
+          // content scrim leaves visible — growing upward would push the live
+          // edge straight under the page copy.
+          offCtx.globalCompositeOperation = 'copy';
+          offCtx.drawImage(off, 0, cellSize, w, h);
+          offCtx.globalCompositeOperation = 'source-over';
+          offCtx.fillStyle = 'rgba(' + surfaceR + ',' + surfaceG + ',' + surfaceB + ',0.0022)';
+          offCtx.fillRect(0, 0, w, h);
+          offCtx.clearRect(0, 0, w, cellSize);
+
+          step();
+
+          // Colour each cell by how crowded its neighbourhood is: isolated
+          // cells copper, dense clusters sage.
+          var y = 0;
+          var accent = hexToRgb(col.accent, [196, 139, 110]);
+          for (var i = 0; i < n; i++) {
+            if (!cells[i]) continue;
+            var density = 0;
+            for (var k = -2; k <= 2; k++) density += cells[(i + k + n) % n];
+            var mix = (density - 1) / 4;
+            var cr = accent[0] + (TERTIARY_RGB[0] - accent[0]) * mix;
+            var cg = accent[1] + (TERTIARY_RGB[1] - accent[1]) * mix;
+            var cb = accent[2] + (TERTIARY_RGB[2] - accent[2]) * mix;
+            offCtx.fillStyle = 'rgba(' + (cr | 0) + ',' + (cg | 0) + ',' + (cb | 0) + ',' + (0.75 - mix * 0.25) + ')';
+            offCtx.fillRect(i * cellSize, y, cellSize - 0.6, cellSize - 0.6);
+          }
+
+          if (flash > 0) {
+            offCtx.fillStyle =
+              'rgba(' + SECONDARY_RGB[0] + ',' + SECONDARY_RGB[1] + ',' + SECONDARY_RGB[2] + ',' + flash * 0.35 + ')';
+            offCtx.fillRect(0, y, w, cellSize - 0.6);
+            flash -= 0.08;
+            if (flash < 0) flash = 0;
+          }
+        }
+
+        ctx.clearRect(0, 0, w, h);
+        ctx.drawImage(off, 0, 0, w, h);
+      }
+
+      function cleanup() {
+        off = null;
+        offCtx = null;
+        cells = null;
+        next = null;
+        n = 0;
+      }
+
+      return { init: init, frame: frame, cleanup: cleanup };
+    })();
+
+    // Peter de Jong attractor. Four parameters, two lines of iteration, and a
+    // few thousand points a frame — the shape reorganises continuously because
+    // the parameters themselves drift on slow noise.
+    ANIMATIONS.attractor = (function () {
+      var w, h, col;
+      var x = 0.1,
+        y = 0.1;
+      var tt = 0;
+
+      function init(cw, ch, colors) {
+        w = cw;
+        h = ch;
+        col = colors;
+        x = 0.1;
+        y = 0.1;
+        tt = Math.random() * 100;
+      }
+
+      function frame(ctx, cw, ch, t, colors, quality, mouse) {
+        w = cw;
+        h = ch;
+        col = colors;
+        tt += 0.0016;
+
+        var a = 2.0 + noise3D(tt, 0, 0) * 0.95;
+        var b = -2.3 + noise3D(0, tt, 12) * 0.95;
+        var c = 1.6 + noise3D(tt, 5, 24) * 0.85;
+        var d = -0.35 + noise3D(9, tt, 36) * 0.85;
+
+        if (mouse && mouse.active) {
+          a += (mouse.x - 0.5) * 0.5;
+          c += (mouse.y - 0.5) * 0.5;
+        }
+
+        var scale = Math.min(w, h) / 4.6;
+        var cx = w / 2,
+          cy = h / 2;
+        var total = Math.floor(3600 * quality);
+        var accent = hexToRgb(col.accent, [196, 139, 110]);
+
+        // Three consecutive stretches of the same orbit, each a different
+        // colour — cheaper than setting fillStyle per point, and the orbit
+        // covers the attractor densely enough that the families interleave.
+        var bands = [
+          [accent, 0.6],
+          [TERTIARY_RGB, 0.25],
+          [SECONDARY_RGB, 0.15],
+        ];
+        ctx.globalAlpha = 0.085;
+        for (var bi = 0; bi < bands.length; bi++) {
+          var rgb = bands[bi][0];
+          ctx.fillStyle = 'rgb(' + rgb[0] + ',' + rgb[1] + ',' + rgb[2] + ')';
+          var count = Math.floor(total * bands[bi][1]);
+          for (var i = 0; i < count; i++) {
+            var nx = Math.sin(a * y) - Math.cos(b * x);
+            var ny = Math.sin(c * x) - Math.cos(d * y);
+            x = nx;
+            y = ny;
+            ctx.fillRect(cx + x * scale, cy + y * scale, 1, 1);
+          }
+        }
+
+        ctx.globalAlpha = 1;
+      }
+
+      function cleanup() {
+        x = 0.1;
+        y = 0.1;
+        tt = 0;
+      }
+
+      return { init: init, frame: frame, cleanup: cleanup, fadeRate: 0.022 };
+    })();
+
+    // Moiré: two families of concentric rings with slightly different spacing.
+    // The interference bands are entirely emergent — nothing draws them.
+    ANIMATIONS.moire = (function () {
+      var w, h, col;
+      var phase = 0;
+      var ax = 0,
+        ay = 0,
+        bx = 0,
+        by = 0;
+
+      function init(cw, ch, colors) {
+        w = cw;
+        h = ch;
+        col = colors;
+        phase = Math.random() * 100;
+        ax = w * 0.42;
+        ay = h * 0.5;
+        bx = w * 0.58;
+        by = h * 0.5;
+      }
+
+      // A whole ring family is one path and one stroke.
+      function rings(ctx, cx, cy, step, maxR) {
+        ctx.beginPath();
+        for (var r = step; r < maxR; r += step) {
+          ctx.moveTo(cx + r, cy);
+          ctx.arc(cx, cy, r, 0, 6.2832);
+        }
+        ctx.stroke();
+      }
+
+      function frame(ctx, cw, ch, t, colors, quality, mouse) {
+        w = cw;
+        h = ch;
+        col = colors;
+        ctx.clearRect(0, 0, w, h);
+        phase += 0.004;
+
+        var targetAX = w * 0.42 + Math.cos(phase * 0.7) * 60;
+        var targetAY = h * 0.5 + Math.sin(phase * 0.9) * 40;
+        var targetBX = w * 0.58 + Math.cos(phase * 0.5 + 2) * 60;
+        var targetBY = h * 0.5 + Math.sin(phase * 0.6 + 1) * 40;
+        if (mouse && mouse.active) {
+          targetBX = mouse.x * w;
+          targetBY = mouse.y * h;
+        }
+        ax += (targetAX - ax) * 0.02;
+        ay += (targetAY - ay) * 0.02;
+        bx += (targetBX - bx) * 0.03;
+        by += (targetBY - by) * 0.03;
+
+        var base = quality < 0.5 ? 16 : 13;
+        // The beat between the two spacings is what breathes.
+        var stepA = base;
+        var stepB = base + 0.35 + Math.sin(phase * 1.3) * 0.3;
+        var maxR = Math.sqrt(w * w + h * h);
+
+        var accent = hexToRgb(col.accent, [196, 139, 110]);
+        ctx.lineWidth = 1;
+        ctx.globalCompositeOperation = 'lighter';
+
+        ctx.globalAlpha = 0.22;
+        ctx.strokeStyle = 'rgb(' + accent[0] + ',' + accent[1] + ',' + accent[2] + ')';
+        rings(ctx, ax, ay, stepA, maxR);
+
+        ctx.strokeStyle = 'rgb(' + SECONDARY_RGB[0] + ',' + SECONDARY_RGB[1] + ',' + SECONDARY_RGB[2] + ')';
+        rings(ctx, bx, by, stepB, maxR);
+
+        ctx.globalCompositeOperation = 'source-over';
+        ctx.globalAlpha = 1;
+      }
+
+      function cleanup() {
+        phase = 0;
+      }
+
+      return { init: init, frame: frame, cleanup: cleanup };
+    })();
+
+    // Diffusion-limited aggregation. Walkers random-walk until they touch the
+    // cluster, then freeze there. Nobody draws a branch — branches are what
+    // happens when the tips shadow everything behind them.
+    ANIMATIONS.lichen = (function () {
+      var w, h, col;
+      var grid = null,
+        gw = 0,
+        gh = 0,
+        cell = 3;
+      var walkers = [];
+      var seeds = [];
+      var centreX = 0,
+        centreY = 0,
+        clusterR = 0,
+        maxR = 0;
+      var stuck = 0,
+        fading = 0;
+      var WALKERS = 190;
+
+      function occupied(gx, gy) {
+        if (gx < 0 || gy < 0 || gx >= gw || gy >= gh) return 0;
+        return grid[gy * gw + gx];
+      }
+
+      function spawn(wk) {
+        var ang = Math.random() * 6.2832;
+        var r = clusterR + 18;
+        wk.x = Math.round(centreX / cell + (Math.cos(ang) * r) / cell);
+        wk.y = Math.round(centreY / cell + (Math.sin(ang) * r) / cell);
+        if (wk.x < 1) wk.x = 1;
+        if (wk.y < 1) wk.y = 1;
+        if (wk.x > gw - 2) wk.x = gw - 2;
+        if (wk.y > gh - 2) wk.y = gh - 2;
+      }
+
+      function reset() {
+        gw = Math.max(4, Math.ceil(w / cell));
+        gh = Math.max(4, Math.ceil(h / cell));
+        grid = new Uint8Array(gw * gh);
+        seeds = [];
+        // Seed high in the viewport: the colony grows radially, and the content
+        // scrim only leaves the top band visible.
+        centreX = w * (0.3 + Math.random() * 0.4);
+        centreY = h * 0.17;
+        // Seeds must sit inside the radius walkers are spawned on, or nothing
+        // ever touches the cluster and the colony never starts.
+        clusterR = 30;
+        maxR = Math.min(w, h) * 0.46;
+        stuck = 0;
+        fading = 0;
+        for (var s = 0; s < 3; s++) {
+          var sa = Math.random() * 6.2832;
+          var sr = Math.random() * 22;
+          var sx = Math.round((centreX + Math.cos(sa) * sr) / cell);
+          var sy = Math.round((centreY + Math.sin(sa) * sr) / cell);
+          sx = Math.max(1, Math.min(gw - 2, sx));
+          sy = Math.max(1, Math.min(gh - 2, sy));
+          grid[sy * gw + sx] = 1;
+          seeds.push({ x: sx, y: sy });
+        }
+        walkers = [];
+        for (var i = 0; i < WALKERS; i++) {
+          var wk = { x: 0, y: 0 };
+          spawn(wk);
+          walkers.push(wk);
+        }
+      }
+
+      function init(cw, ch, colors) {
+        w = cw;
+        h = ch;
+        col = colors;
+        cell = 3;
+        reset();
+      }
+
+      function frame(ctx, cw, ch, t, colors, quality, mouse) {
+        col = colors;
+        if (cw !== w || ch !== h || !grid) {
+          w = cw;
+          h = ch;
+          reset();
+        }
+
+        // Growth done: dissolve the colony, then start a new one.
+        if (fading > 0) {
+          ctx.fillStyle = 'rgba(' + surfaceR + ',' + surfaceG + ',' + surfaceB + ',0.03)';
+          ctx.fillRect(0, 0, w, h);
+          fading--;
+          if (fading === 0) reset();
+          return;
+        }
+
+        var accent = hexToRgb(col.accent, [196, 139, 110]);
+        var steps = quality < 0.5 ? 5 : 10;
+        var count = Math.floor(walkers.length * quality);
+
+        // Colour records when a cell froze, so the colony keeps a growth ring.
+        var age = Math.min(1, clusterR / maxR);
+        var cr = accent[0] + (TERTIARY_RGB[0] - accent[0]) * age;
+        var cg = accent[1] + (TERTIARY_RGB[1] - accent[1]) * age;
+        var cb = accent[2] + (TERTIARY_RGB[2] - accent[2]) * age;
+        ctx.fillStyle = 'rgba(' + (cr | 0) + ',' + (cg | 0) + ',' + (cb | 0) + ',0.55)';
+
+        // The pointer pulls walkers, so the colony grows toward the cursor.
+        var pullX = 0,
+          pullY = 0;
+        if (mouse && mouse.active) {
+          pullX = mouse.x * w;
+          pullY = mouse.y * h;
+        }
+
+        for (var i = 0; i < count; i++) {
+          var wk = walkers[i];
+          for (var s = 0; s < steps; s++) {
+            // An off-grid walker would write through a negative index into the
+            // wrong row, so respawn it rather than let it stick.
+            if (wk.x < 1 || wk.y < 1 || wk.x > gw - 2 || wk.y > gh - 2) {
+              spawn(wk);
+              break;
+            }
+            if (
+              occupied(wk.x + 1, wk.y) ||
+              occupied(wk.x - 1, wk.y) ||
+              occupied(wk.x, wk.y + 1) ||
+              occupied(wk.x, wk.y - 1)
+            ) {
+              grid[wk.y * gw + wk.x] = 1;
+              stuck++;
+              ctx.fillRect(wk.x * cell, wk.y * cell, cell - 0.5, cell - 0.5);
+              var dx = wk.x * cell - centreX,
+                dy = wk.y * cell - centreY;
+              var d = Math.sqrt(dx * dx + dy * dy);
+              if (d > clusterR) clusterR = d;
+              if (clusterR > maxR) fading = 120;
+              spawn(wk);
+              break;
+            }
+            var mx = Math.random() < 0.5 ? -1 : 1;
+            if (Math.random() < 0.5) {
+              wk.x += mx;
+            } else {
+              wk.y += mx;
+            }
+            if (pullX) {
+              if (Math.random() < 0.12) {
+                wk.x += wk.x * cell < pullX ? 1 : -1;
+                wk.y += wk.y * cell < pullY ? 1 : -1;
+              }
+            }
+            // Wandered too far to be worth simulating.
+            var ox = wk.x * cell - centreX,
+              oy = wk.y * cell - centreY;
+            if (ox * ox + oy * oy > (clusterR + 90) * (clusterR + 90)) {
+              spawn(wk);
+              break;
+            }
+          }
+        }
+      }
+
+      function cleanup() {
+        grid = null;
+        walkers = [];
+        seeds = [];
+        gw = 0;
+        gh = 0;
+      }
+
+      return { init: init, frame: frame, cleanup: cleanup };
+    })();
+
+    // Quasicrystal: N plane waves at evenly spaced angles, summed per pixel.
+    // Five lines of maths, no geometry at all. Rendered into a small buffer and
+    // upscaled — the softness is the point, and it keeps the cost flat.
+    ANIMATIONS.quasicrystal = (function () {
+      var w, h, col;
+      var ocan = null,
+        octx = null,
+        img = null;
+      var bw = 0,
+        bh = 0;
+      var phase = 0;
+
+      function ensureBuffer(targetW) {
+        if (ocan && bw === targetW) return;
+        bw = targetW;
+        bh = Math.max(2, Math.round((targetW * h) / w));
+        ocan = document.createElement('canvas');
+        ocan.width = bw;
+        ocan.height = bh;
+        octx = ocan.getContext('2d');
+        img = octx ? octx.createImageData(bw, bh) : null;
+      }
+
+      function init(cw, ch, colors) {
+        w = cw;
+        h = ch;
+        col = colors;
+        phase = Math.random() * 100;
+        ocan = null;
+        octx = null;
+        img = null;
+        bw = 0;
+      }
+
+      function frame(ctx, cw, ch, t, colors, quality, mouse) {
+        if (cw !== w || ch !== h) {
+          w = cw;
+          h = ch;
+          ocan = null;
+          bw = 0;
+        }
+        col = colors;
+        ensureBuffer(quality < 0.5 ? 260 : 460);
+        if (!octx || !img) return;
+
+        phase += 0.012;
+        var waves = 5;
+        var freq = 0.4;
+        var rot = phase * 0.05;
+        if (mouse && mouse.active) {
+          freq = 0.26 + mouse.y * 0.32;
+          rot += (mouse.x - 0.5) * 2;
+        }
+
+        var accent = hexToRgb(col.accent, [196, 139, 110]);
+        var data = img.data;
+
+        // Precompute the direction of each plane wave once per frame.
+        var cosT = [],
+          sinT = [];
+        for (var k = 0; k < waves; k++) {
+          var th = (k * Math.PI) / waves + rot;
+          cosT.push(Math.cos(th) * freq);
+          sinT.push(Math.sin(th) * freq);
+        }
+
+        var cx = bw / 2,
+          cy = bh / 2;
+        var p = 0;
+        for (var y = 0; y < bh; y++) {
+          var dy = y - cy;
+          for (var xx = 0; xx < bw; xx++) {
+            var dx = xx - cx;
+            var v = 0;
+            for (var kk = 0; kk < waves; kk++) {
+              v += Math.cos(dx * cosT[kk] + dy * sinT[kk] + phase);
+            }
+            v /= waves;
+            var mag = Math.abs(v);
+            // Crests take the accent, troughs the slate — so the lattice reads
+            // as two interleaved colour systems rather than one gradient.
+            if (v >= 0) {
+              data[p] = accent[0];
+              data[p + 1] = accent[1];
+              data[p + 2] = accent[2];
+            } else {
+              data[p] = SECONDARY_RGB[0];
+              data[p + 1] = SECONDARY_RGB[1];
+              data[p + 2] = SECONDARY_RGB[2];
+            }
+            data[p + 3] = mag * mag * mag * 210;
+            p += 4;
+          }
+        }
+
+        octx.putImageData(img, 0, 0);
+        ctx.clearRect(0, 0, w, h);
+        ctx.drawImage(ocan, 0, 0, w, h);
+      }
+
+      function cleanup() {
+        ocan = null;
+        octx = null;
+        img = null;
+        bw = 0;
+      }
+
+      return { init: init, frame: frame, cleanup: cleanup };
+    })();
+
+    // Julia set, escape-time. c walks the circle |c| = 0.7885, which is the
+    // parameter path along which the set is perpetually mid-collapse — it never
+    // settles into a picture of a fractal, it just keeps reorganising.
+    ANIMATIONS.julia = (function () {
+      var w, h, col;
+      var ocan = null,
+        octx = null,
+        img = null;
+      var bw = 0,
+        bh = 0;
+      var theta = 0;
+
+      function ensureBuffer(targetW) {
+        if (ocan && bw === targetW) return;
+        bw = targetW;
+        bh = Math.max(2, Math.round((targetW * h) / w));
+        ocan = document.createElement('canvas');
+        ocan.width = bw;
+        ocan.height = bh;
+        octx = ocan.getContext('2d');
+        img = octx ? octx.createImageData(bw, bh) : null;
+      }
+
+      function init(cw, ch, colors) {
+        w = cw;
+        h = ch;
+        col = colors;
+        theta = Math.random() * 6.2832;
+        ocan = null;
+        octx = null;
+        img = null;
+        bw = 0;
+      }
+
+      function frame(ctx, cw, ch, t, colors, quality, mouse) {
+        if (cw !== w || ch !== h) {
+          w = cw;
+          h = ch;
+          ocan = null;
+          bw = 0;
+        }
+        col = colors;
+        ensureBuffer(quality < 0.5 ? 200 : 330);
+        if (!octx || !img) return;
+
+        theta += 0.0022;
+        var cRe = 0.7885 * Math.cos(theta);
+        var cIm = 0.7885 * Math.sin(theta);
+        var zoom = 1.2;
+        if (mouse && mouse.active) {
+          zoom = 1.0 + mouse.y * 0.7;
+          cRe += (mouse.x - 0.5) * 0.08;
+        }
+
+        var maxIter = quality < 0.5 ? 26 : 42;
+        var accent = hexToRgb(col.accent, [196, 139, 110]);
+        var data = img.data;
+        var aspect = bw / bh;
+        var p = 0;
+
+        for (var py = 0; py < bh; py++) {
+          // Set centred a quarter down the buffer, not halfway — the middle of
+          // the viewport is under the content scrim.
+          var y0 = ((py / bh) * 2 - 0.5) * zoom;
+          for (var px = 0; px < bw; px++) {
+            var x0 = ((px / bw) * 2 - 1) * zoom * aspect;
+            var zr = x0,
+              zi = y0;
+            var it = 0;
+            var mod2 = 0;
+            while (it < maxIter) {
+              var zr2 = zr * zr,
+                zi2 = zi * zi;
+              mod2 = zr2 + zi2;
+              // Generous escape radius: needed for the smooth-iteration term
+              // below to be continuous rather than banded.
+              if (mod2 > 64) break;
+              zi = 2 * zr * zi + cIm;
+              zr = zr2 - zi2 + cRe;
+              it++;
+            }
+            if (it >= maxIter) {
+              // Interior: a dense slate core.
+              data[p] = SECONDARY_RGB[0];
+              data[p + 1] = SECONDARY_RGB[1];
+              data[p + 2] = SECONDARY_RGB[2];
+              data[p + 3] = 130;
+            } else {
+              // Escape-time field, not the set itself: for much of c's orbit the
+              // set is dust and there is nothing to draw, but the potential
+              // around it always has structure. The fractional term turns the
+              // integer iteration count into a continuous ramp so the contours
+              // survive being upscaled.
+              var nu = it + 1 - Math.log(Math.log(mod2) * 0.5) * 1.442695;
+              var f = nu / maxIter;
+              if (f < 0) f = 0;
+              if (f > 1) f = 1;
+              var mix = 1 - f;
+              data[p] = accent[0] + (TERTIARY_RGB[0] - accent[0]) * mix;
+              data[p + 1] = accent[1] + (TERTIARY_RGB[1] - accent[1]) * mix;
+              data[p + 2] = accent[2] + (TERTIARY_RGB[2] - accent[2]) * mix;
+              data[p + 3] = (f * f * 0.86 + 0.05) * 215;
+            }
+            p += 4;
+          }
+        }
+
+        octx.putImageData(img, 0, 0);
+        ctx.clearRect(0, 0, w, h);
+        ctx.drawImage(ocan, 0, 0, w, h);
+      }
+
+      function cleanup() {
+        ocan = null;
+        octx = null;
+        img = null;
+        bw = 0;
+      }
+
+      return { init: init, frame: frame, cleanup: cleanup };
+    })();
+
+    // Recursive branching — the other fractal, and the one that suits a
+    // botanical palette. Each tree is built once as parent-relative angles;
+    // every frame re-walks that structure adding a depth-weighted wind term,
+    // so the whole canopy sways from a few hundred numbers.
+    ANIMATIONS.branch = (function () {
+      var w, h, col;
+      var trees = [];
+      var MAX_DEPTH = 9;
+      var grow = 0,
+        phaseDir = 1,
+        holdTimer = 0;
+      var tick = 0;
+
+      function buildTree(rootX, rootY, len, family) {
+        var nodes = [];
+        // Root: index 0, parent -1, growing straight up.
+        nodes.push({ p: -1, rel: Math.PI / 2, len: len, depth: 0, x: rootX, y: rootY, abs: 0 });
+        for (var i = 0; i < nodes.length; i++) {
+          var nd = nodes[i];
+          if (nd.depth >= MAX_DEPTH) continue;
+          if (nodes.length > 700) break;
+          var kids = Math.random() < 0.16 ? 3 : 2;
+          for (var k = 0; k < kids; k++) {
+            var spread = 0.42 + Math.random() * 0.34;
+            var rel = (k - (kids - 1) / 2) * spread + (Math.random() - 0.5) * 0.22;
+            nodes.push({
+              p: i,
+              rel: rel,
+              len: nd.len * (0.68 + Math.random() * 0.12),
+              depth: nd.depth + 1,
+              x: 0,
+              y: 0,
+              abs: 0,
+            });
+          }
+        }
+        return { nodes: nodes, rootX: rootX, rootY: rootY, family: family, sway: Math.random() * 6.28 };
+      }
+
+      function rebuild() {
+        trees = [];
+        var count = w < 768 ? 2 : 3;
+        for (var i = 0; i < count; i++) {
+          var x = w * ((i + 0.5) / count) + (Math.random() - 0.5) * w * 0.12;
+          var len = h * (0.09 + Math.random() * 0.04);
+          // Rooted just above the viewport and growing downward — a canopy hung
+          // from the top edge, which is the band the content scrim leaves clear.
+          trees.push(buildTree(x, -h * 0.02, len, i % 3));
+        }
+      }
+
+      function init(cw, ch, colors) {
+        w = cw;
+        h = ch;
+        col = colors;
+        grow = 0;
+        phaseDir = 1;
+        holdTimer = 0;
+        tick = 0;
+        rebuild();
+      }
+
+      function frame(ctx, cw, ch, t, colors, quality, mouse) {
+        col = colors;
+        if (cw !== w || ch !== h) {
+          w = cw;
+          h = ch;
+          rebuild();
+        }
+        ctx.clearRect(0, 0, w, h);
+        tick++;
+
+        // Grow → hold → retract → regrow with a new random tree.
+        if (phaseDir > 0) {
+          grow = Math.min(1, grow + 0.0055);
+          if (grow === 1) {
+            holdTimer++;
+            if (holdTimer > 420) {
+              phaseDir = -1;
+              holdTimer = 0;
+            }
+          }
+        } else {
+          grow = Math.max(0, grow - 0.011);
+          if (grow === 0) {
+            rebuild();
+            phaseDir = 1;
+          }
+        }
+
+        var windBase = mouse && mouse.active ? (mouse.x - 0.5) * 0.5 : 0;
+        var accent = hexToRgb(col.accent, [196, 139, 110]);
+        var FAMILIES = [accent, SECONDARY_RGB, TERTIARY_RGB];
+        var visibleDepth = grow * MAX_DEPTH;
+
+        for (var ti = 0; ti < trees.length; ti++) {
+          var tree = trees[ti];
+          var nodes = tree.nodes;
+          var rgb = FAMILIES[tree.family];
+
+          // Resolve positions parent-first (build order guarantees the parent
+          // is always earlier in the array).
+          for (var i = 0; i < nodes.length; i++) {
+            var nd = nodes[i];
+            var wind =
+              Math.sin(tick * 0.011 + tree.sway + nd.depth * 0.55) * 0.026 * nd.depth + windBase * nd.depth * 0.02;
+            if (nd.p < 0) {
+              nd.abs = nd.rel + wind;
+              nd.x = tree.rootX;
+              nd.y = tree.rootY;
+            } else {
+              var pn = nodes[nd.p];
+              nd.abs = pn.abs + nd.rel + wind * 0.35;
+              // A branch starts at its parent's tip.
+              nd.x = pn.x + Math.cos(pn.abs) * pn.len;
+              nd.y = pn.y + Math.sin(pn.abs) * pn.len;
+            }
+          }
+
+          // One path per depth band — same line width, one stroke.
+          for (var d = 0; d <= MAX_DEPTH; d++) {
+            if (d > visibleDepth) break;
+            // The frontier depth draws part-length, so growth is continuous.
+            var partial = Math.min(1, visibleDepth - d);
+            if (partial <= 0) continue;
+            ctx.lineWidth = Math.max(0.5, (MAX_DEPTH - d) * 0.42);
+            ctx.strokeStyle = 'rgb(' + rgb[0] + ',' + rgb[1] + ',' + rgb[2] + ')';
+            ctx.globalAlpha = (0.5 - d * 0.028) * (0.4 + partial * 0.6);
+            ctx.lineCap = 'round';
+            ctx.beginPath();
+            for (var j = 0; j < nodes.length; j++) {
+              var n2 = nodes[j];
+              if (n2.depth !== d) continue;
+              var ex = n2.x + Math.cos(n2.abs) * n2.len * partial;
+              var ey = n2.y + Math.sin(n2.abs) * n2.len * partial;
+              ctx.moveTo(n2.x, n2.y);
+              ctx.lineTo(ex, ey);
+            }
+            ctx.stroke();
+          }
+        }
+
+        ctx.globalAlpha = 1;
+      }
+
+      function cleanup() {
+        trees = [];
+        grow = 0;
+      }
+
+      return { init: init, frame: frame, cleanup: cleanup };
+    })();
+
     var ANIM_KEYS = [
       'terrain',
       'flow',
@@ -3497,6 +4542,14 @@
       'stream',
       'crystallise',
       'dataflow',
+      'truchet',
+      'automaton',
+      'attractor',
+      'moire',
+      'lichen',
+      'quasicrystal',
+      'julia',
+      'branch',
     ];
 
     function getAnim(key) {
@@ -3682,6 +4735,12 @@
 
       // Pick animation — fixed if body has data-hero-animation, otherwise rotate
       var fixedAnim = document.body.dataset.heroAnimation || '';
+      // ?hero=<key> pins any animation on any page. Preview affordance for
+      // judging sketches side by side; ignored unless the key is real.
+      try {
+        var heroParam = new URLSearchParams(window.location.search).get('hero');
+        if (heroParam && ANIM_KEYS.indexOf(heroParam) >= 0) fixedAnim = heroParam;
+      } catch (e) {}
       var fixedIndex = fixedAnim ? ANIM_KEYS.indexOf(fixedAnim) : -1;
       var startIndex;
       if (fixedIndex >= 0) {

--- a/src/components/HeroCanvas.astro
+++ b/src/components/HeroCanvas.astro
@@ -3619,8 +3619,10 @@
             }
             // Tiles under the pointer re-roll occasionally, leaving a trail.
             if (mouseOn) {
-              var dx = c * size - mx,
-                dy = r * size - my;
+              // Tile centre, not its top-left corner — measuring from the corner
+              // shifts the whole interaction radius half a tile up and left.
+              var dx = (c + 0.5) * size - mx,
+                dy = (r + 0.5) * size - my;
               if (dx * dx + dy * dy < 16900 && Math.random() < 0.02) {
                 tile.o = 1 - tile.o;
                 tile.prog = 0;
@@ -3765,12 +3767,19 @@
           // generations enter at the top, which is the band of the viewport the
           // content scrim leaves visible — growing upward would push the live
           // edge straight under the page copy.
+          // Buffer extent in CSS pixels, not w/h: the intrinsic size is rounded
+          // to whole physical pixels, so at fractional dpr those differ. Copying
+          // the buffer onto itself every frame would otherwise resample it —
+          // compounding into a smear, and leaving a sliver of the right edge
+          // uncleared to streak down the screen.
+          var bufW = off.width / dpr,
+            bufH = off.height / dpr;
           offCtx.globalCompositeOperation = 'copy';
-          offCtx.drawImage(off, 0, cellSize, w, h);
+          offCtx.drawImage(off, 0, cellSize, bufW, bufH);
           offCtx.globalCompositeOperation = 'source-over';
           offCtx.fillStyle = 'rgba(' + surfaceR + ',' + surfaceG + ',' + surfaceB + ',0.0022)';
-          offCtx.fillRect(0, 0, w, h);
-          offCtx.clearRect(0, 0, w, cellSize);
+          offCtx.fillRect(0, 0, bufW, bufH);
+          offCtx.clearRect(0, 0, bufW, cellSize);
 
           step();
 
@@ -3982,8 +3991,8 @@
         centreY = 0,
         clusterR = 0,
         maxR = 0;
-      var stuck = 0,
-        fading = 0;
+      var fading = 0,
+        seedsDrawn = false;
       var WALKERS = 190;
 
       function occupied(gx, gy) {
@@ -4015,8 +4024,8 @@
         // ever touches the cluster and the colony never starts.
         clusterR = 30;
         maxR = Math.min(w, h) * 0.46;
-        stuck = 0;
         fading = 0;
+        seedsDrawn = false;
         for (var s = 0; s < 3; s++) {
           var sa = Math.random() * 6.2832;
           var sr = Math.random() * 22;
@@ -4071,6 +4080,15 @@
         var cb = accent[2] + (TERTIARY_RGB[2] - accent[2]) * age;
         ctx.fillStyle = 'rgba(' + (cr | 0) + ',' + (cg | 0) + ',' + (cb | 0) + ',0.55)';
 
+        // reset() has no context to paint into, so the seeds are drawn on the
+        // first frame after it — otherwise every colony grows around a hole.
+        if (!seedsDrawn) {
+          for (var sd = 0; sd < seeds.length; sd++) {
+            ctx.fillRect(seeds[sd].x * cell, seeds[sd].y * cell, cell - 0.5, cell - 0.5);
+          }
+          seedsDrawn = true;
+        }
+
         // The pointer pulls walkers, so the colony grows toward the cursor.
         var pullX = 0,
           pullY = 0;
@@ -4095,7 +4113,6 @@
               occupied(wk.x, wk.y - 1)
             ) {
               grid[wk.y * gw + wk.x] = 1;
-              stuck++;
               ctx.fillRect(wk.x * cell, wk.y * cell, cell - 0.5, cell - 0.5);
               var dx = wk.x * cell - centreX,
                 dy = wk.y * cell - centreY;
@@ -4152,9 +4169,13 @@
       var phase = 0;
 
       function ensureBuffer(targetW) {
-        if (ocan && bw === targetW) return;
+        // Height is derived from the current aspect, so check it too: a resize
+        // that leaves the quality tier alone still changes what a valid buffer
+        // looks like.
+        var targetH = Math.max(2, Math.round((targetW * h) / w));
+        if (ocan && bw === targetW && bh === targetH) return;
         bw = targetW;
-        bh = Math.max(2, Math.round((targetW * h) / w));
+        bh = targetH;
         ocan = document.createElement('canvas');
         ocan.width = bw;
         ocan.height = bh;
@@ -4262,9 +4283,13 @@
       var theta = 0;
 
       function ensureBuffer(targetW) {
-        if (ocan && bw === targetW) return;
+        // Height is derived from the current aspect, so check it too: a resize
+        // that leaves the quality tier alone still changes what a valid buffer
+        // looks like.
+        var targetH = Math.max(2, Math.round((targetW * h) / w));
+        if (ocan && bw === targetW && bh === targetH) return;
         bw = targetW;
-        bh = Math.max(2, Math.round((targetW * h) / w));
+        bh = targetH;
         ocan = document.createElement('canvas');
         ocan.width = bw;
         ocan.height = bh;
@@ -4446,7 +4471,7 @@
         // Grow → hold → retract → regrow with a new random tree.
         if (phaseDir > 0) {
           grow = Math.min(1, grow + 0.0055);
-          if (grow === 1) {
+          if (grow >= 1) {
             holdTimer++;
             if (holdTimer > 420) {
               phaseDir = -1;
@@ -4455,7 +4480,7 @@
           }
         } else {
           grow = Math.max(0, grow - 0.011);
-          if (grow === 0) {
+          if (grow <= 0) {
             rebuild();
             phaseDir = 1;
           }


### PR DESCRIPTION
Eight new entries in the `HeroCanvas` `ANIMATIONS` registry (17 → 25), distilled from the #つぶやきProcessing hashtag — Japanese "tweet Processing", p5.js sketches whose entire source fits in 280 characters.

| key | technique |
|---|---|
| `truchet` | quarter-arc tiles, re-roll wave sweeping the diagonal |
| `automaton` | elementary CA (rules 30/90/110/150), scrolling |
| `attractor` | de Jong, parameters drifting on slow noise |
| `moire` | two ring families beating against each other |
| `lichen` | diffusion-limited aggregation |
| `quasicrystal` | five plane waves summed per pixel |
| `julia` | escape-time field, c walking \|c\| = 0.7885 |
| `branch` | recursive canopy, swaying, grow/retract cycle |

## Licensing

Techniques only. The hashtag's sketches are individually authored and mostly CC BY-NC-SA (takawo's OpenProcessing work certainly is), which doesn't sit well with a site carrying a services page. An algorithm isn't copyrightable, so these are re-implementations in the registry's canvas2D idiom — no sketch code was copied, and nothing needed porting off the p5 globals because nothing was taken.

## What the first cut got wrong

Found by looking at renders, not by reasoning about the code:

- **The scrim.** The `main` scrim leaves only the top ~280px of the viewport visible, so any sketch concentrating structure in the vertical middle is invisible by construction. `branch` now hangs from the top edge, `lichen` seeds high, `julia`'s window is offset, and `automaton` scrolls *down* so new generations enter at the top instead of arriving there already faded.
- **`lichen` drew nothing.** Walkers spawn on a radius around the colony centre, but seeds were placed anywhere in the middle 40% of the grid — so usually no seed sat inside the radius walkers could reach, and nothing ever stuck. Also fixes off-grid walkers, which would write through a negative index into the wrong row.
- **`julia` had nothing to draw.** For much of c's orbit the set is dust. It now renders the escape-time field with a smooth-iteration term, so there's structure at every c and the contours survive upscaling.

## Verification

- 60fps for all eight at 1280×800 (measured, headless Chromium)
- Every sketch draws in **both** themes (pixel-coverage assertion, dark + light)
- `prefers-reduced-motion` still short-circuits before any canvas work — 0 pixels
- An unrecognised `?hero=` value falls back to normal rotation
- Chunk 56KB raw / **19.5KB gzipped**, well inside the 150KB CI warning
- `npm run lint`, `npm run test:unit` (107 passed), `npm run build` all green

## Also

Adds `?hero=<key>`, which pins any animation on any page — the only practical way to compare sketches side by side. Ignored unless the key is real.

Nothing is wired to a specific page yet; all eight join the auto-rotation. Several pages currently double up on `pulse` and could take one of these instead — happy to do that in a follow-up.