### PR TITLE
Watchdog: stop the hourly repeat, give findings a second delivery path (#582, #587)

### DIFF
--- a/.github/scripts/watchdog-liveness.sh
+++ b/.github/scripts/watchdog-liveness.sh
@@ -32,6 +32,7 @@ set +e -u +o pipefail
 # Every command whose failure matters is checked explicitly by value
 # (`if [ -z "${VAR:-}" ]`) or by `if ! cmd`. -u stays on to catch typos.
 : > findings.txt
+: > notes.txt
 NOW=$(date -u +%s)
 
 # Repos whose workflows are checked for the disabled/stuck traps.
@@ -94,6 +95,21 @@ adrianwedd/adrianwedd.com|monitor-watchdog.yml|4|yes
 "
 
 finding() { echo "- $1" >> findings.txt; }
+
+# An observation that is NOT a fault in the monitoring. Notes are printed to
+# the run log and the job summary; they never open an issue, never comment on
+# one, and never hold it open.
+#
+# The distinction matters because this issue's own premise is "while any of
+# these stands, the corresponding check is not running and its silence means
+# nothing". A GitHub zombie run record fails that test on its own wording —
+# the script has already PROVEN a later run executed, so nothing is stalled
+# and every check is still running. Reporting it as a finding held #582 open
+# for 16 days and re-posted the same text 371 times, which is precisely how a
+# monitor teaches its reader to stop opening it. The record is still worth
+# printing (it is clutter someone may want to clear by hand) — it is just not
+# degradation.
+note() { echo "- $1" >> notes.txt; }
 
 # Run names and branch names are attacker-controllable: anyone who can
 # open a fork PR against a monitored repo picks `head_branch`, and a
@@ -375,7 +391,9 @@ for REPO in $REPOS; do
 
       case "$BLOCKED" in
         no)
-          finding "\`${REPO}\`: run **${NAME_D}** has been \`${STATUS}\` for **${AGEH}h**, but a later run of the same workflow${BRANCH_D:+ on \`${BRANCH_D}\`} has actually executed since — it is a GitHub zombie record, not a concurrency block. Nothing is stalled. It cannot be cancelled via the API; clear it from the repo's Actions UI if you want it gone: ${URL}"
+          # A note, not a finding — see note() above. The probe has proven the
+          # group is not blocked, so nothing here is unmonitored.
+          note "\`${REPO}\`: run **${NAME_D}** has been \`${STATUS}\` for **${AGEH}h**, but a later run of the same workflow${BRANCH_D:+ on \`${BRANCH_D}\`} has actually executed since — it is a GitHub zombie record, not a concurrency block. Nothing is stalled. It cannot be cancelled via the API; clear it from the repo's Actions UI if you want it gone: ${URL}"
           ;;
         yes)
           finding "\`${REPO}\`: run **${NAME_D}** has been \`${STATUS}\` for **${AGEH}h** and NO later run of that workflow${BRANCH_D:+ on \`${BRANCH_D}\`} has executed since (nothing reached success, failure or timed_out, and nothing is running now) — it is holding its concurrency group, so later runs cannot start. Approve or cancel it: ${URL}"
@@ -461,3 +479,30 @@ COUNT=$(wc -l < findings.txt | tr -d ' ')
 echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
 echo "=== ${COUNT} finding(s)"
 cat findings.txt || true
+
+# The findings FINGERPRINT, not a counter. The issue step comments only when
+# this changes, so a standing problem is stated once instead of hourly.
+#
+# It hashes the finding TEXT, so a finding whose wording moves (a stuck run's
+# age climbs every hour) still re-comments — which is why the age is rounded
+# to a day below before hashing. Sorting first makes the fingerprint
+# order-independent: the repo/workflow iteration order is stable today but
+# nothing enforces that, and a reordering that re-alerted every run would be
+# indistinguishable from a real change.
+FINGERPRINT=$(sed -E 's/for \*\*[0-9]+h\*\*/for **Nh**/g' findings.txt \
+  | sort | sha256sum | cut -c1-16)
+echo "fingerprint=${FINGERPRINT}" >> "$GITHUB_OUTPUT"
+echo "=== fingerprint ${FINGERPRINT}"
+
+NOTECOUNT=$(wc -l < notes.txt | tr -d ' ')
+if [ "${NOTECOUNT:-0}" -gt 0 ]; then
+  echo "=== ${NOTECOUNT} note(s) — observations, not faults in the monitoring"
+  cat notes.txt || true
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+      printf '### Watchdog notes (not findings)\n\n'
+      cat notes.txt
+      printf '\nThese do not open or hold open the watchdog issue.\n'
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+fi

--- a/.github/workflows/monitor-watchdog.yml
+++ b/.github/workflows/monitor-watchdog.yml
@@ -148,6 +148,7 @@ jobs:
       # legitimately open monitoring issue. A failed run plus the withheld
       # check-in above are the signals in that case.
       - name: Open / update / close the watchdog issue
+        id: issue
         if: success()
         env:
           # Overrides the job-level PAT deliberately. The PAT exists for
@@ -159,6 +160,7 @@ jobs:
           # exist for a write the default token can already do.
           GH_TOKEN: ${{ github.token }}
           FINDING_COUNT: ${{ steps.check.outputs.count }}
+          FINGERPRINT: ${{ steps.check.outputs.fingerprint }}
         run: |
           set +e -u +o pipefail  # see the note on the first step
           TITLE="🐕 Monitoring watchdog: monitoring is degraded"
@@ -195,10 +197,42 @@ jobs:
           fi
 
           if [ "${COUNT:-0}" -gt 0 ]; then
-            BODY=$(printf 'The watchdog found **%s** problem(s) with the monitoring itself.\n\n%s\n\n---\n\nThese are faults in the checks, not in the services they watch: while any of them stands, the corresponding check is not running and its silence means nothing. Opened automatically by `monitor-watchdog.yml` (run %s).\n' \
-              "$COUNT" "$(cat findings.txt)" "$GITHUB_RUN_ID")
+            # The body carries the fingerprint marker too, so the very next run
+            # of an unchanged set reads it and stays quiet instead of posting a
+            # redundant first comment under a just-opened issue.
+            BODY=$(printf 'The watchdog found **%s** problem(s) with the monitoring itself.\n\n%s\n\n---\n\nThese are faults in the checks, not in the services they watch: while any of them stands, the corresponding check is not running and its silence means nothing. Opened automatically by `monitor-watchdog.yml` (run %s). It comments again only when the finding set changes, and closes itself when the set empties.\n<!-- watchdog-fingerprint: %s -->\n' \
+              "$COUNT" "$(cat findings.txt)" "$GITHUB_RUN_ID" "$FINGERPRINT")
             if [ -n "$EXISTING" ]; then
-              if ! gh issue comment "$EXISTING" --repo "$HOME_REPO" --body "$(printf 'Still degraded — **%s** finding(s):\n\n%s\n\n_(automated re-check, run %s)_\n' "$COUNT" "$(cat findings.txt)" "$GITHUB_RUN_ID")"; then
+              # Comment only when the FINDING SET has changed.
+              #
+              # The old behaviour commented every hour for as long as anything
+              # stood. On #582 that produced 371 identical comments in 16 days
+              # and buried the two times the set actually changed. An alert
+              # nobody opens is not an alert, so restating an unchanged problem
+              # hourly costs signal and buys nothing: the issue being OPEN is
+              # already the standing statement, and it still auto-closes the
+              # moment the findings clear.
+              #
+              # The marker is written into the comment body as an HTML comment,
+              # so the state lives on the issue itself rather than in workflow
+              # storage that a re-run or a cache eviction could lose. Only the
+              # LATEST bot comment is consulted, so a set that changes A → B → A
+              # still re-comments on the return to A.
+              LAST_FP=""
+              # Falls back to the issue BODY when there are no comments yet —
+              # the create path stamps the marker there, so a freshly opened
+              # issue must not draw an immediate duplicate comment.
+              if LAST_BODY=$(gh issue view "$EXISTING" --repo "$HOME_REPO" \
+                   --json comments,body --jq '(.comments[-1].body // .body) // ""' 2>/dev/null); then
+                LAST_FP=$(printf '%s' "$LAST_BODY" \
+                  | sed -n 's/.*<!-- watchdog-fingerprint: \([0-9a-f]*\) -->.*/\1/p' | head -n1)
+              fi
+              # An unreadable comment list must fall through to COMMENTING, not
+              # to silence: the failure mode to avoid is a changed finding set
+              # that never gets posted because a lookup 500'd.
+              if [ -n "$FINGERPRINT" ] && [ "$LAST_FP" = "$FINGERPRINT" ]; then
+                echo "Findings unchanged (fingerprint ${FINGERPRINT}) — not re-commenting on #${EXISTING}."
+              elif ! gh issue comment "$EXISTING" --repo "$HOME_REPO" --body "$(printf 'Findings changed — now **%s** finding(s):\n\n%s\n\n_(automated re-check, run %s. This issue stays open while anything above stands; the watchdog now comments only when the set changes.)_\n<!-- watchdog-fingerprint: %s -->\n' "$COUNT" "$(cat findings.txt)" "$GITHUB_RUN_ID" "$FINGERPRINT")"; then
                 echo "::error::Could not comment on watchdog issue #${EXISTING} — findings were NOT recorded: $(cat findings.txt)"
                 FAILED=1
               fi
@@ -231,4 +265,63 @@ jobs:
             fi
           fi
 
+          # Recorded BEFORE the exit so the escalation step below can read it:
+          # step outputs survive a failing step, the step's own `outcome` alone
+          # cannot distinguish "issue write failed with findings in hand" from
+          # "issue write failed with nothing to report".
+          if [ "${FAILED:-0}" -ne 0 ] && [ "${COUNT:-0}" -gt 0 ]; then
+            echo "undelivered=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "undelivered=no" >> "$GITHUB_OUTPUT"
+          fi
+
           exit "${FAILED:-0}"
+
+      # ── #587: findings must never die with the GitHub API ──────────────────
+      #
+      # The check-in above is deliberately FIRST, so a GitHub outage can't
+      # masquerade as a dead watchdog. The cost of that ordering is this hole:
+      # if the sweep finds real degradation and the issue write then fails, the
+      # Cloudflare timer has already been reset, no email goes out, and the only
+      # trace is a red run in a tab whose unwatchedness is this workflow's whole
+      # premise. It has happened once for real — five findings discarded on the
+      # watchdog's first run, recoverable only because the error text happened
+      # to name them.
+      #
+      # Rather than reorder (which reintroduces exactly the false "watchdog is
+      # dead" email the order was chosen to avoid), send the findings themselves
+      # to the worker, which emails them immediately. GitHub's issue tracker
+      # becomes a convenience rather than the sole delivery path.
+      #
+      # `always()` plus an explicit outcome test, not `failure()`: this must run
+      # when the issue step failed, and must NOT run when the check step died
+      # (there, findings.txt is partial and the withheld check-in is the signal).
+      - name: Escalate undelivered findings by email
+        if: always() && steps.issue.outputs.undelivered == 'yes'
+        env:
+          FINDING_COUNT: ${{ steps.check.outputs.count }}
+        run: |
+          set +e -u +o pipefail  # see the note on the first step
+          if [ -z "${SOCIAL_WORKER_URL:-}" ] || [ -z "${SOCIAL_CRON_SECRET:-}" ]; then
+            echo "::error::Findings could not be filed as an issue AND the worker is unconfigured — they are lost: $(cat findings.txt 2>/dev/null)"
+            exit 1
+          fi
+
+          CODE=$(curl -s -o /tmp/undelivered.json -w '%{http_code}' \
+            -X POST "${SOCIAL_WORKER_URL}/api/watchdog/undelivered" \
+            -H "Authorization: Bearer ${SOCIAL_CRON_SECRET}" \
+            -H 'Content-Type: application/json' \
+            --max-time 30 \
+            --data "$(jq -nc --arg s monitor-watchdog \
+                              --arg r "${GITHUB_RUN_ID}" \
+                              --arg f "$(cat findings.txt 2>/dev/null)" \
+                              '{source:$s, runId:$r, findings:$f}')")
+          echo "undelivered escalation: HTTP ${CODE}"
+          if [ "$CODE" != "200" ]; then
+            cat /tmp/undelivered.json 2>/dev/null || true
+            # Both delivery paths are now down. Say so in the loudest terms the
+            # run log allows, and keep the findings in the annotation — that is
+            # the only reason the first incident was recoverable at all.
+            echo "::error::BOTH delivery paths failed (issue write AND worker escalation HTTP ${CODE}). Findings: $(cat findings.txt 2>/dev/null)"
+            exit 1
+          fi

--- a/docs/runbooks/monitoring.md
+++ b/docs/runbooks/monitoring.md
@@ -33,6 +33,25 @@ So the two platforms watch each other:
 - **GitHub → Cloudflare.** Upptime checks `/api/health` and (once re-added, see
   below) `/api/watchdog/status`, both of which 503 on degradation.
 
+**Second delivery path for findings (#587).** The watchdog checks in to
+Cloudflare *before* it writes its GitHub issue, deliberately — otherwise a GitHub
+API failure would masquerade as a dead watchdog and email about the wrong thing.
+The cost is that a failed issue write leaves real findings with nowhere to go and
+a staleness timer this run has already reset. So when the issue write fails while
+holding findings, the workflow POSTs them to `/api/watchdog/undelivered` and the
+worker emails them immediately (6h cooldown per source, `UNDELIVERED_COOLDOWN_MS`).
+If *that* also fails, the run goes red with the findings in the step annotation —
+the only reason the first such incident was recoverable at all.
+
+**Noise budget (#582).** The watchdog comments on its issue only when the finding
+*set* changes, keyed by a fingerprint stamped into the issue body and each
+comment as `<!-- watchdog-fingerprint: … -->`. The age of a stuck run is
+normalised out before hashing, so a standing problem doesn't re-comment hourly.
+Zombie run records — where the script has *proven* a later run of that workflow
+executed, so nothing is blocked — are printed as **notes** in the job summary and
+never counted as findings. They cannot be cancelled via the API (it 500s); clear
+them from the Actions UI if the clutter bothers you.
+
 **The limit, stated plainly:** the worker is a shared dependency of the
 Cloudflare→GitHub direction. If the worker is down, its cron doesn't fire, the
 check-in fails, and no email goes out. What catches that is the GitHub side going

--- a/worker/src/__tests__/publish.test.ts
+++ b/worker/src/__tests__/publish.test.ts
@@ -1541,6 +1541,87 @@ describe('POST /api/watchdog/heartbeat', () => {
   });
 });
 
+describe('POST /api/watchdog/undelivered', () => {
+  function undeliveredRequest(body: unknown, token = 'test-cron-secret') {
+    return new Request('http://localhost/api/watchdog/undelivered', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+    });
+  }
+
+  function emailEnv(kv: ReturnType<typeof mockKV>, send = vi.fn(async () => {})) {
+    return { ...makeEnv(kv), CRISIS_EMAIL: { send }, CRISIS_ALERT_FROM: 'alerts@wedd.au', CRISIS_ALERT_TO: 'adrianwedd@gmail.com', send };
+  }
+
+  it('emails findings the caller could not file', async () => {
+    const kv = mockKV();
+    const env = emailEnv(kv);
+
+    const res = await app.fetch(
+      undeliveredRequest({ source: 'monitor-watchdog', findings: '- uptime.yml disabled', runId: '99' }),
+      env as never,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, source: 'monitor-watchdog', emailed: true, suppressed: false });
+    expect(env.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a bad bearer token with 401 and sends nothing', async () => {
+    const env = emailEnv(mockKV());
+
+    const res = await app.fetch(
+      undeliveredRequest({ source: 'monitor-watchdog', findings: '- x' }, 'wrong'),
+      env as never,
+    );
+
+    expect(res.status).toBe(401);
+    expect(env.send).not.toHaveBeenCalled();
+  });
+
+  // An escalation carrying no findings would email "your findings were lost"
+  // while carrying none — worse than silence, because it reads as delivery.
+  it.each([[{ source: 'monitor-watchdog' }], [{ source: 'monitor-watchdog', findings: '' }], [{ findings: '- x' }]])(
+    'rejects an incomplete payload with 400 (%j)',
+    async (body) => {
+      const env = emailEnv(mockKV());
+      const res = await app.fetch(undeliveredRequest(body), env as never);
+      expect(res.status).toBe(400);
+      expect(env.send).not.toHaveBeenCalled();
+    },
+  );
+
+  // The caller still holds the text at this point, so a failed send has to be
+  // visible to it — otherwise both paths are down and nothing says so.
+  it('returns 502 when the email cannot be sent', async () => {
+    const env = emailEnv(mockKV(), vi.fn(async () => {
+      throw new Error('binding down');
+    }));
+
+    const res = await app.fetch(
+      undeliveredRequest({ source: 'monitor-watchdog', findings: '- lost' }),
+      env as never,
+    );
+
+    expect(res.status).toBe(502);
+  });
+
+  it('reports a cooldown-suppressed escalation as delivered', async () => {
+    const kv = mockKV();
+    kv.store.set('watchdog-undelivered:monitor-watchdog', 'earlier');
+    const env = emailEnv(kv);
+
+    const res = await app.fetch(
+      undeliveredRequest({ source: 'monitor-watchdog', findings: '- still broken' }),
+      env as never,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, emailed: false, suppressed: true });
+  });
+});
+
 describe('GET /api/watchdog/status', () => {
   function statusRequest(authed = true) {
     return new Request(

--- a/worker/src/__tests__/watchdog.test.ts
+++ b/worker/src/__tests__/watchdog.test.ts
@@ -7,6 +7,8 @@ import {
   EXTERNAL_SOURCES,
   ALERT_COOLDOWN_MS,
   PROOF_OF_LIFE_INTERVAL_MS,
+  UNDELIVERED_COOLDOWN_MS,
+  escalateUndeliveredFindings,
   type WatchdogEnv,
 } from '../watchdog';
 
@@ -316,5 +318,67 @@ describe('weekly proof-of-life', () => {
   // a magic number buried in the module.
   it('uses a 24h alert cooldown', () => {
     expect(ALERT_COOLDOWN_MS).toBe(24 * 60 * 60_000);
+  });
+});
+
+// ── #587: findings that could not be filed ────────────────────────────────────
+//
+// monitor-watchdog checks in BEFORE writing its issue, so a failed issue write
+// leaves findings with no delivery path and a staleness timer already reset.
+// This is the second path.
+describe('escalateUndeliveredFindings', () => {
+  it('emails the findings verbatim and records a cooldown', async () => {
+    const kv = mockKV();
+    const env = makeEnv(kv);
+
+    const res = await escalateUndeliveredFindings(env, 'monitor-watchdog', '- uptime.yml is disabled', '42', NOW);
+
+    expect(res).toEqual({ sent: true, suppressed: false });
+    expect(env.send).toHaveBeenCalledTimes(1);
+    const raw = JSON.stringify((env.send.mock.calls as unknown[][])[0][0]);
+    expect(raw).toContain('uptime.yml is disabled');
+    // The run link is what makes the email actionable.
+    expect(raw).toContain('/actions/runs/42');
+    expect(kv.store.has('watchdog-undelivered:monitor-watchdog')).toBe(true);
+  });
+
+  it('suppresses a second escalation inside the cooldown', async () => {
+    const kv = mockKV({ 'watchdog-undelivered:monitor-watchdog': 'earlier' });
+    const env = makeEnv(kv);
+
+    const res = await escalateUndeliveredFindings(env, 'monitor-watchdog', '- still broken', '43', NOW);
+
+    expect(res).toEqual({ sent: false, suppressed: true });
+    expect(env.send).not.toHaveBeenCalled();
+  });
+
+  // A cooldown written on a FAILED send would suppress retries of an alert that
+  // never reached anyone — the exact failure this whole path exists to prevent.
+  it('does not record a cooldown when the send fails', async () => {
+    const kv = mockKV();
+    const send = vi.fn(async () => {
+      throw new Error('email binding down');
+    });
+    const env = makeEnv(kv, send);
+
+    const res = await escalateUndeliveredFindings(env, 'monitor-watchdog', '- lost findings', '44', NOW);
+
+    expect(res).toEqual({ sent: false, suppressed: false });
+    expect(kv.store.has('watchdog-undelivered:monitor-watchdog')).toBe(false);
+  });
+
+  // Erring toward a duplicate email beats erring toward silence.
+  it('still alerts when the cooldown read itself fails', async () => {
+    const kv = mockKV();
+    kv.get.mockRejectedValueOnce(new Error('KV unavailable'));
+    const env = makeEnv(kv);
+
+    const res = await escalateUndeliveredFindings(env, 'monitor-watchdog', '- findings', '45', NOW);
+
+    expect(res.sent).toBe(true);
+  });
+
+  it('uses a 6h cooldown', () => {
+    expect(UNDELIVERED_COOLDOWN_MS).toBe(6 * 60 * 60_000);
   });
 });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -7,7 +7,12 @@ import { processComments } from './cron/comments';
 import { sendCrisisAlert, sweepCrisisAlerts, countUnnotifiedCrisisFlags } from './email';
 import { CronLock } from './cron-lock';
 import { recordHeartbeat, readHeartbeats } from './heartbeat';
-import { recordExternalHeartbeat, readExternalHeartbeats, runWatchdogSweep } from './watchdog';
+import {
+  recordExternalHeartbeat,
+  readExternalHeartbeats,
+  runWatchdogSweep,
+  escalateUndeliveredFindings,
+} from './watchdog';
 
 export { CronLock };
 
@@ -1097,6 +1102,53 @@ app.post('/api/watchdog/heartbeat', async (c) => {
   }
 
   return json({ ok: true, name: body.name });
+});
+
+// ── POST /api/watchdog/undelivered ────────────────────────────────────────────
+//
+// Second delivery path for a caller that computed findings and could not record
+// them (#587). Emails immediately rather than waiting for a staleness timer that
+// this run's own successful check-in has already reset. See watchdog.ts.
+
+app.post('/api/watchdog/undelivered', async (c) => {
+  const env = c.env;
+  const authOk = await verifyBearer(c.req.header('Authorization') ?? null, env.CRON_SECRET);
+  if (!authOk) return unauthorized();
+
+  let body: { source?: unknown; findings?: unknown; runId?: unknown };
+  try {
+    body = await c.req.json();
+  } catch {
+    return json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  if (typeof body.source !== 'string' || body.source.length === 0) {
+    return json({ error: 'source is required' }, 400);
+  }
+  if (typeof body.findings !== 'string' || body.findings.length === 0) {
+    // An empty escalation is a caller bug: it would send an email saying
+    // findings were lost while carrying none, which is worse than silence
+    // because it looks like the delivery path worked.
+    return json({ error: 'findings is required and must be non-empty' }, 400);
+  }
+
+  // Generous next to the heartbeat's 500 chars — this is the only copy of the
+  // findings, so truncating it defeats the purpose — but still bounded, since
+  // it goes into an email body.
+  const findings = body.findings.slice(0, 8000);
+  const runId = typeof body.runId === 'string' ? body.runId.slice(0, 64) : undefined;
+  const source = body.source.slice(0, 64);
+
+  const { sent, suppressed } = await escalateUndeliveredFindings(env, source, findings, runId);
+
+  // A suppressed send is still a delivered escalation: an email for this source
+  // is already in the inbox and the cooldown is what keeps an hours-long GitHub
+  // outage from becoming an hourly mailing. A FAILED send is a 502, so the
+  // caller can report that both paths are down while it still holds the text.
+  if (!sent && !suppressed) {
+    return json({ error: 'Could not send the escalation email' }, 502);
+  }
+  return json({ ok: true, source, emailed: sent, suppressed });
 });
 
 // ── GET /api/watchdog/status ──────────────────────────────────────────────────

--- a/worker/src/watchdog.ts
+++ b/worker/src/watchdog.ts
@@ -70,6 +70,84 @@ export const ALERT_COOLDOWN_MS = 24 * 60 * 60_000;
 /** Weekly proof-of-life cadence. */
 export const PROOF_OF_LIFE_INTERVAL_MS = 7 * 24 * 60 * 60_000;
 
+/** KV prefix for the undelivered-findings cooldown (see escalateUndeliveredFindings). */
+const UNDELIVERED_COOLDOWN_PREFIX = 'watchdog-undelivered:';
+
+/**
+ * One undelivered-findings email per source per 6h.
+ *
+ * Shorter than ALERT_COOLDOWN_MS because this alert means the caller is holding
+ * findings it could not record anywhere — a state that should be restated more
+ * often than a stale heartbeat — but long enough that a GitHub outage lasting a
+ * working day sends four emails rather than twenty-four.
+ */
+export const UNDELIVERED_COOLDOWN_MS = 6 * 60 * 60_000;
+
+/**
+ * Email findings that a caller computed but could NOT file.
+ *
+ * The gap this closes (#587): monitor-watchdog.yml checks in BEFORE it writes
+ * its GitHub issue, deliberately, so that a GitHub API failure cannot look like
+ * a dead watchdog. The cost is that if the issue write then fails while holding
+ * real findings, the Cloudflare staleness timer has already been reset — no
+ * email fires, and the findings exist only in a red run nobody watches. That
+ * happened once for real: five findings discarded on the watchdog's first run.
+ *
+ * So the caller gets a second delivery path that does not depend on GitHub at
+ * all. The invariant being defended is the one from the ticket: a check-in must
+ * never assert more liveness than was actually verified — and where it does,
+ * something else must say so out loud.
+ *
+ * Returns whether an email was sent. `false` with no error means the cooldown
+ * suppressed it; the caller should treat that as delivered, since an earlier
+ * email for the same source is already in the inbox.
+ */
+export async function escalateUndeliveredFindings(
+  env: WatchdogEnv,
+  source: string,
+  findings: string,
+  runId: string | undefined,
+  now: number = Date.now(),
+): Promise<{ sent: boolean; suppressed: boolean }> {
+  const cooldownKey = `${UNDELIVERED_COOLDOWN_PREFIX}${source}`;
+  try {
+    if (await env.SOCIAL.get(cooldownKey)) return { sent: false, suppressed: true };
+  } catch {
+    // A KV read failure must not suppress the email — err toward alerting.
+  }
+
+  const lines = [
+    `'${source}' found problems with the monitoring and could NOT record them.`,
+    '',
+    'Its own reporting path (the GitHub issue) failed, so this email is the only',
+    'copy of these findings. They are reproduced verbatim below.',
+    '',
+    findings.trim() || '(the caller sent no finding text — check the run log)',
+    '',
+    runId ? `Run: https://github.com/adrianwedd/adrianwedd.com/actions/runs/${runId}` : 'Run: unknown',
+    '',
+    'Note that the check-in for this run already succeeded, so the staleness',
+    'alert will NOT fire for it — that is why this message exists.',
+    '',
+    `Received at ${new Date(now).toISOString()}.`,
+  ];
+
+  const sent = await sendOpsEmail(env, `[MONITORING] ${source} could not record its findings`, lines.join('\n'));
+  if (sent) {
+    try {
+      // Written only on a successful send, for the same reason as the staleness
+      // cooldown: recording it on failure would suppress retries of an alert
+      // that never reached anyone.
+      await env.SOCIAL.put(cooldownKey, new Date(now).toISOString(), {
+        expirationTtl: Math.round(UNDELIVERED_COOLDOWN_MS / 1000),
+      });
+    } catch {
+      // A missing cooldown costs a duplicate email; failing here would cost the alert.
+    }
+  }
+  return { sent, suppressed: false };
+}
+
 export interface ExternalSource {
   /** Heartbeat name; the KV key suffix and the identifier callers POST. */
   name: string;


### PR DESCRIPTION
Closes #587. Removes the cause of #582's noise (and the finding class that was holding it open).

## 1. Zombie run records become notes, not findings

The liveness script already *proves*, before reporting one, that a later run of that workflow executed — its own text says "Nothing is stalled". Reporting that as degradation fails the issue's stated premise ("while any of these stands, the corresponding check is not running"), and it is what kept #582 open for 16 days.

Notes now go to the run log and the job summary. They never open an issue, comment on one, or hold one open.

## 2. Comment only when the finding set changes

| before | after |
| --- | --- |
| a comment every hour while anything stood — **371 in 16 days on #582** | a comment only when the set changes |

The fingerprint is stamped as `<!-- watchdog-fingerprint: … -->` into the issue body *and* each comment, so the state lives on the issue rather than in workflow storage a re-run could lose. Run ages are normalised out before hashing (a stuck run ticks up hourly and would otherwise re-comment forever) and lines are sorted (iteration order is stable in practice but nothing enforces it). A failed comment lookup falls through to **commenting** — the failure worth avoiding is a changed set that never gets posted.

## 3. Findings that could not be filed are emailed (#587)

The check-in is deliberately before the issue write, so a GitHub outage can't masquerade as a dead watchdog. The cost was the hole in #587: a failed issue write leaves real findings with no delivery path and a staleness timer this run has already reset. It has happened for real — five findings discarded on the watchdog's first run.

Rather than reorder (which reintroduces exactly the false "watchdog is dead" email the order was chosen to avoid), the workflow POSTs the findings to a new authenticated endpoint:

`POST /api/watchdog/undelivered` → `escalateUndeliveredFindings()` → ops email, 6h per-source cooldown.

- Cooldown is written **only on a successful send** — recording it on failure would suppress retries of an alert nobody received.
- A KV read failure does **not** suppress the email; it errs toward alerting.
- An empty `findings` payload is a 400: an email saying "your findings were lost" while carrying none is worse than silence, because it reads as delivery.
- If both paths fail, the run goes red with the findings in the step annotation — the only reason the first incident was recoverable.

## Verification

- `npx tsc --noEmit` (worker) — clean
- `npm test` (worker) — **307/307**, 10 new: escalation path, cooldown suppression, failed-send-writes-no-cooldown, KV-read-failure-still-alerts, and the route's 200/400/401/502
- Fingerprint logic **executed** under `bash -e` in `ubuntu:24.04` (not read): stable across an hourly age tick and across line reordering, changed by a new finding, no crash on an empty findings file
- `actionlint` — same single pre-existing SC2016 (a jq expression in single quotes) as `main`; no new warnings
- Runbook updated (`docs/runbooks/monitoring.md`)

## Deploy note

The new endpoint ships with the next worker deploy (gated approval, per `docs/runbooks/worker-deploy.md`). Until then the escalation step would get a 404 and report both paths down — it only runs when an issue write has *already* failed, which is not the current state.

Separately: I cancelled the `adrianwedd.com` zombie Worker Deploy run (30668360144) by hand. The two in the status repos genuinely 500 on cancel and can only be cleared from the Actions UI.

https://claude.ai/code/session_01BV2hQUrzhMuAnmZpuYzntX