### PR TITLE
Bump worker-links postcss override past the sourceMappingURL advisory

### DIFF
--- a/worker-links/package-lock.json
+++ b/worker-links/package-lock.json
@@ -2136,9 +2136,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2203,9 +2203,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2223,7 +2223,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/worker-links/package.json
+++ b/worker-links/package.json
@@ -13,7 +13,7 @@
     "wrangler": "^4.123.0"
   },
   "overrides": {
-    "postcss": "^8.5.18",
+    "postcss": "^8.5.23",
     "sharp": "^0.35.0"
   }
 }


### PR DESCRIPTION
Dependabot's only remaining non-Astro *fixable* alert.

**Advisory:** PostCSS incomplete fix of GHSA-6g55-p6wh-862q — attacker-controlled `sourceMappingURL` read. Fixed in **8.5.23**.

`worker-links` already pins postcss via an override at `^8.5.18`, which resolved to **8.5.20** — below the fix. Bumped the override to `^8.5.23`; the lockfile now resolves **8.5.26**.

Dev scope only: postcss arrives through vite under vitest, and nothing it touches ships in the deployed worker. Hygiene, not exposure.

## Verification

- `npm test` (worker-links) — 10/10 pass
- `npm install` — "found 0 vulnerabilities"

## What this leaves open

| alert | status |
| --- | --- |
| 3 × astro XSS (low/medium) | need Astro 7 — tracked in #586 |
| extract-zip symlink traversal (high, dev, transitive) | **no patched version exists upstream** — nothing to bump to |

https://claude.ai/code/session_01BV2hQUrzhMuAnmZpuYzntX