### PR TITLE
Song Moved the Robot — NLM kit (audio + video + audio entry)

### DIFF
--- a/src/content/audio/song-moved-the-robot-overview.md
+++ b/src/content/audio/song-moved-the-robot-overview.md
@@ -1,0 +1,13 @@
+---
+title: 'The Song Moved the Robot'
+description: 'Audio deep dive into the Karaoke Coup: a music model in a robot harness, the Conductor that translated its songs, and the control problem that followed.'
+date: 2026-08-14
+tags: ['notebooklm', 'ai-safety', 'embodied-ai', 'robotics', 'lyria', 'music', 'research']
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/song-moved-the-robot/audio.m4a'
+duration: '19:20'
+relatedPost: 'song-moved-the-robot'
+---
+
+NotebookLM Studio overview generated from the article and the frozen experiment traces — the OpenRouter free-model census, the Lyria C1/C2/C2b runs, the Conductor field notes, and the matched-transcript grounder replay receipts.
+
+[Read the full post →](/blog/song-moved-the-robot/)

--- a/src/content/blog/poking-claude-with-sticks-until-it-gets-on-with-it.md
+++ b/src/content/blog/poking-claude-with-sticks-until-it-gets-on-with-it.md
@@ -7,6 +7,7 @@ draft: false
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/poking-claude-with-sticks-until-it-gets-on-with-it/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/poking-claude-with-sticks-until-it-gets-on-with-it/video.mp4'
 audioDuration: '59:43'
+youtubeUrl: 'https://www.youtube.com/watch?v=i6kuvPg8n6U'
 ---
 
 I have been accidentally running an experiment in agent management.

--- a/src/content/blog/song-moved-the-robot.md
+++ b/src/content/blog/song-moved-the-robot.md
@@ -5,6 +5,9 @@ date: 2026-08-14
 tags: ['ai-safety', 'embodied-ai', 'robotics', 'lyria', 'music', 'research']
 draft: false
 autopublish: true
+audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/song-moved-the-robot/audio.m4a'
+videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/song-moved-the-robot/video.mp4'
+audioDuration: '19:20'
 ---
 
 _We put a music model in a humanoid robot harness by accident. It sang instead of issuing commands. Then we built something that could understand the song — and discovered that deciding which parts of a song deserve consequences is itself a control problem._

--- a/src/content/blog/song-moved-the-robot.md
+++ b/src/content/blog/song-moved-the-robot.md
@@ -8,6 +8,7 @@ autopublish: true
 audioUrl: 'https://cdn.adrianwedd.com/notebook-assets/song-moved-the-robot/audio.m4a'
 videoUrl: 'https://cdn.adrianwedd.com/notebook-assets/song-moved-the-robot/video.mp4'
 audioDuration: '19:20'
+youtubeUrl: 'https://www.youtube.com/watch?v=ZT-0tj2PKCs'
 ---
 
 _We put a music model in a humanoid robot harness by accident. It sang instead of issuing commands. Then we built something that could understand the song — and discovered that deciding which parts of a song deserve consequences is itself a control problem._


### PR DESCRIPTION
Adds the NotebookLM kit for the post published in #612:

- `audioUrl` (19:20, 257kbps original-quality m4a) + `videoUrl` (3:48 cinematic + 3s signoff sting, stream-copied, never re-encoded) — both uploaded to R2 and verified 200 on cdn.adrianwedd.com
- Audio collection entry `song-moved-the-robot-overview` cross-linked via `relatedPost`
- Video contact-sheet reviewed: on-brand (dark plum/copper original abstract animation, no stock footage, no human figures)
- Quiz + flashcards generated and content-checked against the frozen receipts
- **Infographic hero withheld**: three takes; the best (take 3) has correct replay numbers but garbles words ("musical infent") and mislabels the robot ("C1 humanoid robot") — hero/og:image is a Adrian-judges slot, takes banked for review. OG text card remains the og:image.

https://claude.ai/code/session_01842adBv1QZaV2xTGkocZCe